### PR TITLE
Feat/goedgepickt fixes

### DIFF
--- a/packages/vendure-plugin-goedgepickt/README.md
+++ b/packages/vendure-plugin-goedgepickt/README.md
@@ -64,7 +64,8 @@ old webhook via GoedGepickt.
 
 Stocklevels in Vendure will be updated by incoming webhook events from GoedGepickt.
 
-Vendure variants will be pushed to GoedGepickt on `ProductVariantEvent` events.
+Vendure variants will be pushed to GoedGepickt on product variant creation events. Name, price and image updates are
+only done by full sync.
 
 ## Full sync
 
@@ -73,10 +74,11 @@ Full sync:
 1. Pushes all products in Vendure to GoedGepickt. Products are matched by SKU.
 2. Pulls stocklevels from GoedGepickt and updates in Vendure.
 
-Full sync creates jobs with batches of products for both stocklevel updates and product pushes. GoedGepickt has rate limit, so some jobs might fail and should be retried with exponential backoff for the sync to succeed.
+Full sync creates jobs with batches of products for both stocklevel updates and product pushes. GoedGepickt has rate
+limit, so some jobs might fail and should be retried with exponential backoff for the sync to succeed.
 
-Full sync can be run manually via the Admin ui or via a GET request to endpoint`/goedgepickt/fullsync/<webhook-secret>/`. 
-Full sync can be resource heavy, so use with care.
+Full sync can be run manually via the Admin ui or via a GET request to endpoint`/goedgepickt/fullsync/<webhook-secret>/`
+. Full sync can be resource heavy, so use with care.
 
 ## Pickup points / drop off points
 
