### PR TITLE
fix(picqer): added webhook creation on startup and country and city push

### DIFF
--- a/packages/vendure-plugin-picqer/test/dev-server.ts
+++ b/packages/vendure-plugin-picqer/test/dev-server.ts
@@ -41,7 +41,13 @@ import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
         // These are just test values to test the strtegies, they don't mean anything in this context
         pushProductVariantFields: (variant) => ({ barcode: variant.sku }),
         pullPicqerProductFields: (picqerProd) => ({ outOfStockThreshold: 123 }),
-        addPicqerOrderNote: (order) => 'test note',
+        pushPicqerOrderFields: (order) => ({
+          customer_remarks: 'test note',
+          pickup_point_data: {
+            carrier: 'dhl',
+            id: '901892834',
+          },
+        }),
       }),
       AssetServerPlugin.init({
         assetUploadDir: path.join(__dirname, '../__data__/assets'),

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -109,10 +109,10 @@ describe('Picqer plugin', function () {
     expect(everyVariantHasStockTracking).toBe(true);
   });
 
+  // Caught webhook creation requests
   const createdHooks: any[] = [];
 
   it('Should update Picqer config via admin api', async () => {
-    // Mock hooks GET, because webhooks are updated on config save
     nock(nockBaseUrl).get('/hooks').reply(200, []).persist();
     nock(nockBaseUrl)
       .post('/hooks', (reqBody) => {
@@ -213,7 +213,8 @@ describe('Picqer plugin', function () {
     expect(picqerOrderRequest.deliverycontactname).toBeDefined();
     expect(picqerOrderRequest.deliveryaddress).toBeDefined();
     expect(picqerOrderRequest.deliveryzipcode).toBeDefined();
-    expect(picqerOrderRequest.deliverycountry).toBeDefined();
+    expect(picqerOrderRequest.deliverycity).toBeDefined();
+    expect(picqerOrderRequest.deliverycountry).toBe('NL');
     expect(picqerOrderRequest.products.length).toBe(1);
     expect(picqerOrderRequest.products[0].amount).toBe(3);
     expect(isOrderInProcessing).toBe(true);


### PR DESCRIPTION
# Description

* Register webhooks in Picqer for all channels that have Picqer enabled
* Push countryCode to Picqer instead of country name
* Push City to Picqer

# Checklist

Please make sure you've done the following checks:

- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed
- [x] I have reviewed my own PR
- [x] I have fixed all typo's and have removed unused or commented code
