### PR TITLE
feat(stripe-subscription): Allow $0 orders and use order total for payment

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.controller.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.controller.ts
@@ -160,6 +160,17 @@ export class StripeSubscriptionController {
     const channelToken =
       body.data.object.metadata?.channelToken ||
       body.data.object.lines?.data[0]?.metadata.channelToken;
+    if (
+      body.type !== 'payment_intent.succeeded' &&
+      body.type !== 'invoice.payment_failed' &&
+      body.type !== 'invoice.payment_succeeded'
+    ) {
+      Logger.info(
+        `Received incoming '${body.type}' webhook, not processing this event.`,
+        loggerCtx
+      );
+      return;
+    }
     if (!orderCode) {
       return Logger.error(
         `Incoming webhook is missing metadata.orderCode, cannot process this event`,
@@ -205,12 +216,6 @@ export class StripeSubscriptionController {
           body,
           order
         );
-      } else {
-        Logger.info(
-          `Received incoming '${body.type}' webhook, not processing this event.`,
-          loggerCtx
-        );
-        return;
       }
       Logger.info(`Successfully handled webhook ${body.type}`, loggerCtx);
     } catch (error) {

--- a/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.service.ts
@@ -231,12 +231,19 @@ export class StripeSubscriptionService {
   }
 
   async createPaymentIntent(ctx: RequestContext): Promise<string> {
-    const order = (await this.activeOrderService.getActiveOrder(
+    let order = (await this.activeOrderService.getActiveOrder(
       ctx,
       undefined
     )) as OrderWithSubscriptions;
     if (!order) {
       throw new UserInputError('No active order for session');
+    }
+    if (!order.totalWithTax) {
+      order = (await this.orderService.addSurchargeToOrder(ctx, order.id, {
+        description: 'Verification fee',
+        listPrice: 100,
+        listPriceIncludesTax: true,
+      })) as OrderWithSubscriptions;
     }
     await this.entityHydrator.hydrate(ctx, order, {
       relations: ['customer', 'shippingLines', 'lines.productVariant'],
@@ -270,20 +277,8 @@ export class StripeSubscriptionService {
           err
         )
       );
-    let totalAmountDueNow = 0;
     const hasSubscriptionProducts = order.lines.some(
       (l) => l.productVariant.customFields.subscriptionSchedule
-    );
-    await Promise.all(
-      order.lines.map(async (line) => {
-        totalAmountDueNow += line.proratedLinePriceWithTax;
-        Logger.info(
-          `Added ${printMoney(
-            line.proratedLinePriceWithTax // Prorated line price has subscriptionPrice because of our custom strategy
-          )} to payment intent for ${line.productVariant.name}`,
-          loggerCtx
-        );
-      })
     );
     const intent = await stripeClient.paymentIntents.create({
       customer: stripeCustomer.id,
@@ -291,14 +286,17 @@ export class StripeSubscriptionService {
       setup_future_usage: hasSubscriptionProducts
         ? 'off_session'
         : 'on_session',
-      amount: totalAmountDueNow,
+      amount: order.totalWithTax,
       currency: order.currencyCode,
       metadata: {
         orderCode: order.code,
         channelToken: ctx.channel.token,
-        amount: totalAmountDueNow,
+        amount: order.totalWithTax,
       },
     });
+    Logger.info(
+      `Created payment intent '${intent.id}' for order ${order.code}`
+    );
     return intent.client_secret!;
   }
 

--- a/packages/vendure-plugin-stripe-subscription/src/stripe.client.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/stripe.client.ts
@@ -1,6 +1,5 @@
 import Stripe from 'stripe';
 import { CustomerWithSubscriptionFields } from './subscription-custom-fields';
-import { ID } from '@vendure/core';
 
 interface SubscriptionInput {
   customerId: string;

--- a/packages/vendure-plugin-stripe-subscription/test/dev-server.ts
+++ b/packages/vendure-plugin-stripe-subscription/test/dev-server.ts
@@ -122,7 +122,7 @@ export let clientSecret = 'test';
   await adminClient.query(UPSERT_SCHEDULES, {
     input: {
       name: '3 months, billed monthly, 199 downpayment',
-      downpaymentWithTax: 19900,
+      downpaymentWithTax: 0,
       durationInterval: SubscriptionInterval.Month,
       durationCount: 3,
       startMoment: SubscriptionStartMoment.StartOfBillingInterval,
@@ -195,14 +195,14 @@ export let clientSecret = 'test';
       // startDate: in3Days,
     },
   });
-  await shopClient.query(ADD_ITEM_TO_ORDER, {
-    productVariantId: '2',
-    quantity: 1,
-    customFields: {
-      // downpayment: 40000,
-      // startDate: in3Days,
-    },
-  });
+  // await shopClient.query(ADD_ITEM_TO_ORDER, {
+  //   productVariantId: '2',
+  //   quantity: 1,
+  //   customFields: {
+  //     // downpayment: 40000,
+  //     // startDate: in3Days,
+  //   },
+  // });
   /*     await shopClient.query(ADD_ITEM_TO_ORDER, {
     productVariantId: '1',
     quantity: 1,


### PR DESCRIPTION
We were manually calculating the order total (because of a previous setup), this caused issues with orders with shipping costs and surcharges. Now we use the order total.

For orders that are $0, we add a verification fee of $1, so that we can still use the payment_intent. Otherwise we need to implement setup_intent. This complicates things on the backend and the frontend, because a different type of client_secret is generated.