### PR TITLE
fix: webhook plugin - circular dependency

### DIFF
--- a/packages/vendure-plugin-webhook/src/api/webhook.resolver.ts
+++ b/packages/vendure-plugin-webhook/src/api/webhook.resolver.ts
@@ -1,7 +1,12 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { Allow, Ctx, RequestContext } from '@vendure/core';
 import { WebhookService } from './webhook.service';
-import { webhookPermission } from '../index';
+import { PermissionDefinition } from '@vendure/core';
+
+export const webhookPermission = new PermissionDefinition({
+  name: 'SetWebhook',
+  description: 'Allows setting a webhook URL',
+});
 
 /**
  * Graphql resolvers for retrieving and updating webhook for channel

--- a/packages/vendure-plugin-webhook/src/api/webhook.service.ts
+++ b/packages/vendure-plugin-webhook/src/api/webhook.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, Inject, OnApplicationBootstrap } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import {
   EventBus,
@@ -8,7 +8,8 @@ import {
   VendureEvent,
 } from '@vendure/core';
 import { WebhookPerChannelEntity } from './webhook-per-channel.entity';
-import { WebhookPlugin } from '../webhook.plugin';
+import { PLUGIN_INIT_OPTIONS, loggerCtx } from '../constants';
+import { WebhookPluginOptions } from './webhook-plugin-options';
 import fetch from 'node-fetch';
 import { loggerCtx } from '../constants';
 
@@ -22,7 +23,8 @@ export class WebhookService implements OnApplicationBootstrap {
   constructor(
     private eventBus: EventBus,
     private connection: TransactionalConnection,
-    private moduleRef: ModuleRef
+    private moduleRef: ModuleRef,
+    @Inject(PLUGIN_INIT_OPTIONS) private options: WebhookPluginOptions<any>,
   ) {}
 
   async getWebhook(

--- a/packages/vendure-plugin-webhook/src/api/webhook.service.ts
+++ b/packages/vendure-plugin-webhook/src/api/webhook.service.ts
@@ -62,16 +62,16 @@ export class WebhookService implements OnApplicationBootstrap {
    * Subscribe to events specified in config
    */
   async onApplicationBootstrap(): Promise<void> {
-    if (!WebhookPlugin.options || !WebhookPlugin.options.events) {
+    if (!this.options || !this.options.events) {
       throw Error(
         `Please specify VendureEvents with Webhook.init() in your Vendure config.`
       );
     }
-    if (WebhookPlugin.options.disabled) {
+    if (this.options.disabled) {
       Logger.info(`Webhook plugin disabled`, loggerCtx);
       return;
     }
-    WebhookPlugin.options.events!.forEach((configuredEvent) => {
+    this.options.events!.forEach((configuredEvent) => {
       this.eventBus.ofType(configuredEvent).subscribe((event) => {
         const channelId = (event as any)?.ctx?.channelId;
         if (!channelId) {
@@ -104,8 +104,8 @@ export class WebhookService implements OnApplicationBootstrap {
       return;
     }
     WebhookService.queue.add(webhookPerChannel.url);
-    if (WebhookPlugin.options.delay) {
-      setTimeout(() => this.doWebhook(event), WebhookPlugin.options.delay);
+    if (this.options.delay) {
+      setTimeout(() => this.doWebhook(event), this.options.delay);
     } else {
       await this.doWebhook(event);
     }
@@ -122,12 +122,12 @@ export class WebhookService implements OnApplicationBootstrap {
     await Promise.all(
       channels.map(async (channel) => {
         try {
-          const request = await WebhookPlugin.options.requestFn?.(
+          const request = await this.options.requestFn?.(
             event,
             new Injector(this.moduleRef)
           );
           await fetch(channel!, {
-            method: WebhookPlugin.options.httpMethod,
+            method: this.options.httpMethod,
             headers: request?.headers,
             body: request?.body,
           });

--- a/packages/vendure-plugin-webhook/src/constants.ts
+++ b/packages/vendure-plugin-webhook/src/constants.ts
@@ -1,1 +1,2 @@
 export const loggerCtx = 'WebhookPlugin';
+export const PLUGIN_INIT_OPTIONS = Symbol('PLUGIN_INIT_OPTIONS');

--- a/packages/vendure-plugin-webhook/src/index.ts
+++ b/packages/vendure-plugin-webhook/src/index.ts
@@ -1,9 +1,3 @@
-import { PermissionDefinition } from '@vendure/core';
-// Permission needs to be defined first
-export const webhookPermission = new PermissionDefinition({
-  name: 'SetWebhook',
-  description: 'Allows setting a webhook URL',
-});
-
+export * from './api/webhook.resolver'
 export * from './webhook.plugin';
 export * from './api/webhook-plugin-options';

--- a/packages/vendure-plugin-webhook/src/webhook.plugin.ts
+++ b/packages/vendure-plugin-webhook/src/webhook.plugin.ts
@@ -32,7 +32,7 @@ import { PLUGIN_INIT_OPTIONS } from './constants';
     return config;
   },
 })
-export class WebhookPlugin {``
+export class WebhookPlugin {
   static options: WebhookPluginOptions<any>;
 
   static init<T extends VendureEvent>(

--- a/packages/vendure-plugin-webhook/src/webhook.plugin.ts
+++ b/packages/vendure-plugin-webhook/src/webhook.plugin.ts
@@ -10,6 +10,7 @@ import {
 import { WebhookResolver } from './api/webhook.resolver';
 import { WebhookService } from './api/webhook.service';
 import { webhookPermission } from './index';
+import { PLUGIN_INIT_OPTIONS } from './constants';
 
 /**
  * Calls a configurable webhook when configured events arise.
@@ -18,7 +19,10 @@ import { webhookPermission } from './index';
 @VendurePlugin({
   imports: [PluginCommonModule],
   entities: [WebhookPerChannelEntity],
-  providers: [WebhookService],
+  providers: [
+    WebhookService,
+    { provide: PLUGIN_INIT_OPTIONS, useFactory: () => WebhookPlugin.options }
+  ],
   adminApiExtensions: {
     schema,
     resolvers: [WebhookResolver],
@@ -28,7 +32,7 @@ import { webhookPermission } from './index';
     return config;
   },
 })
-export class WebhookPlugin {
+export class WebhookPlugin {``
   static options: WebhookPluginOptions<any>;
 
   static init<T extends VendureEvent>(


### PR DESCRIPTION
# Description
In certain cases when working with custom populate scripts for multi-channel seeds I ran in this obscure error whenever the I tried to get the webhookService in that script. Turns out the WebhookService was undefined because of a circular dependency.
Also a circular dependency regarding the Permission acted up.

Hope you can approve this change! :) It shouldn't change anything functionally!

Options for the plugin are now injected via NestJs service container instead of importing the plugin. And the Permission is now defined in he resolver.
# Breaking changes

Does this PR include any breaking changes we should be aware of?
No

