### PR TITLE
Continued setup for adding discounts to subscription based orders

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/README.md
+++ b/packages/vendure-plugin-stripe-subscription/README.md
@@ -279,6 +279,15 @@ You can also get the subscription and Schedule pricing details per order line wi
         }
 ```
 
+### Discount future payments
+
+You can discount future subscription payments when the custom promotion action `discount_future_subscription_payments` has been applied to an order.
+
+Example:
+
+- We have a subscription that will cost $30 a month, but has the promotion `Discount future subscription payments by 10%` applied
+- The actual monthly price of the subscription will be $27, forever.
+
 ## Caveats
 
 1. This plugin overrides any set OrderItemCalculationStrategies. The strategy in this plugin is used for calculating the

--- a/packages/vendure-plugin-stripe-subscription/src/api/discount-future-payments.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/discount-future-payments.ts
@@ -1,0 +1,32 @@
+import { LanguageCode, PromotionOrderAction } from '@vendure/core';
+
+export const discountFutureSubscriptionPayments = new PromotionOrderAction({
+  // See the custom condition example above for explanations
+  // of code, description & args fields.
+  code: 'discount_future_subscription_payments',
+  description: [
+    {
+      languageCode: LanguageCode.en,
+      value: 'Discount future subscription payments by { discount } %',
+    },
+  ],
+  args: {
+    discount: {
+      type: 'int',
+      ui: {
+        component: 'number-form-input',
+        suffix: '%',
+      },
+    },
+  },
+
+  /**
+   * This is the function that defines the actual amount to be discounted.
+   * It should return a negative number representing the discount in
+   * pennies/cents etc. Rounding to an integer is handled automatically.
+   */
+  execute(ctx, order, args) {
+    // This discount affects future payments, not the current order total. See @link PricingHelper for more information
+    return 0;
+  },
+});

--- a/packages/vendure-plugin-stripe-subscription/src/api/graphql-schemas.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/graphql-schemas.ts
@@ -74,6 +74,10 @@ export const shopSchemaExtensions = gql`
     productVariantId: ID!
     startDate: DateTime
     downpaymentWithTax: Int
+    """
+    If orderId is supplied, any promotions applied to the order will be taken into account
+    """
+    orderId: ID
   }
   extend type Query {
     """

--- a/packages/vendure-plugin-stripe-subscription/src/api/pricing.helper.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/pricing.helper.ts
@@ -107,7 +107,6 @@ export function calculateSubscriptionPricing(
     );
   }
   let proratedDays = 0;
-  let discounts = [];
   let totalProratedAmount = 0;
   if (schedule.useProration) {
     proratedDays = getDaysUntilNextStartDate(

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.controller.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.controller.ts
@@ -100,6 +100,7 @@ export class ShopOrderLinePricingResolver {
         downpaymentWithTax: orderLine.customFields.downpayment,
         startDate: orderLine.customFields.startDate,
         productVariantId: orderLine.productVariant.id as string,
+        orderId: orderLine.order.id as string,
       });
     }
     return;

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -25,6 +25,7 @@ import {
   StockMovementEvent,
   TransactionalConnection,
   UserInputError,
+  assertFound,
 } from '@vendure/core';
 import { loggerCtx } from '../constants';
 import { IncomingStripeWebhook } from './stripe.types';
@@ -319,6 +320,17 @@ export class StripeSubscriptionService {
       throw new UserInputError(
         `No variant found with id ${input!.productVariantId}`
       );
+    }
+    if (input.orderId) {
+      const order = await this.orderService.findOne(ctx, input.orderId, [
+        'promotions',
+      ]);
+      if (!order) {
+        throw new UserInputError(`No order found with id ${input.orderId}`);
+      }
+      // TODO Check if our custom promotion "discount_future_subscription_payments" is applied
+      // order.promotions[0].actions
+      // TODO Get the discount percentage from the configured promotion and pass that to the calculateSubscriptionPricing function
     }
     return calculateSubscriptionPricing(variant, input);
   }

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe.client.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe.client.ts
@@ -6,6 +6,7 @@ interface SubscriptionInput {
   productId: string;
   currencyCode: string;
   amount: number;
+  coupon: string;
   interval: Stripe.SubscriptionCreateParams.Item.PriceData.Recurring.Interval;
   intervalCount: number;
   paymentMethodId: string;
@@ -69,6 +70,7 @@ export class StripeClient extends Stripe {
     productId,
     currencyCode,
     amount,
+    coupon,
     interval,
     intervalCount,
     paymentMethodId,
@@ -98,6 +100,7 @@ export class StripeClient extends Stripe {
           },
         },
       ],
+      coupon: coupon,
       off_session: true,
       default_payment_method: paymentMethodId,
       payment_behavior: 'allow_incomplete',

--- a/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.plugin.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.plugin.ts
@@ -24,6 +24,7 @@ import {
 import { StripeSubscriptionService } from './api/stripe-subscription.service';
 import { stripeSubscriptionHandler } from './api/stripe-subscription.handler';
 import { hasStripeSubscriptionProductsPaymentChecker } from './api/has-stripe-subscription-products-payment-checker';
+import { discountFutureSubscriptionPayments } from './api/discount-future-payments';
 
 export interface StripeSubscriptionPluginOptions {
   /**
@@ -66,6 +67,9 @@ export interface StripeSubscriptionPluginOptions {
     config.customFields.ProductVariant.push(...productVariantCustomFields);
     config.customFields.Customer.push(...customerCustomFields);
     config.customFields.OrderLine.push(...orderLineCustomFields);
+    config.promotionOptions.promotionActions.push(
+      discountFutureSubscriptionPayments
+    );
     return config;
   },
 })


### PR DESCRIPTION
# Description
This should provide some of the logic to at least add discount information to the pricing query and once we create coupons in stripe when they're created in Vendure, we should be able to pass that coupon in on the order and it will then include those discounts on the subscription payments.

# Breaking changes
NO

# Checklist

Please make sure you've done the following checks:

- [ ] I have set a clear title
- [ ] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [ ] I have added or updated test cases for important functionality
- [ ] I have reviewed my own PR
- [ ] I have fixed all typo's and have removed unused or commented code
