### PR TITLE
feat(e-boekhouden): exporting tax utility

### DIFF
--- a/packages/vendure-plugin-e-boekhouden/src/index.ts
+++ b/packages/vendure-plugin-e-boekhouden/src/index.ts
@@ -6,3 +6,4 @@ export const eBoekhoudenPermission = new PermissionDefinition({
 });
 export * from './ui/generated/graphql';
 export * from './e-boekhouden.plugin';
+export { recalculateTaxFromTotalIncVAT } from './api/e-boekhouden.adapter';


### PR DESCRIPTION
Exporting the `recalculateTaxFromTotalIncVAT()`from e-boekhouden plugin so it can be reused in the consuming project.

Vendure calculates taxes per orderline, while the EBoekhouden plugin sends taxes per taxRate (from the ordersummary) to the EBoekhouden platform. This sometimes results in small rounding differences where `taxBase + taxTotal` is not equal to `taxBase * taxRate`.
The function calculates the totalIncVAT as `totalIncVAT = taxBase + taxTotal`, and recalculates the `totalExVAT` and the `totalTax` based on the new totalIncVAT.

By exporting this function we can reuse it in our InvoicePlugin template, so that there are no differences between invoices and tax administration