### PR TITLE
Feat/Sendcloud default phone number

### DIFF
--- a/packages/vendure-plugin-sendcloud/README.md
+++ b/packages/vendure-plugin-sendcloud/README.md
@@ -40,6 +40,8 @@ AdminUiPlugin.init({
 8. Make sure you have the permission `SetSendCloudConfig`
 9. Go to `Settings > SendCloud`
 10. You can fill in your SendCloud `secret` and `public key` here and click save.
+11. Additionally, you can set a fallback phone number, for when a customer hasn't filled out one. A phone number is
+    required by Sendcloud in some cases.
 
 Now, when an order is placed, it will be automatically fulfilled and send to SendCloud.
 

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud-config.entity.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud-config.entity.ts
@@ -10,9 +10,12 @@ export class SendcloudConfigEntity extends VendureEntity {
   @Column({ unique: true })
   channelId!: string;
 
-  @Column()
+  @Column({ nullable: true })
   secret?: string;
 
-  @Column()
+  @Column({ nullable: true })
   publicKey?: string;
+
+  @Column({ nullable: true })
+  defaultPhoneNr?: string;
 }

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.adapter.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.adapter.ts
@@ -9,7 +9,8 @@ import { SendcloudPluginOptions } from './types/sendcloud.types';
  */
 export function toParcelInput(
   order: Order,
-  options: SendcloudPluginOptions
+  options: SendcloudPluginOptions,
+  defaultPhoneNr?: string
 ): ParcelInput {
   const items = order.lines
     .filter((line) => line.quantity >= 1)
@@ -22,7 +23,7 @@ export function toParcelInput(
     city: order.shippingAddress.city!,
     postal_code: order.shippingAddress.postalCode!,
     country: order.shippingAddress.countryCode!.toUpperCase(),
-    telephone: order.customer?.phoneNumber,
+    telephone: order.customer?.phoneNumber || defaultPhoneNr,
     request_label: false,
     email: order.customer?.emailAddress,
     order_number: order.code,

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.controller.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.controller.ts
@@ -20,7 +20,7 @@ export class SendcloudController {
   ): Promise<unknown> {
     const rawBody = (req as any).rawBody || JSON.stringify(body); // TestEnvironment doesnt have middleware applied, so no rawBody available
     const ctx = await this.sendcloudService.createContext(channelToken);
-    const client = await this.sendcloudService.getClient(ctx);
+    const { client } = await this.sendcloudService.getClient(ctx);
     if (!client.isValidWebhook(rawBody, signature)) {
       Logger.warn(
         `Ignoring incoming webhook for channel ${channelToken}, because it has an invalid signature`,

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.resolver.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.resolver.ts
@@ -47,7 +47,8 @@ export class SendcloudResolver {
   @Allow(sendcloudPermission.Permission)
   async updateSendCloudConfig(
     @Ctx() ctx: RequestContext,
-    @Args('input') input: { secret: string; publicKey: string }
+    @Args('input')
+    input: { secret: string; publicKey: string; defaultPhoneNr: string }
   ): Promise<SendcloudConfigEntity> {
     return this.service.upsertConfig(ctx, input);
   }

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.service.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.service.ts
@@ -215,6 +215,7 @@ export class SendcloudService implements OnApplicationBootstrap, OnModuleInit {
     config: {
       secret: string;
       publicKey: string;
+      defaultPhoneNr: string;
     }
   ): Promise<SendcloudConfigEntity> {
     const repo = this.connection.getRepository(ctx, SendcloudConfigEntity);
@@ -223,12 +224,14 @@ export class SendcloudService implements OnApplicationBootstrap, OnModuleInit {
       await repo.update(existing.id, {
         secret: config.secret,
         publicKey: config.publicKey,
+        defaultPhoneNr: config.defaultPhoneNr,
       });
     } else {
       await repo.insert({
         channelId: String(ctx.channelId),
         secret: config.secret,
         publicKey: config.publicKey,
+        defaultPhoneNr: config.defaultPhoneNr,
       });
     }
     return repo.findOneOrFail({ channelId: String(ctx.channelId) });

--- a/packages/vendure-plugin-sendcloud/src/sendcloud.plugin.ts
+++ b/packages/vendure-plugin-sendcloud/src/sendcloud.plugin.ts
@@ -22,10 +22,12 @@ import { createRawBodyMiddleWare } from '../../util/src/raw-body';
         id: ID!
         secret: String
         publicKey: String
+        defaultPhoneNr: String
       }
       input SendCloudConfigInput {
         secret: String
         publicKey: String
+        defaultPhoneNr: String
       }
       extend type Mutation {
         sendToSendCloud(orderId: ID!): Boolean!

--- a/packages/vendure-plugin-sendcloud/src/ui/queries.ts
+++ b/packages/vendure-plugin-sendcloud/src/ui/queries.ts
@@ -6,6 +6,7 @@ export const UPDATE_SENDCLOUD_CONFIG = gql`
       id
       secret
       publicKey
+      defaultPhoneNr
     }
   }
 `;
@@ -16,6 +17,7 @@ export const GET_SENDCLOUD_CONFIG = gql`
       id
       secret
       publicKey
+      defaultPhoneNr
     }
   }
 `;

--- a/packages/vendure-plugin-sendcloud/src/ui/sendcloud.component.ts
+++ b/packages/vendure-plugin-sendcloud/src/ui/sendcloud.component.ts
@@ -16,6 +16,17 @@ import { GET_SENDCLOUD_CONFIG, UPDATE_SENDCLOUD_CONFIG } from './queries';
             <vdr-form-field label="SendCloud public key" for="publicKey">
               <input id="publicKey" type="text" formControlName="publicKey" />
             </vdr-form-field>
+            <vdr-form-field
+              label="Fallback phone nr."
+              for="defaultPhoneNr"
+              tooltip="Used when a customer hasn't entered a phone number. Phone number is required in some cases by Sendcloud"
+            >
+              <input
+                id="defaultPhoneNr"
+                type="text"
+                formControlName="defaultPhoneNr"
+              />
+            </vdr-form-field>
             <button
               class="btn btn-primary"
               (click)="save()"
@@ -41,6 +52,7 @@ export class SendcloudComponent implements OnInit {
     this.form = this.formBuilder.group({
       secret: ['your-secret'],
       publicKey: ['your-public-key'],
+      defaultPhoneNr: ['your-phone-number'],
     });
   }
 
@@ -51,6 +63,7 @@ export class SendcloudComponent implements OnInit {
       .subscribe((config) => {
         this.form.controls['secret'].setValue(config.secret);
         this.form.controls['publicKey'].setValue(config.publicKey);
+        this.form.controls['defaultPhoneNr'].setValue(config.defaultPhoneNr);
       });
   }
 
@@ -60,7 +73,11 @@ export class SendcloudComponent implements OnInit {
         const formValue = this.form.value;
         await this.dataService
           .mutate(UPDATE_SENDCLOUD_CONFIG, {
-            input: { secret: formValue.secret, publicKey: formValue.publicKey },
+            input: {
+              secret: formValue.secret,
+              publicKey: formValue.publicKey,
+              defaultPhoneNr: formValue.defaultPhoneNr,
+            },
           })
           .toPromise();
       }

--- a/packages/vendure-plugin-sendcloud/test/dev-server.ts
+++ b/packages/vendure-plugin-sendcloud/test/dev-server.ts
@@ -83,7 +83,8 @@ require('dotenv').config();
   await updateSendCloudConfig(
     adminClient,
     process.env.SECRET!,
-    process.env.PUBLIC!
+    process.env.PUBLIC!,
+    '058123456789'
   );
   await createSettledOrder(shopClient, 1);
   console.log('created test order');

--- a/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
+++ b/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
@@ -117,16 +117,27 @@ describe('SendCloud', () => {
   it('Fails to update SendCloud config without permission', async () => {
     await adminClient.asAnonymousUser();
     await expect(
-      updateSendCloudConfig(adminClient, 'test-secret', 'test-public')
+      updateSendCloudConfig(
+        adminClient,
+        'test-secret',
+        'test-public',
+        '06123456789'
+      )
     ).rejects.toThrow('authorized');
   });
 
   it('Updates SendCloudConfig as superadmin', async () => {
     await adminClient.asSuperAdmin();
-    await updateSendCloudConfig(adminClient, 'test-secret', 'test-public');
+    await updateSendCloudConfig(
+      adminClient,
+      'test-secret',
+      'test-public',
+      '06123456789'
+    );
     const config = await getSendCloudConfig(adminClient);
     expect(config.secret).toBe('test-secret');
     expect(config.publicKey).toBe('test-public');
+    expect(config.defaultPhoneNr).toBe('06123456789');
     expect(config.id).toBeDefined();
   });
 

--- a/packages/vendure-plugin-sendcloud/test/test.helpers.ts
+++ b/packages/vendure-plugin-sendcloud/test/test.helpers.ts
@@ -8,12 +8,13 @@ import { SendcloudConfigEntity } from '../src/api/sendcloud-config.entity';
 export async function updateSendCloudConfig(
   adminClient: SimpleGraphQLClient,
   secret: string,
-  publicKey: string
+  publicKey: string,
+  defaultPhoneNr: string
 ): Promise<SendcloudConfigEntity> {
   const { updateSendCloudConfig } = await adminClient.query(
     UPDATE_SENDCLOUD_CONFIG,
     {
-      input: { secret, publicKey },
+      input: { secret, publicKey, defaultPhoneNr },
     }
   );
   return updateSendCloudConfig;


### PR DESCRIPTION
Added a default phone number, which is sent to Sendcloud when a customer hasn't filled out a customer. This is because Sendcloud expects phone numbers for certain packages, like pallets. 

With this default we don't have to force customers to use a phone number, which might lower conversion in checkout