### PR TITLE
Google Cloud plugin Retry on ECONNRESET

### DIFF
--- a/packages/vendure-plugin-google-cloud-tasks/README.md
+++ b/packages/vendure-plugin-google-cloud-tasks/README.md
@@ -29,7 +29,8 @@ plugins: [
      */
     queueSuffix: 'plugin-test',
     // Default amount of retries when no job.retries is given
-    defaultRetries: 15,
+    defaultJobRetries: 15,
+    createTaskRetries: 3,
   }),
 ];
 ```

--- a/packages/vendure-plugin-google-cloud-tasks/README.md
+++ b/packages/vendure-plugin-google-cloud-tasks/README.md
@@ -30,6 +30,7 @@ plugins: [
     queueSuffix: 'plugin-test',
     // Default amount of retries when no job.retries is given
     defaultJobRetries: 15,
+    // The amount of retries when a job fails to be pushed to the queue
     createTaskRetries: 3,
   }),
 ];

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -1,4 +1,5 @@
-import { CloudTasksClient } from '@google-cloud/tasks';
+import { CloudTasksClient, Tasks } from '@google-cloud/tasks';
+import ITask from '@google-cloud/tasks';
 import { Job, JobData, JobQueueStrategy, Logger } from '@vendure/core';
 import { CloudTasksPlugin } from './cloud-tasks.plugin';
 import { CloudTaskMessage, CloudTaskOptions } from './types';
@@ -46,9 +47,13 @@ export class CloudTasksJobQueueStrategy implements JobQueueStrategy {
         },
       };
       const request = { parent, task };
-      await this.client.createTask(request, {
-        maxRetries: cloudTaskMessage.maxRetries,
-      });
+      let reply = null;
+      while (!reply) {
+        reply = await this.client.createTask(request, {
+          maxRetries: cloudTaskMessage.maxRetries,
+        });
+        console.log(reply);
+      }
       Logger.debug(
         `Added job with retries=${cloudTaskMessage.maxRetries} to queue ${queueName}: ${cloudTaskMessage.id} for ${task.httpRequest.url}`,
         CloudTasksPlugin.loggerCtx

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -24,57 +24,52 @@ export class CloudTasksJobQueueStrategy implements JobQueueStrategy {
     if (!LIVE_QUEUES.has(queueName)) {
       await this.createQueue(queueName);
     }
-    try {
-      const cloudTaskMessage: CloudTaskMessage = {
-        id: `${queueName}-${Date.now()}`,
-        queueName: queueName,
-        data: job.data,
-        createdAt: new Date(),
-        maxRetries: job.retries || this.options.defaultRetries || 3,
-      };
-      const parent = this.getQueuePath(queueName);
-      const task = {
-        httpRequest: {
-          httpMethod: 'POST' as const,
-          headers: {
-            'Content-type': 'application/json',
-            Authorization: `Bearer ${this.options.authSecret}`,
-          },
-          url: `${this.options.taskHandlerHost}/cloud-tasks/handler`,
-          body: Buffer.from(JSON.stringify(cloudTaskMessage)).toString(
-            'base64'
-          ),
+    const cloudTaskMessage: CloudTaskMessage = {
+      id: `${queueName}-${Date.now()}`,
+      queueName: queueName,
+      data: job.data,
+      createdAt: new Date(),
+      maxRetries: job.retries || this.options.defaultRetries || 3,
+    };
+    const parent = this.getQueuePath(queueName);
+    const task = {
+      httpRequest: {
+        httpMethod: 'POST' as const,
+        headers: {
+          'Content-type': 'application/json',
+          Authorization: `Bearer ${this.options.authSecret}`,
         },
-      };
-      const request = { parent, task };
-      let reply = null;
-      while (!reply) {
-        reply = await this.client.createTask(request, {
+        url: `${this.options.taskHandlerHost}/cloud-tasks/handler`,
+        body: Buffer.from(JSON.stringify(cloudTaskMessage)).toString('base64'),
+      },
+    };
+    const request = { parent, task };
+    while (true) {
+      try {
+        await this.client.createTask(request, {
           maxRetries: cloudTaskMessage.maxRetries,
         });
-        console.log(reply);
+        Logger.debug(
+          `Added job with retries=${cloudTaskMessage.maxRetries} to queue ${queueName}: ${cloudTaskMessage.id} for ${task.httpRequest.url}`,
+          CloudTasksPlugin.loggerCtx
+        );
+        return new Job({
+          id: cloudTaskMessage.id,
+          queueName: job.queueName,
+          data: job.data,
+          attempts: job.attempts,
+          state: JobState.RUNNING,
+          startedAt: job.startedAt,
+          createdAt: job.createdAt,
+          retries: job.retries,
+        });
+      } catch (e) {
+        Logger.error(
+          `Failed to add task to queue ${queueName}: ${e?.message}`,
+          CloudTasksPlugin.loggerCtx,
+          e
+        );
       }
-      Logger.debug(
-        `Added job with retries=${cloudTaskMessage.maxRetries} to queue ${queueName}: ${cloudTaskMessage.id} for ${task.httpRequest.url}`,
-        CloudTasksPlugin.loggerCtx
-      );
-      return new Job({
-        id: cloudTaskMessage.id,
-        queueName: job.queueName,
-        data: job.data,
-        attempts: job.attempts,
-        state: JobState.RUNNING,
-        startedAt: job.startedAt,
-        createdAt: job.createdAt,
-        retries: job.retries,
-      });
-    } catch (e) {
-      Logger.error(
-        `Failed to add task to queue ${queueName}: ${e?.message}`,
-        CloudTasksPlugin.loggerCtx,
-        e
-      );
-      throw e;
     }
   }
 

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -16,7 +16,7 @@ export interface CloudTaskOptions {
    */
   defaultJobRetries?: number;
   /**
-   *
+   *Nr of attempts the plugin should try to push a job to the queue, in case it fails. Default is 5
    */
   createTaskRetries?: number;
 }

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -14,7 +14,11 @@ export interface CloudTaskOptions {
   /**
    * Default nr of retries a job should attempt if no job.retries is given
    */
-  defaultRetries?: number;
+  defaultJobRetries?: number;
+  /**
+   *
+   */
+  createTaskRetries?: number;
 }
 
 export interface CloudTaskMessage {

--- a/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
@@ -38,7 +38,7 @@ describe('CloudTasks job queue e2e', () => {
       location: 'europe-west1',
       authSecret: 'some-secret',
       queueSuffix: 'plugin-test',
-      defaultRetries: 50,
+      defaultJobRetries: 50,
     }),
     DefaultSearchPlugin
   );


### PR DESCRIPTION
# Description

When a task is pushed into a Google cloud instance, sometime an ECONNRESET is returned from server. This change does a   configurable number of retries if that happens. Developers could pass an optional `createTaskRetries` field to `CloudTaskOptions`, otherwise the default is five times.

 Breaking changes

Does this PR include any breaking changes we should be aware of? No

# Screenshots

Add screenshots if needed. (Only if it makes this PR clearer)

# Checklist

Please make sure you've done the following checks:

- [X] I have set a clear title
- [X] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [X] I have added or updated test cases for important functionality
- [X] I have updated the README if needed
- [X] I have reviewed my own PR
- [X] I have fixed all typo's and have removed unused or commented code
