### PR TITLE
invoice-plugin - s3 storage naming and content type

### DIFF
--- a/packages/vendure-plugin-invoices/src/api/strategies/google-storage-invoice-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/api/strategies/google-storage-invoice-strategy.ts
@@ -54,9 +54,7 @@ export class GoogleStorageInvoiceStrategy implements RemoteStorageStrategy {
     invoiceNumber: number,
     channelToken: string
   ): Promise<string> {
-    const name = `${channelToken}/${path.basename(
-      tmpFile
-    )}-${invoiceNumber}.pdf`;
+    const name = `${channelToken}/${invoiceNumber}.pdf`;
     await this.storage.bucket(this.bucketName).upload(tmpFile, {
       destination: name,
     });

--- a/packages/vendure-plugin-invoices/src/api/strategies/local-file-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/api/strategies/local-file-strategy.ts
@@ -19,7 +19,7 @@ export class LocalFileStrategy implements LocalStorageStrategy {
       await fs.mkdir(this.invoiceDir);
     }
     const fileName = path.basename(tmpFile);
-    const newPath = `${this.invoiceDir}/${invoiceNumber}-${fileName}`;
+    const newPath = `${this.invoiceDir}/${invoiceNumber}.pdf`;
     await fs.rename(tmpFile, newPath);
     return newPath;
   }

--- a/packages/vendure-plugin-invoices/src/api/strategies/s3-storage.strategy.ts
+++ b/packages/vendure-plugin-invoices/src/api/strategies/s3-storage.strategy.ts
@@ -52,13 +52,13 @@ export class S3StorageStrategy implements RemoteStorageStrategy {
     invoiceNumber: number,
     channelToken: string
   ): Promise<string> {
-    const Key: string = `invoices/${channelToken}/${path.basename(
-      tmpFile
-    )}-${invoiceNumber}.pdf`;
+    const Key: string = `invoices/${channelToken}/${invoiceNumber}.pdf`;
     await this.s3!.upload({
       Bucket: this.bucket,
       Key,
       Body: await readFile(tmpFile),
+      ContentType: 'application/pdf',
+      ContentDisposition: 'inline',
     }).promise();
     return Key;
   }


### PR DESCRIPTION
Suggesting simpler naming inside bucket and setting the content type for direct display from s3 url