### PR TITLE
Deferred loading of libraries

### DIFF
--- a/packages/vendure-plugin-invoices/src/api/strategies/google-storage-invoice-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/api/strategies/google-storage-invoice-strategy.ts
@@ -1,10 +1,10 @@
-import { RemoteStorageStrategy } from './storage-strategy';
+import { StorageOptions } from '@google-cloud/storage';
 import { Response } from 'express';
-import { InvoiceEntity } from '../entities/invoice.entity';
 import { createReadStream, ReadStream } from 'fs';
-import { Storage, StorageOptions } from '@google-cloud/storage';
 import path from 'path';
+import { InvoiceEntity } from '../entities/invoice.entity';
 import { createTempFile, zipFiles, ZippableFile } from '../file.util';
+import { RemoteStorageStrategy } from './storage-strategy';
 
 interface GoogleInvoiceConfig {
   bucketName: string;
@@ -15,14 +15,19 @@ interface GoogleInvoiceConfig {
 }
 
 export class GoogleStorageInvoiceStrategy implements RemoteStorageStrategy {
-  storage: Storage;
-  bucketName: string;
+  private storage: import("@google-cloud/storage").Storage;
+  private bucketName: string;
 
   constructor(private config: GoogleInvoiceConfig) {
     this.bucketName = config.bucketName;
-    this.storage = config.storageOptions
-      ? new Storage(config.storageOptions)
-      : new Storage();
+  }
+
+  async init(): Promise<void> {
+    const storage = await import("@google-cloud/storage");
+
+    this.storage = this.config.storageOptions
+      ? new storage.Storage(this.config.storageOptions)
+      : new storage.Storage();
   }
 
   async getPublicUrl(invoice: InvoiceEntity): Promise<string> {

--- a/packages/vendure-plugin-invoices/src/api/strategies/local-file-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/api/strategies/local-file-strategy.ts
@@ -1,9 +1,9 @@
-import { promises as fs, createReadStream, ReadStream } from 'fs';
+import { Response } from 'express';
+import { createReadStream, promises as fs, ReadStream } from 'fs';
 import path from 'path';
 import { InvoiceEntity } from '../entities/invoice.entity';
-import { Response } from 'express';
-import { LocalStorageStrategy } from './storage-strategy';
 import { exists, zipFiles, ZippableFile } from '../file.util';
+import { LocalStorageStrategy } from './storage-strategy';
 
 /**
  * Default storage strategy just stores file on local disk with sync operations
@@ -11,6 +11,8 @@ import { exists, zipFiles, ZippableFile } from '../file.util';
  */
 export class LocalFileStrategy implements LocalStorageStrategy {
   invoiceDir = 'invoices';
+
+  async init(): Promise<void> { }
 
   async save(tmpFile: string, invoiceNumber: number, channelToken: string) {
     if (!(await exists(this.invoiceDir))) {

--- a/packages/vendure-plugin-invoices/src/api/strategies/storage-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/api/strategies/storage-strategy.ts
@@ -1,5 +1,5 @@
-import { ReadStream } from 'fs';
 import { Response } from 'express';
+import { ReadStream } from 'fs';
 import { InvoiceEntity } from '../entities/invoice.entity';
 
 /**
@@ -26,6 +26,8 @@ interface BaseStorageStrategy {
    * Will only be called by admins
    */
   streamMultiple(invoices: InvoiceEntity[], res: Response): Promise<ReadStream>;
+
+  init(): Promise<void>;
 }
 
 export interface RemoteStorageStrategy extends BaseStorageStrategy {
@@ -35,6 +37,7 @@ export interface RemoteStorageStrategy extends BaseStorageStrategy {
    * or Amazon S3 instance
    */
   getPublicUrl(invoice: InvoiceEntity): Promise<string>;
+
 }
 
 export interface LocalStorageStrategy extends BaseStorageStrategy {

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -1,40 +1,41 @@
 import {
-  createTestEnvironment,
-  registerInitializer,
-  SimpleGraphQLClient,
-  SqljsInitializer,
-  testConfig,
-} from '@vendure/testing';
-import { initialData } from '../../test/src/initial-data';
-import {
   ChannelService,
   DefaultLogger,
   LogLevel,
   mergeConfig,
-  Order,
+  Order
 } from '@vendure/core';
+import {
+  createTestEnvironment,
+  registerInitializer,
+  SimpleGraphQLClient,
+  SqljsInitializer,
+  testConfig
+} from '@vendure/testing';
 import { TestServer } from '@vendure/testing/lib/test-server';
-import { InvoicePlugin } from '../src';
-import { testPaymentMethod } from '../../test/src/test-payment-method';
+import fetch from 'node-fetch';
 import {
   addShippingMethod,
-  createSettledOrder,
+  createSettledOrder
 } from '../../test/src/admin-utils';
-import fetch from 'node-fetch';
+import { initialData } from '../../test/src/initial-data';
+import { testPaymentMethod } from '../../test/src/test-payment-method';
+import { GoogleStorageInvoiceStrategy } from '../dist';
+import { InvoicesQuery } from '../dist/ui/generated/graphql';
+import { InvoicePlugin } from '../src';
+import { defaultTemplate } from '../src/api/default-template';
+import { InvoiceService } from '../src/api/invoice.service';
 import {
   Invoice,
   InvoiceConfigQuery,
   MutationUpsertInvoiceConfigArgs,
-  UpsertInvoiceConfigMutation,
+  UpsertInvoiceConfigMutation
 } from '../src/ui/generated/graphql';
-import { defaultTemplate } from '../src/api/default-template';
 import {
   getAllInvoicesQuery,
   getConfigQuery,
-  upsertConfigMutation,
+  upsertConfigMutation
 } from '../src/ui/queries.graphql';
-import { InvoiceService } from '../src/api/invoice.service';
-import { InvoicesQuery } from '../dist/ui/generated/graphql';
 
 jest.setTimeout(20000);
 
@@ -57,6 +58,10 @@ describe('Invoices plugin', function () {
       plugins: [
         InvoicePlugin.init({
           vendureHost: 'http://localhost:3106',
+          storageStrategy: new GoogleStorageInvoiceStrategy({
+            bucketName: "bucket",
+            
+          })
         }),
       ],
       paymentOptions: {

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -20,7 +20,6 @@ import {
 } from '../../test/src/admin-utils';
 import { initialData } from '../../test/src/initial-data';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
-import { GoogleStorageInvoiceStrategy } from '../dist';
 import { InvoicesQuery } from '../dist/ui/generated/graphql';
 import { InvoicePlugin } from '../src';
 import { defaultTemplate } from '../src/api/default-template';
@@ -36,6 +35,9 @@ import {
   getConfigQuery,
   upsertConfigMutation
 } from '../src/ui/queries.graphql';
+<<<<<<< HEAD
+=======
+>>>>>>> aff4c3e (feat(invoices) - defer loading of @google-cloud/storage)
 
 jest.setTimeout(20000);
 
@@ -58,10 +60,6 @@ describe('Invoices plugin', function () {
       plugins: [
         InvoicePlugin.init({
           vendureHost: 'http://localhost:3106',
-          storageStrategy: new GoogleStorageInvoiceStrategy({
-            bucketName: "bucket",
-            
-          })
         }),
       ],
       paymentOptions: {

--- a/packages/vendure-plugin-invoices/tsconfig.json
+++ b/packages/vendure-plugin-invoices/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "strictPropertyInitialization": false,
     "outDir": "dist",
     "lib": ["dom"]
   },


### PR DESCRIPTION
I added deferred library loading as implemented in asset storage strategy of vendure's [asset-server-plugin](https://github.com/vendure-ecommerce/vendure/blob/c6cf4d4e214f3941bc5f27017b0354dda732f9e0/packages/asset-server-plugin/src/s3-asset-storage-strategy.ts#L151) this removes the required dependency to @google-cloud/storage when using local storage or implement your own storage provider.