@@ -85,29 +87,29 @@ mutation, the plugin will then send the address to Goedgepickt:
 
 ```graphql
 mutation {
-    setOrderCustomFields(
-        input: {
-            customFields: {
-                pickupLocationNumber: "1234"
-                pickupLocationCarrier: "1"
-                pickupLocationName: "Local shop"
-                pickupLocationStreet: "Shopstreet"
-                pickupLocationHouseNumber: "13"
-                pickupLocationZipcode: "8888HG"
-                pickupLocationCity: "Leeuwarden"
-                pickupLocationCountry: "nl"
-            }
-        }
-    ) {
-        ... on Order {
-            id
-            code
-        }
-        ... on NoActiveOrderError {
-            errorCode
-            message
-        }
+  setOrderCustomFields(
+    input: {
+      customFields: {
+        pickupLocationNumber: "1234"
+        pickupLocationCarrier: "1"
+        pickupLocationName: "Local shop"
+        pickupLocationStreet: "Shopstreet"
+        pickupLocationHouseNumber: "13"
+        pickupLocationZipcode: "8888HG"
+        pickupLocationCity: "Leeuwarden"
+        pickupLocationCountry: "nl"
+      }
     }
+  ) {
+    ... on Order {
+      id
+      code
+    }
+    ... on NoActiveOrderError {
+      errorCode
+      message
+    }
+  }
 }
 ```
 

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.client.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.client.ts
@@ -29,7 +29,7 @@ export interface ClientInput {
 export class GoedgepicktClient {
   private readonly headers: Record<string, string>;
 
-  constructor(public readonly config: ClientInput) {
+  constructor(private readonly config: ClientInput) {
     this.headers = {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.client.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.client.ts
@@ -104,7 +104,7 @@ export class GoedgepicktClient {
     const result = await this.rawRequest({
       entity: 'products',
       method: 'GET',
-      queryParams: `searchAttribute=sku&searchDelimiter=%3D&searchValue=${sku}`
+      queryParams: `searchAttribute=sku&searchDelimiter=%3D&searchValue=${sku}`,
     });
     return result.items as Product[];
   }

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.client.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.client.ts
@@ -19,7 +19,7 @@ interface RawRequestInput {
   pathParam?: string;
 }
 
-interface ClientInput {
+export interface ClientInput {
   apiKey: string;
   webshopUuid: string;
   orderWebhookKey?: string;
@@ -29,7 +29,7 @@ interface ClientInput {
 export class GoedgepicktClient {
   private readonly headers: Record<string, string>;
 
-  constructor(private readonly config: ClientInput) {
+  constructor(public readonly config: ClientInput) {
     this.headers = {
       Accept: 'application/json',
       'Content-Type': 'application/json',
@@ -94,9 +94,18 @@ export class GoedgepicktClient {
       payload: product,
     });
     Logger.debug(
-      `Created product ${product.productId} in Goedgepickt`,
+      `Created product ${result.items?.[0]?.uuid} in Goedgepickt`,
       loggerCtx
     );
+    return result.items as Product[];
+  }
+
+  async findProductBySku(sku: string): Promise<Product[]> {
+    const result = await this.rawRequest({
+      entity: 'products',
+      method: 'GET',
+      queryParams: `searchAttribute=sku&searchDelimiter=%3D&searchValue=${sku}`
+    });
     return result.items as Product[];
   }
 
@@ -143,7 +152,7 @@ export class GoedgepicktClient {
   async rawRequest(input: RawRequestInput): Promise<any> {
     const queryExtension = input.queryParams ? `?${input.queryParams}` : '';
     const pathParam = input.pathParam ? `/${input.pathParam}` : '';
-    const result = await fetch(
+    const response = await fetch(
       `https://account.goedgepickt.nl/api/v1/${input.entity}${pathParam}${queryExtension}`,
       {
         method: input.method,
@@ -158,13 +167,12 @@ export class GoedgepicktClient {
         redirect: 'follow',
       }
     );
-    const json = (await result.json()) as any;
-    if (json.error || json.errorMessage || json.errors) {
-      const errorMessage = json.error ?? json.errorMessage ?? json.message; // If json.errors, then there should also be a message
-      Logger.warn(JSON.stringify(json), loggerCtx);
-      throw Error(errorMessage);
+    const json = (await response.json()) as any;
+    if (response.ok) {
+      return json;
     }
-    return json;
+    Logger.error(JSON.stringify(json), loggerCtx);
+    throw Error(json.error || json.errorMessage || json.message);
   }
 
   validateOrderWebhookSignature(data: Object, incomingSignature: string): void {

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.controller.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.controller.ts
@@ -32,16 +32,9 @@ export class GoedgepicktController {
       );
       return;
     }
-    // Push sync jobs to the worker queue
-    const configs = (await this.service.getConfigs()).filter(
-      (config) => config.enabled
-    );
-    for (const config of configs) {
-      await this.service.fullSyncQueue!.add(
-        { channelToken: config.channelToken },
-        { retries: 2 }
-      );
-      Logger.info(`Added full sync job for ${config.channelToken}`);
+    const configs = await this.service.getConfigs();
+    for (const config of configs.filter(config => config.enabled)) {
+      await this.service.createFullsyncJobs(config.channelToken)
     }
   }
 

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.controller.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.controller.ts
@@ -33,8 +33,8 @@ export class GoedgepicktController {
       return;
     }
     const configs = await this.service.getConfigs();
-    for (const config of configs.filter(config => config.enabled)) {
-      await this.service.createFullsyncJobs(config.channelToken)
+    for (const config of configs.filter((config) => config.enabled)) {
+      await this.service.createFullsyncJobs(config.channelToken);
     }
   }
 

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.handler.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.handler.ts
@@ -47,6 +47,7 @@ export const goedgepicktHandler = new FulfillmentHandler({
       } catch (e) {
         Logger.error(`Failed to create order: ${e?.message}`, loggerCtx);
         Logger.error(JSON.stringify(e), loggerCtx);
+        throw e;
       }
     }
     return {

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.resolver.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.resolver.ts
@@ -49,10 +49,10 @@ export class GoedgepicktResolver {
   async runGoedgepicktFullSync(@Ctx() ctx: RequestContext): Promise<boolean> {
     const channelToken = ctx.channel.token;
     const config = await this.service.getConfig(channelToken);
-    if (!config?.apiKey) {
+    if (!config?.apiKey || !config.webshopUuid) {
       throw Error(`No GoedGepickt apiKey set for channel ${channelToken}`);
     }
-    await this.service.fullSyncQueue!.add({ channelToken }, { retries: 2 });
+    await this.service.createFullsyncJobs(channelToken);
     if (this.config.setWebhook) {
       await this.service.setWebhooks(ctx.channel.token);
     }

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.resolver.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.resolver.ts
@@ -49,7 +49,7 @@ export class GoedgepicktResolver {
   async runGoedgepicktFullSync(@Ctx() ctx: RequestContext): Promise<boolean> {
     const channelToken = ctx.channel.token;
     const config = await this.service.getConfig(channelToken);
-    if (!config?.apiKey || !config.webshopUuid) {
+    if (!config?.apiKey || !config?.webshopUuid) {
       throw Error(`No GoedGepickt apiKey set for channel ${channelToken}`);
     }
     await this.service.createFullsyncJobs(channelToken);

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.types.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.types.ts
@@ -89,7 +89,7 @@ export interface OrderInput {
     city?: string;
     country?: string;
   };
-  ignoreUnknownProductWarnings?: boolean
+  ignoreUnknownProductWarnings?: boolean;
 }
 
 export type OrderStatus = 'on_hold' | 'open' | 'completed';

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.types.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.types.ts
@@ -11,6 +11,7 @@ export interface GoedgepicktPluginConfig {
 }
 
 export interface ProductInput {
+  uuid?: string;
   name: string;
   sku: string;
   productId: string;
@@ -88,6 +89,7 @@ export interface OrderInput {
     city?: string;
     country?: string;
   };
+  ignoreUnknownProductWarnings?: boolean
 }
 
 export type OrderStatus = 'on_hold' | 'open' | 'completed';

--- a/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
+++ b/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
@@ -3,115 +3,117 @@ import {
   registerInitializer,
   SimpleGraphQLClient,
   SqljsInitializer,
-  testConfig,
-} from '@vendure/testing';
-import { initialData } from '../../test/src/initial-data';
+  testConfig
+} from "@vendure/testing";
+import { initialData } from "../../test/src/initial-data";
 import {
   DefaultLogger,
+  LanguageCode,
   LogLevel,
   mergeConfig,
   Order,
   OrderService,
+  ProductService,
   ProductVariant,
   ProductVariantService,
-  ShippingMethodService,
-} from '@vendure/core';
-import { TestServer } from '@vendure/testing/lib/test-server';
+  ShippingMethodService
+} from "@vendure/core";
+import { TestServer } from "@vendure/testing/lib/test-server";
 import {
   GoedgepicktConfig,
   goedgepicktHandler,
   GoedgepicktPlugin,
   IncomingOrderStatusEvent,
   IncomingStockUpdateEvent,
-  OrderInput,
-} from '../src';
-import nock from 'nock';
-import { GoedgepicktService } from '../src/api/goedgepickt.service';
-import {
-  getGoedgepicktConfig,
-  runGoedgepicktFullSync,
-  updateGoedgepicktConfig,
-} from '../src/ui/queries.graphql';
-import fs from 'fs';
-import path from 'path';
-import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
-import { GoedgepicktController } from '../src/api/goedgepickt.controller';
-import { GoedgepicktClient } from '../src/api/goedgepickt.client';
-import { getOrder } from '../../test/src/admin-utils';
-import { addItem, createSettledOrder } from '../../test/src/shop-utils';
-import { testPaymentMethod } from '../../test/src/test-payment-method';
-import gql from 'graphql-tag';
-import { SetShippingAddress } from '../../test/src/generated/shop-graphql';
+  OrderInput
+} from "../src";
+import nock from "nock";
+import { GoedgepicktService } from "../src/api/goedgepickt.service";
+import { getGoedgepicktConfig, runGoedgepicktFullSync, updateGoedgepicktConfig } from "../src/ui/queries.graphql";
+import fs from "fs";
+import path from "path";
+import { compileUiExtensions } from "@vendure/ui-devkit/compiler";
+import { GoedgepicktController } from "../src/api/goedgepickt.controller";
+import { GoedgepicktClient } from "../src/api/goedgepickt.client";
+import { getOrder } from "../../test/src/admin-utils";
+import { addItem, createSettledOrder } from "../../test/src/shop-utils";
+import { testPaymentMethod } from "../../test/src/test-payment-method";
+import gql from "graphql-tag";
 
 jest.setTimeout(20000);
 
-describe('Goedgepickt plugin', function () {
+describe("Goedgepickt plugin", function() {
   let server: TestServer;
   let adminClient: SimpleGraphQLClient;
   let shopClient: SimpleGraphQLClient;
   let serverStarted = false;
   const ggConfig = {
-    apiKey: 'test-api-key',
-    webshopUuid: 'test-webshop-uuid',
-    autoFulfill: true,
+    apiKey: "test-api-key",
+    webshopUuid: "test-webshop-uuid",
+    autoFulfill: true
   };
 
   let pushProductsPayloads: any[] = [];
   let createOrderPayload: OrderInput;
   let webhookPayloads: any[] = [];
   let order: Order;
-  const apiUrl = 'https://account.goedgepickt.nl/';
+  const apiUrl = "https://account.goedgepickt.nl/";
   // Update products
   nock(apiUrl)
     .persist(true)
-    .post('/api/v1/products', (reqBody) => {
+    .post("/api/v1/products", (reqBody) => {
       pushProductsPayloads.push(reqBody);
       return true;
     })
     .reply(200, []);
   // Create order
   nock(apiUrl)
-    .post('/api/v1/orders', (reqBody) => {
+    .post("/api/v1/orders", (reqBody) => {
       createOrderPayload = reqBody;
       return true;
     })
     .reply(200, {
-      message: 'Order created',
-      orderUuid: 'testUuid',
+      message: "Order created",
+      orderUuid: "testUuid"
     });
+  // Find by SKU
+  nock(apiUrl)
+    .persist(true)
+    .get("/api/v1/products?searchAttribute=sku&searchDelimiter=%3D&searchValue=sku123")
+    .reply(200, { items: [] });
   // Get webshops
   nock(apiUrl)
     .persist(true)
-    .get('/api/v1/webshops')
+    .get("/api/v1/webshops")
     .reply(200, { items: [{ uuid: ggConfig.webshopUuid }] });
   // get webhooks
-  nock(apiUrl).persist(true).get('/api/v1/webhooks').reply(200, { items: [] });
+  nock(apiUrl).persist(true).get("/api/v1/webhooks").reply(200, { items: [] });
   // Update webhooks
   nock(apiUrl)
     .persist(true)
-    .post('/api/v1/webhooks', (reqBody) => {
+    .post("/api/v1/webhooks", (reqBody) => {
       webhookPayloads.push(reqBody);
       return true;
     })
-    .reply(200, { webhookSecret: 'test-secret' });
+    .reply(200, { webhookSecret: "test-secret" });
 
   beforeAll(async () => {
-    registerInitializer('sqljs', new SqljsInitializer('__data__'));
+    registerInitializer("sqljs", new SqljsInitializer("__data__"));
     const config = mergeConfig(testConfig, {
       apiOptions: {
         adminListQueryLimit: 10000,
-        port: 3105,
+        port: 3105
       },
       logger: new DefaultLogger({ level: LogLevel.Info }),
       plugins: [
         GoedgepicktPlugin.init({
-          vendureHost: 'https://test-host',
-          endpointSecret: 'test',
-        }),
+          vendureHost: "https://test-host",
+          endpointSecret: "test"
+        })
       ],
       paymentOptions: {
-        paymentMethodHandlers: [testPaymentMethod],
-      },
+        paymentMethodHandlers: [testPaymentMethod]
+      }
     });
 
     ({ server, adminClient, shopClient } = createTestEnvironment(config));
@@ -121,41 +123,41 @@ describe('Goedgepickt plugin', function () {
         paymentMethods: [
           {
             name: testPaymentMethod.code,
-            handler: { code: testPaymentMethod.code, arguments: [] },
-          },
-        ],
+            handler: { code: testPaymentMethod.code, arguments: [] }
+          }
+        ]
       },
-      productsCsvPath: '../test/src/products-import.csv',
+      productsCsvPath: "../test/src/products-import.csv"
     });
     serverStarted = true;
     await adminClient.asSuperAdmin();
   }, 60000);
 
-  it('Should start successfully', async () => {
+  it("Should start successfully", async () => {
     await expect(serverStarted).toBe(true);
   });
 
-  it('Updates config via graphql and sets webhooks', async () => {
+  it("Updates config via graphql and sets webhooks", async () => {
     const result: { updateGoedgepicktConfig: GoedgepicktConfig } =
       await adminClient.query(updateGoedgepicktConfig, {
-        input: ggConfig,
+        input: ggConfig
       });
     await expect(result.updateGoedgepicktConfig.webshopUuid).toBe(
       ggConfig.webshopUuid
     );
     await expect(result.updateGoedgepicktConfig.orderWebhookKey).toBe(
-      'test-secret'
+      "test-secret"
     );
     await expect(result.updateGoedgepicktConfig.stockWebhookKey).toBe(
-      'test-secret'
+      "test-secret"
     );
     await expect(webhookPayloads.length).toBe(2); // Order and Stock webhooks
     await expect(webhookPayloads[0].targetUrl).toBe(
-      'https://test-host/goedgepickt/webhook/e2e-default-channel'
+      "https://test-host/goedgepickt/webhook/e2e-default-channel"
     );
   });
 
-  it('Retrieves config via graphql', async () => {
+  it("Retrieves config via graphql", async () => {
     const result = await adminClient.query(getGoedgepicktConfig);
     await expect(result.goedgepicktConfig.webshopUuid).toBe(
       ggConfig.webshopUuid
@@ -163,132 +165,160 @@ describe('Goedgepickt plugin', function () {
     await expect(result.goedgepicktConfig.apiKey).toBe(ggConfig.apiKey);
   });
 
-  it('Pushes products and updates stocklevel on FullSync', async () => {
-    nock(apiUrl).put('/api/v1/products/test-uuid').reply(200, []);
+  it("Pushes products and updates stocklevel on FullSync", async () => {
+    nock(apiUrl).put("/api/v1/products/test-uuid").reply(200, []);
     nock(apiUrl)
-      .get('/api/v1/products')
+      .get("/api/v1/products")
       .query(true)
       .reply(200, {
         items: [
           {
-            uuid: 'test-uuid',
-            sku: 'L2201308',
+            uuid: "test-uuid",
+            sku: "L2201308",
             stock: {
-              freeStock: 33,
-            },
-          },
-        ],
+              freeStock: 33
+            }
+          }
+        ]
       });
     await adminClient.query(runGoedgepicktFullSync);
     await new Promise((resolve) => setTimeout(resolve, 500)); // Some time for async event handling
     await expect(pushProductsPayloads.length).toBe(3);
     const laptopPayload = pushProductsPayloads.find(
-      (p) => p.sku === 'L2201516'
+      (p) => p.sku === "L2201516"
     );
     await expect(laptopPayload.webshopUuid).toBe(ggConfig.webshopUuid);
-    await expect(laptopPayload.productId).toBe('L2201516');
-    await expect(laptopPayload.sku).toBe('L2201516');
-    await expect(laptopPayload.name).toBe('Laptop 15 inch 16GB');
-    await expect(laptopPayload.price).toBe('2299.00');
+    await expect(laptopPayload.productId).toBe("L2201516");
+    await expect(laptopPayload.sku).toBe("L2201516");
+    await expect(laptopPayload.name).toBe("Laptop 15 inch 16GB");
+    await expect(laptopPayload.price).toBe("2299.00");
     await expect(laptopPayload.url).toBe(
       `https://test-host/admin/catalog/products/1;id=1;tab=variants`
     );
-    const updatedVariant = await findVariantBySku('L2201308');
+    const updatedVariant = await findVariantBySku("L2201308");
     await expect(updatedVariant?.stockOnHand).toBe(33);
   });
 
-  it('Set goedgepickt as fulfillment handler', async () => {
+  it("Set goedgepickt as fulfillment handler", async () => {
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel('e2e-default-channel');
+      .getCtxForChannel("e2e-default-channel");
     const shippingMethod = await server.app
       .get(ShippingMethodService)
       .update(ctx, {
         id: 1,
         fulfillmentHandler: goedgepicktHandler.code,
-        translations: [],
+        translations: []
       });
-    expect(shippingMethod.fulfillmentHandlerCode).toBe('goedgepickt');
+    expect(shippingMethod.fulfillmentHandlerCode).toBe("goedgepickt");
   });
 
-  it('Pushes order with autofulfill', async () => {
+  it("Pushes order with autofulfill", async () => {
     await shopClient.asUserWithCredentials(
-      'hayden.zieme12@hotmail.com',
-      'test'
+      "hayden.zieme12@hotmail.com",
+      "test"
     );
-    await addItem(shopClient, 'T_1', 1);
+    await addItem(shopClient, "T_1", 1);
     const res = await shopClient.query(SET_CUSTOM_FIELDS);
     order = await createSettledOrder(shopClient, 1);
     await new Promise((resolve) => setTimeout(resolve, 500)); // Some time for async event handling
     const adminOrder = await getOrder(adminClient, order.id as string);
     const fulfillment = adminOrder?.fulfillments?.[0];
-    await expect(fulfillment?.method).toBe('testUuid');
+    await expect(fulfillment?.method).toBe("testUuid");
     await expect(createOrderPayload.orderId).toBe(order.code);
-    await expect(createOrderPayload.shippingFirstName).toBe('Hayden');
-    await expect(createOrderPayload.shippingLastName).toBe('Zieme');
-    await expect(createOrderPayload.shippingAddress).toBe('Verzetsstraat');
-    await expect(createOrderPayload.shippingHouseNumber).toBe('12');
-    await expect(createOrderPayload.shippingHouseNumberAddition).toBe('a');
-    await expect(createOrderPayload.shippingZipcode).toBe('8923CP');
-    await expect(createOrderPayload.shippingCity).toBe('Liwwa');
-    await expect(createOrderPayload.shippingCountry).toBe('NL');
+    await expect(createOrderPayload.shippingFirstName).toBe("Hayden");
+    await expect(createOrderPayload.shippingLastName).toBe("Zieme");
+    await expect(createOrderPayload.shippingAddress).toBe("Verzetsstraat");
+    await expect(createOrderPayload.shippingHouseNumber).toBe("12");
+    await expect(createOrderPayload.shippingHouseNumberAddition).toBe("a");
+    await expect(createOrderPayload.shippingZipcode).toBe("8923CP");
+    await expect(createOrderPayload.shippingCity).toBe("Liwwa");
+    await expect(createOrderPayload.shippingCountry).toBe("NL");
     await expect(createOrderPayload.pickupLocationData?.houseNumber).toBe(
-      '13a'
+      "13a"
     );
     await expect(createOrderPayload.pickupLocationData?.city).toBe(
-      'Leeuwarden'
+      "Leeuwarden"
     );
     await expect(createOrderPayload.pickupLocationData?.locationNumber).toBe(
-      '1234'
+      "1234"
     );
-    await expect(createOrderPayload.pickupLocationData?.country).toBe('NL');
+    await expect(createOrderPayload.pickupLocationData?.country).toBe("NL");
   });
 
-  it('Completes order via webhook', async () => {
+  it("Completes order via webhook", async () => {
     const body: IncomingOrderStatusEvent = {
-      newStatus: 'completed',
+      newStatus: "completed",
       orderNumber: order.code,
-      event: 'orderStatusChanged',
-      orderUuid: 'doesntmatter',
+      event: "orderStatusChanged",
+      orderUuid: "doesntmatter"
     };
-    const signature = GoedgepicktClient.computeSignature('test-secret', body);
+    const signature = GoedgepicktClient.computeSignature("test-secret", body);
     await server.app
       .get(GoedgepicktController)
-      .webhook('e2e-default-channel', body, signature);
+      .webhook("e2e-default-channel", body, signature);
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel('e2e-default-channel');
+      .getCtxForChannel("e2e-default-channel");
     order = (await server.app
       .get(OrderService)
       .findOneByCode(ctx, order.code))!;
-    expect(order.state).toBe('Delivered');
+    expect(order.state).toBe("Delivered");
   });
 
-  it('Decreases stock via webhook', async () => {
+  it("Decreases stock via webhook", async () => {
     const body: IncomingStockUpdateEvent = {
-      event: 'stockUpdated',
-      newStock: '123',
-      productSku: 'L2201308',
-      productUuid: 'doesntmatter',
+      event: "stockUpdated",
+      newStock: "123",
+      productSku: "L2201308",
+      productUuid: "doesntmatter"
     };
-    const signature = GoedgepicktClient.computeSignature('test-secret', body);
+    const signature = GoedgepicktClient.computeSignature("test-secret", body);
     await server.app
       .get(GoedgepicktController)
-      .webhook('e2e-default-channel', body, signature);
-    const updatedVariant = await findVariantBySku('L2201308');
+      .webhook("e2e-default-channel", body, signature);
+    const updatedVariant = await findVariantBySku("L2201308");
     expect(updatedVariant.stockOnHand).toBe(123);
   });
 
-  it.skip('Should compile admin', async () => {
-    fs.rmSync(path.join(__dirname, '__admin-ui'), {
+  it("Pushes product on product creation", async () => {
+    const ctx = await server.app
+      .get(GoedgepicktService)
+      .getCtxForChannel("e2e-default-channel");
+    await server.app
+      .get(ProductService).create(ctx, {
+        translations: [{
+          languageCode: LanguageCode.en,
+          name: "test",
+          slug: "test",
+          description: ""
+        }]
+      });
+    await server.app
+      .get(ProductVariantService).create(ctx, [{
+        productId: 2,
+        price: 1200,
+        sku: "sku123",
+        translations: [{
+          languageCode: LanguageCode.en,
+          name: "test variant"
+        }]
+      }]);
+    await new Promise((resolve) => setTimeout(resolve, 500)); // Some time for async event handling
+    const payload = pushProductsPayloads.find(p => p.sku === "sku123");
+    expect(payload).toBeDefined();
+  });
+
+  it.skip("Should compile admin", async () => {
+    fs.rmSync(path.join(__dirname, "__admin-ui"), {
       recursive: true,
-      force: true,
+      force: true
     });
     await compileUiExtensions({
-      outputPath: path.join(__dirname, '__admin-ui'),
-      extensions: [GoedgepicktPlugin.ui],
+      outputPath: path.join(__dirname, "__admin-ui"),
+      extensions: [GoedgepicktPlugin.ui]
     }).compile?.();
-    const files = fs.readdirSync(path.join(__dirname, '__admin-ui/dist'));
+    const files = fs.readdirSync(path.join(__dirname, "__admin-ui/dist"));
     expect(files?.length).toBeGreaterThan(0);
   }, 240000);
 
@@ -299,36 +329,36 @@ describe('Goedgepickt plugin', function () {
   async function findVariantBySku(sku: string): Promise<ProductVariant> {
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel('e2e-default-channel');
+      .getCtxForChannel("e2e-default-channel");
     const result = await server.app.get(ProductVariantService).findAll(ctx);
     return result.items.find((variant) => variant.sku === sku)!;
   }
 });
 
 const SET_CUSTOM_FIELDS = gql`
-  mutation {
-    setOrderCustomFields(
-      input: {
-        customFields: {
-          pickupLocationNumber: "1234"
-          pickupLocationCarrier: "1"
-          pickupLocationName: "Local shop"
-          pickupLocationStreet: "Shopstreet"
-          pickupLocationHouseNumber: "13a"
-          pickupLocationZipcode: "8888HG"
-          pickupLocationCity: "Leeuwarden"
-          pickupLocationCountry: "nl"
+    mutation {
+        setOrderCustomFields(
+            input: {
+                customFields: {
+                    pickupLocationNumber: "1234"
+                    pickupLocationCarrier: "1"
+                    pickupLocationName: "Local shop"
+                    pickupLocationStreet: "Shopstreet"
+                    pickupLocationHouseNumber: "13a"
+                    pickupLocationZipcode: "8888HG"
+                    pickupLocationCity: "Leeuwarden"
+                    pickupLocationCountry: "nl"
+                }
+            }
+        ) {
+            ... on Order {
+                id
+                code
+            }
+            ... on NoActiveOrderError {
+                errorCode
+                message
+            }
         }
-      }
-    ) {
-      ... on Order {
-        id
-        code
-      }
-      ... on NoActiveOrderError {
-        errorCode
-        message
-      }
     }
-  }
 `;

--- a/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
+++ b/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
@@ -3,9 +3,9 @@ import {
   registerInitializer,
   SimpleGraphQLClient,
   SqljsInitializer,
-  testConfig
-} from "@vendure/testing";
-import { initialData } from "../../test/src/initial-data";
+  testConfig,
+} from '@vendure/testing';
+import { initialData } from '../../test/src/initial-data';
 import {
   DefaultLogger,
   LanguageCode,
@@ -16,104 +16,110 @@ import {
   ProductService,
   ProductVariant,
   ProductVariantService,
-  ShippingMethodService
-} from "@vendure/core";
-import { TestServer } from "@vendure/testing/lib/test-server";
+  ShippingMethodService,
+} from '@vendure/core';
+import { TestServer } from '@vendure/testing/lib/test-server';
 import {
   GoedgepicktConfig,
   goedgepicktHandler,
   GoedgepicktPlugin,
   IncomingOrderStatusEvent,
   IncomingStockUpdateEvent,
-  OrderInput
-} from "../src";
-import nock from "nock";
-import { GoedgepicktService } from "../src/api/goedgepickt.service";
-import { getGoedgepicktConfig, runGoedgepicktFullSync, updateGoedgepicktConfig } from "../src/ui/queries.graphql";
-import fs from "fs";
-import path from "path";
-import { compileUiExtensions } from "@vendure/ui-devkit/compiler";
-import { GoedgepicktController } from "../src/api/goedgepickt.controller";
-import { GoedgepicktClient } from "../src/api/goedgepickt.client";
-import { getOrder } from "../../test/src/admin-utils";
-import { addItem, createSettledOrder } from "../../test/src/shop-utils";
-import { testPaymentMethod } from "../../test/src/test-payment-method";
-import gql from "graphql-tag";
+  OrderInput,
+} from '../src';
+import nock from 'nock';
+import { GoedgepicktService } from '../src/api/goedgepickt.service';
+import {
+  getGoedgepicktConfig,
+  runGoedgepicktFullSync,
+  updateGoedgepicktConfig,
+} from '../src/ui/queries.graphql';
+import fs from 'fs';
+import path from 'path';
+import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
+import { GoedgepicktController } from '../src/api/goedgepickt.controller';
+import { GoedgepicktClient } from '../src/api/goedgepickt.client';
+import { getOrder } from '../../test/src/admin-utils';
+import { addItem, createSettledOrder } from '../../test/src/shop-utils';
+import { testPaymentMethod } from '../../test/src/test-payment-method';
+import gql from 'graphql-tag';
 
 jest.setTimeout(20000);
 
-describe("Goedgepickt plugin", function() {
+describe('Goedgepickt plugin', function () {
   let server: TestServer;
   let adminClient: SimpleGraphQLClient;
   let shopClient: SimpleGraphQLClient;
   let serverStarted = false;
   const ggConfig = {
-    apiKey: "test-api-key",
-    webshopUuid: "test-webshop-uuid",
-    autoFulfill: true
+    apiKey: 'test-api-key',
+    webshopUuid: 'test-webshop-uuid',
+    autoFulfill: true,
   };
 
   let pushProductsPayloads: any[] = [];
   let createOrderPayload: OrderInput;
   let webhookPayloads: any[] = [];
   let order: Order;
-  const apiUrl = "https://account.goedgepickt.nl/";
+  const apiUrl = 'https://account.goedgepickt.nl/';
   // Update products
   nock(apiUrl)
     .persist(true)
-    .post("/api/v1/products", (reqBody) => {
+    .post('/api/v1/products', (reqBody) => {
       pushProductsPayloads.push(reqBody);
       return true;
     })
     .reply(200, []);
   // Create order
   nock(apiUrl)
-    .post("/api/v1/orders", (reqBody) => {
+    .post('/api/v1/orders', (reqBody) => {
       createOrderPayload = reqBody;
       return true;
     })
     .reply(200, {
-      message: "Order created",
-      orderUuid: "testUuid"
+      message: 'Order created',
+      orderUuid: 'testUuid',
     });
   // Find by SKU
   nock(apiUrl)
     .persist(true)
-    .get("/api/v1/products?searchAttribute=sku&searchDelimiter=%3D&searchValue=sku123")
+    .get(
+      '/api/v1/products?searchAttribute=sku&searchDelimiter=%3D&searchValue=sku123'
+    )
     .reply(200, { items: [] });
   // Get webshops
   nock(apiUrl)
     .persist(true)
-    .get("/api/v1/webshops")
+    .get('/api/v1/webshops')
     .reply(200, { items: [{ uuid: ggConfig.webshopUuid }] });
   // get webhooks
-  nock(apiUrl).persist(true).get("/api/v1/webhooks").reply(200, { items: [] });
+  nock(apiUrl).persist(true).get('/api/v1/webhooks').reply(200, { items: [] });
   // Update webhooks
   nock(apiUrl)
     .persist(true)
-    .post("/api/v1/webhooks", (reqBody) => {
+    .post('/api/v1/webhooks', (reqBody) => {
       webhookPayloads.push(reqBody);
       return true;
     })
-    .reply(200, { webhookSecret: "test-secret" });
+    .reply(200, { webhookSecret: 'test-secret' });
 
   beforeAll(async () => {
-    registerInitializer("sqljs", new SqljsInitializer("__data__"));
+    registerInitializer('sqljs', new SqljsInitializer('__data__'));
     const config = mergeConfig(testConfig, {
       apiOptions: {
         adminListQueryLimit: 10000,
-        port: 3105
+        port: 3105,
       },
       logger: new DefaultLogger({ level: LogLevel.Info }),
       plugins: [
         GoedgepicktPlugin.init({
-          vendureHost: "https://test-host",
-          endpointSecret: "test"
-        })
+          vendureHost: 'https://test-host',
+          endpointSecret: 'test',
+        }),
       ],
       paymentOptions: {
-        paymentMethodHandlers: [testPaymentMethod]
-      }
+        paymentMethodHandlers: [testPaymentMethod],
+      },
     });
 
     ({ server, adminClient, shopClient } = createTestEnvironment(config));
@@ -123,41 +129,41 @@ describe("Goedgepickt plugin", function() {
         paymentMethods: [
           {
             name: testPaymentMethod.code,
-            handler: { code: testPaymentMethod.code, arguments: [] }
-          }
-        ]
+            handler: { code: testPaymentMethod.code, arguments: [] },
+          },
+        ],
       },
-      productsCsvPath: "../test/src/products-import.csv"
+      productsCsvPath: '../test/src/products-import.csv',
     });
     serverStarted = true;
     await adminClient.asSuperAdmin();
   }, 60000);
 
-  it("Should start successfully", async () => {
+  it('Should start successfully', async () => {
     await expect(serverStarted).toBe(true);
   });
 
-  it("Updates config via graphql and sets webhooks", async () => {
+  it('Updates config via graphql and sets webhooks', async () => {
     const result: { updateGoedgepicktConfig: GoedgepicktConfig } =
       await adminClient.query(updateGoedgepicktConfig, {
-        input: ggConfig
+        input: ggConfig,
       });
     await expect(result.updateGoedgepicktConfig.webshopUuid).toBe(
       ggConfig.webshopUuid
     );
     await expect(result.updateGoedgepicktConfig.orderWebhookKey).toBe(
-      "test-secret"
+      'test-secret'
     );
     await expect(result.updateGoedgepicktConfig.stockWebhookKey).toBe(
-      "test-secret"
+      'test-secret'
     );
     await expect(webhookPayloads.length).toBe(2); // Order and Stock webhooks
     await expect(webhookPayloads[0].targetUrl).toBe(
-      "https://test-host/goedgepickt/webhook/e2e-default-channel"
+      'https://test-host/goedgepickt/webhook/e2e-default-channel'
     );
   });
 
-  it("Retrieves config via graphql", async () => {
+  it('Retrieves config via graphql', async () => {
     const result = await adminClient.query(getGoedgepicktConfig);
     await expect(result.goedgepicktConfig.webshopUuid).toBe(
       ggConfig.webshopUuid
@@ -165,160 +171,164 @@ describe("Goedgepickt plugin", function() {
     await expect(result.goedgepicktConfig.apiKey).toBe(ggConfig.apiKey);
   });
 
-  it("Pushes products and updates stocklevel on FullSync", async () => {
-    nock(apiUrl).put("/api/v1/products/test-uuid").reply(200, []);
+  it('Pushes products and updates stocklevel on FullSync', async () => {
+    nock(apiUrl).put('/api/v1/products/test-uuid').reply(200, []);
     nock(apiUrl)
-      .get("/api/v1/products")
+      .get('/api/v1/products')
       .query(true)
       .reply(200, {
         items: [
           {
-            uuid: "test-uuid",
-            sku: "L2201308",
+            uuid: 'test-uuid',
+            sku: 'L2201308',
             stock: {
-              freeStock: 33
-            }
-          }
-        ]
+              freeStock: 33,
+            },
+          },
+        ],
       });
     await adminClient.query(runGoedgepicktFullSync);
     await new Promise((resolve) => setTimeout(resolve, 500)); // Some time for async event handling
     await expect(pushProductsPayloads.length).toBe(3);
     const laptopPayload = pushProductsPayloads.find(
-      (p) => p.sku === "L2201516"
+      (p) => p.sku === 'L2201516'
     );
     await expect(laptopPayload.webshopUuid).toBe(ggConfig.webshopUuid);
-    await expect(laptopPayload.productId).toBe("L2201516");
-    await expect(laptopPayload.sku).toBe("L2201516");
-    await expect(laptopPayload.name).toBe("Laptop 15 inch 16GB");
-    await expect(laptopPayload.price).toBe("2299.00");
+    await expect(laptopPayload.productId).toBe('L2201516');
+    await expect(laptopPayload.sku).toBe('L2201516');
+    await expect(laptopPayload.name).toBe('Laptop 15 inch 16GB');
+    await expect(laptopPayload.price).toBe('2299.00');
     await expect(laptopPayload.url).toBe(
       `https://test-host/admin/catalog/products/1;id=1;tab=variants`
     );
-    const updatedVariant = await findVariantBySku("L2201308");
+    const updatedVariant = await findVariantBySku('L2201308');
     await expect(updatedVariant?.stockOnHand).toBe(33);
   });
 
-  it("Set goedgepickt as fulfillment handler", async () => {
+  it('Set goedgepickt as fulfillment handler', async () => {
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel("e2e-default-channel");
+      .getCtxForChannel('e2e-default-channel');
     const shippingMethod = await server.app
       .get(ShippingMethodService)
       .update(ctx, {
         id: 1,
         fulfillmentHandler: goedgepicktHandler.code,
-        translations: []
+        translations: [],
       });
-    expect(shippingMethod.fulfillmentHandlerCode).toBe("goedgepickt");
+    expect(shippingMethod.fulfillmentHandlerCode).toBe('goedgepickt');
   });
 
-  it("Pushes order with autofulfill", async () => {
+  it('Pushes order with autofulfill', async () => {
     await shopClient.asUserWithCredentials(
-      "hayden.zieme12@hotmail.com",
-      "test"
+      'hayden.zieme12@hotmail.com',
+      'test'
     );
-    await addItem(shopClient, "T_1", 1);
+    await addItem(shopClient, 'T_1', 1);
     const res = await shopClient.query(SET_CUSTOM_FIELDS);
     order = await createSettledOrder(shopClient, 1);
     await new Promise((resolve) => setTimeout(resolve, 500)); // Some time for async event handling
     const adminOrder = await getOrder(adminClient, order.id as string);
     const fulfillment = adminOrder?.fulfillments?.[0];
-    await expect(fulfillment?.method).toBe("testUuid");
+    await expect(fulfillment?.method).toBe('testUuid');
     await expect(createOrderPayload.orderId).toBe(order.code);
-    await expect(createOrderPayload.shippingFirstName).toBe("Hayden");
-    await expect(createOrderPayload.shippingLastName).toBe("Zieme");
-    await expect(createOrderPayload.shippingAddress).toBe("Verzetsstraat");
-    await expect(createOrderPayload.shippingHouseNumber).toBe("12");
-    await expect(createOrderPayload.shippingHouseNumberAddition).toBe("a");
-    await expect(createOrderPayload.shippingZipcode).toBe("8923CP");
-    await expect(createOrderPayload.shippingCity).toBe("Liwwa");
-    await expect(createOrderPayload.shippingCountry).toBe("NL");
+    await expect(createOrderPayload.shippingFirstName).toBe('Hayden');
+    await expect(createOrderPayload.shippingLastName).toBe('Zieme');
+    await expect(createOrderPayload.shippingAddress).toBe('Verzetsstraat');
+    await expect(createOrderPayload.shippingHouseNumber).toBe('12');
+    await expect(createOrderPayload.shippingHouseNumberAddition).toBe('a');
+    await expect(createOrderPayload.shippingZipcode).toBe('8923CP');
+    await expect(createOrderPayload.shippingCity).toBe('Liwwa');
+    await expect(createOrderPayload.shippingCountry).toBe('NL');
     await expect(createOrderPayload.pickupLocationData?.houseNumber).toBe(
-      "13a"
+      '13a'
     );
     await expect(createOrderPayload.pickupLocationData?.city).toBe(
-      "Leeuwarden"
+      'Leeuwarden'
     );
     await expect(createOrderPayload.pickupLocationData?.locationNumber).toBe(
-      "1234"
+      '1234'
     );
-    await expect(createOrderPayload.pickupLocationData?.country).toBe("NL");
+    await expect(createOrderPayload.pickupLocationData?.country).toBe('NL');
   });
 
-  it("Completes order via webhook", async () => {
+  it('Completes order via webhook', async () => {
     const body: IncomingOrderStatusEvent = {
-      newStatus: "completed",
+      newStatus: 'completed',
       orderNumber: order.code,
-      event: "orderStatusChanged",
-      orderUuid: "doesntmatter"
+      event: 'orderStatusChanged',
+      orderUuid: 'doesntmatter',
     };
-    const signature = GoedgepicktClient.computeSignature("test-secret", body);
+    const signature = GoedgepicktClient.computeSignature('test-secret', body);
     await server.app
       .get(GoedgepicktController)
-      .webhook("e2e-default-channel", body, signature);
+      .webhook('e2e-default-channel', body, signature);
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel("e2e-default-channel");
+      .getCtxForChannel('e2e-default-channel');
     order = (await server.app
       .get(OrderService)
       .findOneByCode(ctx, order.code))!;
-    expect(order.state).toBe("Delivered");
+    expect(order.state).toBe('Delivered');
   });
 
-  it("Decreases stock via webhook", async () => {
+  it('Decreases stock via webhook', async () => {
     const body: IncomingStockUpdateEvent = {
-      event: "stockUpdated",
-      newStock: "123",
-      productSku: "L2201308",
-      productUuid: "doesntmatter"
+      event: 'stockUpdated',
+      newStock: '123',
+      productSku: 'L2201308',
+      productUuid: 'doesntmatter',
     };
-    const signature = GoedgepicktClient.computeSignature("test-secret", body);
+    const signature = GoedgepicktClient.computeSignature('test-secret', body);
     await server.app
       .get(GoedgepicktController)
-      .webhook("e2e-default-channel", body, signature);
-    const updatedVariant = await findVariantBySku("L2201308");
+      .webhook('e2e-default-channel', body, signature);
+    const updatedVariant = await findVariantBySku('L2201308');
     expect(updatedVariant.stockOnHand).toBe(123);
   });
 
-  it("Pushes product on product creation", async () => {
+  it('Pushes product on product creation', async () => {
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel("e2e-default-channel");
-    await server.app
-      .get(ProductService).create(ctx, {
-        translations: [{
+      .getCtxForChannel('e2e-default-channel');
+    await server.app.get(ProductService).create(ctx, {
+      translations: [
+        {
           languageCode: LanguageCode.en,
-          name: "test",
-          slug: "test",
-          description: ""
-        }]
-      });
-    await server.app
-      .get(ProductVariantService).create(ctx, [{
+          name: 'test',
+          slug: 'test',
+          description: '',
+        },
+      ],
+    });
+    await server.app.get(ProductVariantService).create(ctx, [
+      {
         productId: 2,
         price: 1200,
-        sku: "sku123",
-        translations: [{
-          languageCode: LanguageCode.en,
-          name: "test variant"
-        }]
-      }]);
+        sku: 'sku123',
+        translations: [
+          {
+            languageCode: LanguageCode.en,
+            name: 'test variant',
+          },
+        ],
+      },
+    ]);
     await new Promise((resolve) => setTimeout(resolve, 500)); // Some time for async event handling
-    const payload = pushProductsPayloads.find(p => p.sku === "sku123");
+    const payload = pushProductsPayloads.find((p) => p.sku === 'sku123');
     expect(payload).toBeDefined();
   });
 
-  it.skip("Should compile admin", async () => {
-    fs.rmSync(path.join(__dirname, "__admin-ui"), {
+  it.skip('Should compile admin', async () => {
+    fs.rmSync(path.join(__dirname, '__admin-ui'), {
       recursive: true,
-      force: true
+      force: true,
     });
     await compileUiExtensions({
-      outputPath: path.join(__dirname, "__admin-ui"),
-      extensions: [GoedgepicktPlugin.ui]
+      outputPath: path.join(__dirname, '__admin-ui'),
+      extensions: [GoedgepicktPlugin.ui],
     }).compile?.();
-    const files = fs.readdirSync(path.join(__dirname, "__admin-ui/dist"));
+    const files = fs.readdirSync(path.join(__dirname, '__admin-ui/dist'));
     expect(files?.length).toBeGreaterThan(0);
   }, 240000);
 
@@ -329,36 +339,36 @@ describe("Goedgepickt plugin", function() {
   async function findVariantBySku(sku: string): Promise<ProductVariant> {
     const ctx = await server.app
       .get(GoedgepicktService)
-      .getCtxForChannel("e2e-default-channel");
+      .getCtxForChannel('e2e-default-channel');
     const result = await server.app.get(ProductVariantService).findAll(ctx);
     return result.items.find((variant) => variant.sku === sku)!;
   }
 });
 
 const SET_CUSTOM_FIELDS = gql`
-    mutation {
-        setOrderCustomFields(
-            input: {
-                customFields: {
-                    pickupLocationNumber: "1234"
-                    pickupLocationCarrier: "1"
-                    pickupLocationName: "Local shop"
-                    pickupLocationStreet: "Shopstreet"
-                    pickupLocationHouseNumber: "13a"
-                    pickupLocationZipcode: "8888HG"
-                    pickupLocationCity: "Leeuwarden"
-                    pickupLocationCountry: "nl"
-                }
-            }
-        ) {
-            ... on Order {
-                id
-                code
-            }
-            ... on NoActiveOrderError {
-                errorCode
-                message
-            }
+  mutation {
+    setOrderCustomFields(
+      input: {
+        customFields: {
+          pickupLocationNumber: "1234"
+          pickupLocationCarrier: "1"
+          pickupLocationName: "Local shop"
+          pickupLocationStreet: "Shopstreet"
+          pickupLocationHouseNumber: "13a"
+          pickupLocationZipcode: "8888HG"
+          pickupLocationCity: "Leeuwarden"
+          pickupLocationCountry: "nl"
         }
+      }
+    ) {
+      ... on Order {
+        id
+        code
+      }
+      ... on NoActiveOrderError {
+        errorCode
+        message
+      }
     }
+  }
 `;


### PR DESCRIPTION
* All worker jobs go to a single `goedgepickt-sync` queue
* Full sync creates 2 types of jobs:
   * Push products to GoedGepickt with 30 products per job
   * Update stocklevels in Vendure per 100 variants
* On variant creation a job is created for all created variants. These variants are all in 1 job, with a delay between every 30 products, because of the 60 request per minute API rate limit of GoedgGepickt