### PR TITLE
feat(shipping): variant weight overrides

### DIFF
--- a/packages/vendure-plugin-shipping-by-weight-and-country/src/shipping-by-weight-and-country.plugin.ts
+++ b/packages/vendure-plugin-shipping-by-weight-and-country/src/shipping-by-weight-and-country.plugin.ts
@@ -39,6 +39,23 @@ export interface ShippingByWeightAndCountryOptions {
       nullable: true,
       type: 'int',
     });
+    config.customFields.ProductVariant.push({
+      name: 'weight',
+      label: [
+        {
+          languageCode: LanguageCode.en,
+          value: `Weight in ${ShippingByWeightAndCountryPlugin.options?.weightUnit}`,
+        },
+      ],
+      ui: {
+        component: 'number-form-input',
+        tab: ShippingByWeightAndCountryPlugin.options?.customFieldsTab,
+        options: { min: 0 },
+      },
+      public: true,
+      nullable: true,
+      type: 'int',
+    });
     return config;
   },
 })

--- a/packages/vendure-plugin-shipping-by-weight-and-country/src/weight-and-country-checker.ts
+++ b/packages/vendure-plugin-shipping-by-weight-and-country/src/weight-and-country-checker.ts
@@ -17,7 +17,10 @@ export function calculateOrderWeight(
     const product = products.find(
       (p) => p.id === line.productVariant.productId
     );
-    const weight = (product?.customFields as any).weight || 0;
+    const weight =
+      (line.productVariant.customFields as any).weight ??
+      (product?.customFields as any).weight ??
+      0;
     const lineWeight = weight * line.quantity;
     return acc + lineWeight;
   }, 0);


### PR DESCRIPTION
This change allows users to change weight of a product on a variant basis. If no variant weight is specified, the product weight is used. If this still doesn't exist then 0 is used (like before).

This probably doesn't need its own release, as I am intending to add more physical property features in the near future.