### PR TITLE
feat(picqer): api url update and channel default

### DIFF
--- a/packages/vendure-plugin-picqer/src/api/picqer.client.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.client.ts
@@ -24,8 +24,9 @@ export class PicqerClient {
     storefrontUrl,
     supportEmail,
   }: PicqerClientInput) {
+    apiEndpoint = apiEndpoint.replace(/\/$/, ''); // Remove trailing slash
     this.instance = axios.create({
-      baseURL: apiEndpoint,
+      baseURL: `${apiEndpoint}/api/v1/`,
       timeout: 5000,
       headers: {
         Authorization: `Basic ${Buffer.from(apiKey + ':').toString('base64')}`,

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -182,10 +182,11 @@ export class PicqerService implements OnApplicationBootstrap {
    * If not found, creates a new product.
    */
   async pushVariantsToPicqer(
-    ctx: RequestContext,
+    userCtx: RequestContext,
     variantIds?: ID[],
     productId?: ID
   ): Promise<void> {
+    const ctx = this.createDefaultLanguageContext(userCtx);
     const client = await this.getClient(ctx);
     if (!client) {
       return;
@@ -302,6 +303,19 @@ export class PicqerService implements OnApplicationBootstrap {
       loggerCtx
     );
     return repository.findOneOrFail({ channelId: String(ctx.channelId) });
+  }
+
+  /**
+   * Create a new RequestContext with the default language of the current channel.
+   */
+  createDefaultLanguageContext(ctx: RequestContext): RequestContext {
+    return new RequestContext({
+      apiType: 'admin',
+      isAuthorized: true,
+      authorizedAsOwnerOnly: false,
+      languageCode: ctx.channel.defaultLanguageCode,
+      channel: ctx.channel,
+    });
   }
 
   /**

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -23,7 +23,7 @@ import { FULL_SYNC, GET_CONFIG, UPSERT_CONFIG } from '../src/ui/queries';
 
 let server: TestServer;
 let adminClient: SimpleGraphQLClient;
-const apiUrl = 'https://test-picqer.io/api/v1/';
+const nockBaseUrl = 'https://test-picqer.io/api/v1/';
 
 jest.setTimeout(60000);
 
@@ -62,7 +62,7 @@ describe('Order export plugin', function () {
         input: {
           enabled: true,
           apiKey: 'test-api-key',
-          apiEndpoint: 'https://test-picqer.io/api/v1/',
+          apiEndpoint: 'https://test-picqer.io/',
           storefrontUrl: 'mystore.io',
           supportEmail: 'support@mystore.io',
         },
@@ -70,7 +70,7 @@ describe('Order export plugin', function () {
     );
     await expect(config.enabled).toBe(true);
     await expect(config.apiKey).toBe('test-api-key');
-    await expect(config.apiEndpoint).toBe('https://test-picqer.io/api/v1/');
+    await expect(config.apiEndpoint).toBe('https://test-picqer.io/');
     await expect(config.storefrontUrl).toBe('mystore.io');
     await expect(config.supportEmail).toBe('support@mystore.io');
   });
@@ -80,7 +80,7 @@ describe('Order export plugin', function () {
     const { picqerConfig: config } = await adminClient.query(GET_CONFIG);
     await expect(config.enabled).toBe(true);
     await expect(config.apiKey).toBe('test-api-key');
-    await expect(config.apiEndpoint).toBe('https://test-picqer.io/api/v1/');
+    await expect(config.apiEndpoint).toBe('https://test-picqer.io/');
     await expect(config.storefrontUrl).toBe('mystore.io');
     await expect(config.supportEmail).toBe('support@mystore.io');
   });
@@ -89,16 +89,16 @@ describe('Order export plugin', function () {
 
   it('Should push all products to Picqer on full sync', async () => {
     // Mock vatgroups GET
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .get('/vatgroups')
       .reply(200, [{ idvatgroup: 12, percentage: 20 }] as VatGroup[]);
     // Mock products GET multiple times
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .get(/.products*/)
       .reply(200, [])
       .persist();
     // Mock product POST multiple times
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .post(/.products*/, (reqBody) => {
         pushProductPayloads.push(reqBody);
         return true;
@@ -122,16 +122,16 @@ describe('Order export plugin', function () {
   it('Should push product to Picqer when updated in Vendure', async () => {
     let updatedProduct: any;
     // Mock vatgroups GET
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .get('/vatgroups')
       .reply(200, [{ idvatgroup: 12, percentage: 20 }] as VatGroup[]);
     // Mock products GET multiple times
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .get(/.products*/)
       .reply(200, [])
       .persist();
     // Mock product POST once
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .post(/.products*/, (reqBody) => {
         updatedProduct = reqBody;
         return true;
@@ -148,16 +148,16 @@ describe('Order export plugin', function () {
   it('Disables a product in Picqer when disabled in Vendure', async () => {
     let pushProductPayloads: any[] = [];
     // Mock vatgroups GET
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .get('/vatgroups')
       .reply(200, [{ idvatgroup: 12, percentage: 20 }] as VatGroup[]);
     // Mock products GET multiple times
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .get(/.products*/)
       .reply(200, [])
       .persist();
     // Mock product POST multiple times
-    nock(apiUrl)
+    nock(nockBaseUrl)
       .post(/.products*/, (reqBody) => {
         pushProductPayloads.push(reqBody);
         return true;


### PR DESCRIPTION
* Append configured api endpoint with `/api/v1`, so the user doesn't have to specify that
* Use channel.defaultLanguage for sync instead of user context