### PR TITLE
Fix: Stripe Subscription validations and pre-commit lint:fix instead of check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint:check
+yarn lint:fix
 git add .

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -241,7 +241,7 @@ export class StripeSubscriptionService {
     if (!order) {
       throw new UserInputError('No active order for session');
     }
-    if (!order.total) {
+    if (!order.totalWithTax) {
       // Add a verification fee to the order to support orders that are actually $0
       order = (await this.orderService.addSurchargeToOrder(ctx, order.id, {
         description: 'Verification fee',
@@ -321,8 +321,10 @@ export class StripeSubscriptionService {
         `No variant found with id ${input!.productVariantId}`
       );
     }
-    if (!variant.price) {
-      throw new UserInputError(`Variant ${variant.id} has no price`);
+    if (!variant.listPrice) {
+      throw new UserInputError(
+        `Variant ${variant.id} doesn't have a "listPrice". Variant.listPrice is needed to calculate subscription pricing`
+      );
     }
     if (!variant.customFields.subscriptionSchedule) {
       throw new UserInputError(


### PR DESCRIPTION
# Description

* Fixed pre-subscription creation validations in Stripe Subscription plugin
* Use `lint:fix` instead of `lint:check` on pre-commit hook

# Checklist

Please make sure you've done the following checks:

- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed
- [x] I have reviewed my own PR
- [x] I have fixed all typo's and have removed unused or commented code
