### PR TITLE
feat: new Vendure version badges

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lerna": "2.0.0",
   "npmClient": "yarn",
   "useWorkspaces": true

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.ts",
   "license": "MIT",
   "private": true,

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.ts",
   "license": "MIT",
   "private": true,

--- a/packages/vendure-order-client/package.json
+++ b/packages/vendure-order-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-order-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A tiny, framework agnostic client for managing active orders and checkout with Vendure.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-admin-ui-helpers/README.md
+++ b/packages/vendure-plugin-admin-ui-helpers/README.md
@@ -1,6 +1,6 @@
 # Admin UI helper buttons for Vendure
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-admin-ui-helpers/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-admin-ui-helpers)
 

--- a/packages/vendure-plugin-admin-ui-helpers/package.json
+++ b/packages/vendure-plugin-admin-ui-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-admin-ui-helpers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for various admin ui helpers. Cancel button, complete order button etc.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-coinbase/README.md
+++ b/packages/vendure-plugin-coinbase/README.md
@@ -1,6 +1,6 @@
 # Vendure Coinbase plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-coinbase/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-coinbase)
 

--- a/packages/vendure-plugin-coinbase/package.json
+++ b/packages/vendure-plugin-coinbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-coinbase",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for Coinbase payments",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-customer-managed-groups/package.json
+++ b/packages/vendure-plugin-customer-managed-groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-customer-managed-groups",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This plugin allows customer groups to have 'Group admins', that are allowed to fetch placed orders for everyone in the group.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-dutch-postalcode/README.md
+++ b/packages/vendure-plugin-dutch-postalcode/README.md
@@ -1,6 +1,6 @@
 # Vendure Plugin Dutch Postalcodes
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-dutch-postalcode/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-dutch-postalcode)
 

--- a/packages/vendure-plugin-dutch-postalcode/package.json
+++ b/packages/vendure-plugin-dutch-postalcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-dutch-postalcode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for retrieving Dutch addresses by postal code via postcode.tech",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-e-boekhouden/README.md
+++ b/packages/vendure-plugin-e-boekhouden/README.md
@@ -1,6 +1,6 @@
 # Vendure E-boekhouden plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-e-boekhouden/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-e-boekhouden)
 

--- a/packages/vendure-plugin-e-boekhouden/package.json
+++ b/packages/vendure-plugin-e-boekhouden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-e-boekhouden",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for integration with the e-boekhouden accounting platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-goedgepickt/README.md
+++ b/packages/vendure-plugin-goedgepickt/README.md
@@ -1,6 +1,6 @@
 # Vendure GoedGepickt plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-goedgepickt/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-goedgepickt)
 

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-google-cloud-tasks/README.md
+++ b/packages/vendure-plugin-google-cloud-tasks/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Tasks Vendure plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-google-cloud-tasks/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 Plugin for using Vendure worker with Google Cloud Tasks. This plugin will show ending, successful and failed jobs in the admin UI under `sytem/jobs`, but not running jobs. Only jobs of the past 7 days are kept in the DB.
 

--- a/packages/vendure-plugin-google-cloud-tasks/package.json
+++ b/packages/vendure-plugin-google-cloud-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-cloud-tasks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for using worker jobs with Google Cloud Tasks",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-google-storage-assets/README.md
+++ b/packages/vendure-plugin-google-storage-assets/README.md
@@ -1,6 +1,6 @@
 # Vendure Google Asset Storage plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-google-storage-assets/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-google-storage-assets)
 

--- a/packages/vendure-plugin-google-storage-assets/package.json
+++ b/packages/vendure-plugin-google-storage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-storage-assets",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for uploading assets to Google storage",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-invoices/README.md
+++ b/packages/vendure-plugin-invoices/README.md
@@ -1,6 +1,6 @@
 # Vendure Plugin for generating invoices
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-invoices/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-invoices)
 

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-invoices",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-limit-variant-per-order/README.md
+++ b/packages/vendure-plugin-limit-variant-per-order/README.md
@@ -1,6 +1,6 @@
 # Vendure Plugin for limiting the amount of specific product variants per order
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-limit-product-per-order/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-limit-product-per-order)
 

--- a/packages/vendure-plugin-limit-variant-per-order/package.json
+++ b/packages/vendure-plugin-limit-variant-per-order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-limit-variant-per-order",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin to limit the amount of a specific product that can be ordered per order.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-metrics/README.md
+++ b/packages/vendure-plugin-metrics/README.md
@@ -1,6 +1,6 @@
 # Vendure Metrics plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-metrics/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 A plugin to measure and visualize your shop's average order value (AOV),number of orders per
 month or per week and number of items per product variant for the past 12 months (or weeks) per variants.

--- a/packages/vendure-plugin-metrics/package.json
+++ b/packages/vendure-plugin-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-metrics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin measuring and visualizing e-commerce metrics",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-modify-customer-orders/package.json
+++ b/packages/vendure-plugin-modify-customer-orders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-modify-customer-orders",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for converting Active orders to Draft",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-multiserver-db-sessioncache/README.md
+++ b/packages/vendure-plugin-multiserver-db-sessioncache/README.md
@@ -1,6 +1,6 @@
 # Multi-Server Session Cache Plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-multiserver-db-sessioncache/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 This plugin implements a multi-server proof session cache, using the existing database as cache. Vendure's built-in (default) InMemoryCache can cause conflicts on multi-server environment, and setting up Redis only for session caching might be overkill for most shops.
 

