### PR TITLE
feat(picqer): added order custom fields

### DIFF
--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -27,13 +27,20 @@ import {PicqerPlugin} from 'vendure-plugin-picqer'
 ...
 plugins: [
   PicqerPlugin.init({
-    vendureHost: 'https://example-vendure.io'
-    /**
-     * Optional strategy to push additional fields to Picqer.
-     * This example pushes variant.sku as product.barcode to Picqer
-     */
-    pushFieldsToPicqer: (variant) => ({ barcode: variant.sku })
-  }),
+          enabled: true,
+          vendureHost: 'https://example-vendure.io',
+          pushProductVariantFields: (variant) => ({ barcode: variant.sku }),
+          pullPicqerProductFields: (picqerProd) => ({
+            outOfStockThreshold: picqerProd.stockThreshold,
+          }),
+          pushPicqerOrderFields: (order) => ({
+            customer_remarks: order.customFields.customerNote,
+            pickup_point_data: {
+              carrier: 'dhl',
+              id: '901892834',
+            },
+          }),
+        }),
   AdminUiPlugin.init({
     port: 3002,
     route: 'admin',

--- a/packages/vendure-plugin-picqer/src/api/picqer.client.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.client.ts
@@ -120,13 +120,6 @@ export class PicqerClient {
     return this.rawRequest('put', `/products/${productId}`, input);
   }
 
-  async addOrderNote(
-    orderId: string | number,
-    note: string
-  ): Promise<ProductData> {
-    return this.rawRequest('post', `/orders/${orderId}/notes`, { note });
-  }
-
   /**
    * Add an image to a product
    */

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -702,7 +702,6 @@ export class PicqerService implements OnApplicationBootstrap {
         loggerCtx
       );
     }
-    console.log('===============', orderInput);
     const createdOrder = await client.createOrder(orderInput);
     await client.processOrder(createdOrder.idorder);
     Logger.info(

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -686,22 +686,29 @@ export class PicqerService implements OnApplicationBootstrap {
         amount: line.quantity,
       });
     }
-    const orderInput = this.mapToOrderInput(
+    let orderInput = this.mapToOrderInput(
       order,
       productInputs,
       picqerCustomer?.idcustomer
     );
+    if (this.options.pushPicqerOrderFields) {
+      const additionalFields = this.options.pushPicqerOrderFields(order);
+      orderInput = {
+        ...orderInput,
+        ...additionalFields,
+      };
+      Logger.info(
+        `Added custom order fields to order '${order.code}'`,
+        loggerCtx
+      );
+    }
+    console.log('===============', orderInput);
     const createdOrder = await client.createOrder(orderInput);
     await client.processOrder(createdOrder.idorder);
     Logger.info(
       `Created order "${order.code}" in status "processing" in Picqer with id ${createdOrder.idorder}`,
       loggerCtx
     );
-    if (this.options.addPicqerOrderNote) {
-      const note = this.options.addPicqerOrderNote(order);
-      await client.addOrderNote(createdOrder.idorder, note);
-      Logger.info(`Added custom note to order ${order.code}`, loggerCtx);
-    }
   }
 
   /**

--- a/packages/vendure-plugin-picqer/src/picqer.plugin.ts
+++ b/packages/vendure-plugin-picqer/src/picqer.plugin.ts
@@ -43,12 +43,12 @@ export interface PicqerOptions {
    */
   pushProductVariantFields?: (variant: ProductVariant) => Partial<ProductInput>;
   /**
-   * Add a note to order in Picqer
+   * Map any Vendure fields to Order fields in Picqer.
+   * See https://picqer.com/en/api/orders#attributes for available Picqer fields
    * @example
-   * // Push `order.customFields.customerNote` to Picqer
-   * addPicqerOrderNote: (order) => `This is note from Vendure ${order.customFields.customerNote}`)
+   * pushPicqerOrderFields: (order) => {customer_remarks: 'Please don't package my order in plastic'})
    */
-  addPicqerOrderNote?: (order: Order) => string;
+  pushPicqerOrderFields?: (order: Order) => any;
 }
 
 @VendurePlugin({

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -53,7 +53,10 @@ describe('Picqer plugin', function () {
           pullPicqerProductFields: (picqerProd) => ({
             outOfStockThreshold: 123,
           }),
-          addPicqerOrderNote: (order) => 'test note',
+          pushPicqerOrderFields: (order) => ({
+            customer_remarks: 'test note',
+            pick,
+          }),
         }),
       ],
       paymentOptions: {
@@ -165,7 +168,6 @@ describe('Picqer plugin', function () {
 
   it('Should push order to Picqer on order placement', async () => {
     let isOrderInProcessing = false;
-    let createdOrderNote = undefined;
     let picqerOrderRequest: any;
     nock(nockBaseUrl)
       .get('/vatgroups') // Mock vatgroups, because it will try to update products
@@ -193,12 +195,6 @@ describe('Picqer plugin', function () {
         return true;
       })
       .reply(200, { idordder: 'mockOrderId' });
-    nock(nockBaseUrl)
-      .post('/orders/mockOrderId/notes', (reqBody) => {
-        createdOrderNote = reqBody.note;
-        return true;
-      })
-      .reply(200, { idordder: 'mockOrderId' });
     // Shipping method 3 should be our created Picqer handler method
     createdOrder = await createSettledOrder(shopClient, 3, true, [
       { id: 'T_1', quantity: 3 },
@@ -218,7 +214,7 @@ describe('Picqer plugin', function () {
     expect(picqerOrderRequest.products.length).toBe(1);
     expect(picqerOrderRequest.products[0].amount).toBe(3);
     expect(isOrderInProcessing).toBe(true);
-    expect(createdOrderNote).toBe('test note');
+    expect(picqerOrderRequest.customer_remarks).toBe('test note');
   });
 
   // FIXME enable after fix: https://github.com/vendure-ecommerce/vendure/issues/2191

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -55,7 +55,10 @@ describe('Picqer plugin', function () {
           }),
           pushPicqerOrderFields: (order) => ({
             customer_remarks: 'test note',
-            pick,
+            pickup_point_data: {
+              carrier: 'dhl',
+              id: '901892834',
+            },
           }),
         }),
       ],
@@ -215,6 +218,10 @@ describe('Picqer plugin', function () {
     expect(picqerOrderRequest.products[0].amount).toBe(3);
     expect(isOrderInProcessing).toBe(true);
     expect(picqerOrderRequest.customer_remarks).toBe('test note');
+    expect(picqerOrderRequest.pickup_point_data).toEqual({
+      carrier: 'dhl',
+      id: '901892834',
+    });
   });
 
   // FIXME enable after fix: https://github.com/vendure-ecommerce/vendure/issues/2191


### PR DESCRIPTION
# Description

* Added a strategy function to allow pushing custom order fields to Picqer
* Refactored adding order notes to adding a single `customer_remark` field. (Order not is meant for employees)

# Breaking changes

`addPicqerOrderNote` was removed, because order notes can now be added as customer_remark

```diff
PicqerPlugin.init({
          enabled: true,
          vendureHost: 'https://example-vendure.io',
          // Dummy data for testing purposes
          pushProductVariantFields: (variant) => ({ barcode: variant.sku }),
          pullPicqerProductFields: (picqerProd) => ({
            outOfStockThreshold: 123,
          }),
-        addPicqerOrderNote: (order) => 'test note',
+       pushPicqerOrderFields: (order) => ({
+         customer_remarks: 'test note',
+       }),
        }),
```

# Checklist

Please make sure you've done the following checks:

- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed
- [ ] I have reviewed my own PR
- [ ] I have fixed all typo's and have removed unused or commented code
