### PR TITLE
feat(stripe-subscription): fixed negative discount calculation

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/src/api/pricing.helper.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/pricing.helper.ts
@@ -156,7 +156,7 @@ export function calculateSubscriptionPricing(
 /**
  * Calculate the discounted recurring price based on given promotions
  */
-export async function getDiscountedRecurringPrice(
+export async function applySubscriptionPromotions(
   ctx: RequestContext,
   recurringPrice: number,
   orderLine: OrderLineWithSubscriptionFields,
@@ -174,7 +174,7 @@ export async function getDiscountedRecurringPrice(
           orderLine,
           action.args
         );
-        const newDiscountedPrice = discountedRecurringPrice - discount;
+        const newDiscountedPrice = discountedRecurringPrice + discount;
         Logger.info(
           `Discounted recurring price from ${discountedRecurringPrice} to ${newDiscountedPrice} for promotion ${promotion.name}`,
           loggerCtx

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -44,7 +44,7 @@ import { Request } from 'express';
 import { filter } from 'rxjs/operators';
 import {
   calculateSubscriptionPricing,
-  getDiscountedRecurringPrice,
+  applySubscriptionPromotions,
   getNextCyclesStartDate,
   printMoney,
 } from './pricing.helper';
@@ -376,7 +376,7 @@ export class StripeSubscriptionService {
       }
     );
     // Execute promotions on recurringPrice
-    const discountedRecurringPrice = await getDiscountedRecurringPrice(
+    const discountedRecurringPrice = await applySubscriptionPromotions(
       ctx,
       subscriptionPricing.recurringPrice,
       orderLine,

--- a/packages/vendure-plugin-stripe-subscription/src/api/subscription.promotion.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/subscription.promotion.ts
@@ -80,7 +80,7 @@ export const allByPercentage = new SubscriptionPromotionAction({
   },
   async executeOnSubscription(ctx, currentSubscriptionPrice, orderLine, args) {
     const discount = currentSubscriptionPrice * (args.discount / 100);
-    return discount;
+    return -discount;
   },
 });
 
@@ -116,7 +116,7 @@ export const withFacetsByPercentage = new SubscriptionPromotionAction({
   async executeOnSubscription(ctx, currentSubscriptionPrice, orderLine, args) {
     if (await facetValueChecker.hasFacetValues(orderLine, args.facets, ctx)) {
       const discount = currentSubscriptionPrice * (args.discount / 100);
-      return discount;
+      return -discount;
     }
     return 0;
   },
@@ -192,8 +192,8 @@ export const selectedProductsByPercentage = new SubscriptionPromotionAction({
   },
   async executeOnSubscription(ctx, currentSubscriptionPrice, orderLine, args) {
     if (lineContainsIds(args.productVariantIds, orderLine)) {
-      const discount = -currentSubscriptionPrice * (args.discount / 100);
-      return discount;
+      const discount = currentSubscriptionPrice * (args.discount / 100);
+      return -discount;
     }
     return 0;
   },


### PR DESCRIPTION
# Description

Some discounts returned `-100`, while others returned `100`. All discounts should return the discount as a negative number (same way Vendure does it).

Closes #152 

# Checklist

Please make sure you've done the following checks:

- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed
- [x] I have reviewed my own PR
- [x] I have fixed all typo's and have removed unused or commented code