--- a/packages/vendure-plugin-multiserver-db-sessioncache/package.json
+++ b/packages/vendure-plugin-multiserver-db-sessioncache/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pinelab/vendure-plugin-multiserver-db-sessioncache",
   "description": "An implementation of Vendure's SessionCacheStrategy that caches session in the database",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Surafel Melese Tariku <surafelmelese09@gmail.com>",
   "homepage": "https://pinelab-plugins.com/",
   "repository": "https://github.com/Pinelab-studio/pinelab-vendure-plugins",

--- a/packages/vendure-plugin-myparcel/README.md
+++ b/packages/vendure-plugin-myparcel/README.md
@@ -1,6 +1,6 @@
 # Vendure MyParcel Plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-myparcel/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-myparcel)
 

--- a/packages/vendure-plugin-myparcel/package.json
+++ b/packages/vendure-plugin-myparcel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-myparcel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for MyParcel fulfillment",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-order-export/README.md
+++ b/packages/vendure-plugin-order-export/README.md
@@ -1,6 +1,6 @@
 # Vendure Order Export Plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-order-export/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-order-export)
 

--- a/packages/vendure-plugin-order-export/package.json
+++ b/packages/vendure-plugin-order-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-order-export",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for exporting orders to a file",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -1,6 +1,6 @@
 # Vendure Picqer Plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-picqer/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 !! This plugin is still being developed and it's still incomplete!
 

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-popularity-scores/package.json
+++ b/packages/vendure-plugin-popularity-scores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-popularity-scores",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Sort products and collections by popularity based on previously placed orders",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-sendcloud/README.md
+++ b/packages/vendure-plugin-sendcloud/README.md
@@ -1,6 +1,6 @@
 # Vendure SendCloud plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-sendcloud/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### Visit [pinelab-plugins.com](https://pinelab-plugins.com/plugin/vendure-plugin-sendcloud) for more documentation and examples.
 

--- a/packages/vendure-plugin-sendcloud/package.json
+++ b/packages/vendure-plugin-sendcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-sendcloud",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for syncing orders with SendCloud",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-shipping-by-weight-and-country/README.md
+++ b/packages/vendure-plugin-shipping-by-weight-and-country/README.md
@@ -1,6 +1,6 @@
 # Shipping by weight and country Vendure Plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-shipping-by-weight-and-country/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-shipping-by-weight-and-country)
 

--- a/packages/vendure-plugin-shipping-by-weight-and-country/package.json
+++ b/packages/vendure-plugin-shipping-by-weight-and-country/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-shipping-by-weight-and-country",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for selecting a shipping method based on the total weight and the shipping address of an order.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-stock-monitoring/README.md
+++ b/packages/vendure-plugin-stock-monitoring/README.md
@@ -1,6 +1,6 @@
 # Vendure stock monitoring plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-stock-monitoring/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-stock-monitoring)
 

--- a/packages/vendure-plugin-stock-monitoring/package.json
+++ b/packages/vendure-plugin-stock-monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stock-monitoring",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for monitoring stock levels through a widget or by email",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-stripe-subscription/README.md
+++ b/packages/vendure-plugin-stripe-subscription/README.md
@@ -1,6 +1,6 @@
 # Vendure Stripe Subscription plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-stripe-subscription/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 A channel aware plugin that allows you to sell subscription based services or memberships through Vendure. Also support
 non-subscription payments. This plugin was made in collaboration with the great people

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-variant-bulk-update/README.md
+++ b/packages/vendure-plugin-variant-bulk-update/README.md
@@ -1,6 +1,6 @@
 # Vendure Plugin for bulk updating all variants of a product
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-variant-bulk-update/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 ### [Official documentation here](https://pinelab-plugins.com/plugin/vendure-plugin-variant-bulk-update)
 

--- a/packages/vendure-plugin-variant-bulk-update/package.json
+++ b/packages/vendure-plugin-variant-bulk-update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-variant-bulk-update",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vendure plugin to bulk update all variants of a product",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-webhook/README.md
+++ b/packages/vendure-plugin-webhook/README.md
@@ -1,6 +1,6 @@
 # Vendure Webhook plugin
 
-![Vendure version](https://img.shields.io/npm/dependency-version/vendure-plugin-webhook/dev/@vendure/core)
+![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)
 
 Triggers an outgoing webhook based on configured events. Events are specified in `vendure-config` and webhooks are configured per
 channel via the admin UI.

--- a/packages/vendure-plugin-webhook/package.json
+++ b/packages/vendure-plugin-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-webhook",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Call webhooks based on configured events from Vendure",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",


### PR DESCRIPTION
# Description

Added Vendure version badge from Github main branch, which should be published (because of auto publish when merged to main)

# Screenshots

![Vendure version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FPinelab-studio%2Fpinelab-vendure-plugins%2Fmain%2Fpackage.json&query=$.devDependencies[%27@vendure/core%27]&colorB=blue&label=Built%20on%20Vendure)

# Checklist

:pushpin: Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [ ] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed
- [ ] Have you correctly increased the version number to the next [patch/minor/major](https://semver.org/#summary)? _(Only needed for publishable NPM packages)_
