### PR TITLE
WIP Metrics: Reintroduce custom strategies to display custom metrics in dashboard

### DIFF
--- a/packages/vendure-plugin-metrics/src/api/metric-strategy.ts
+++ b/packages/vendure-plugin-metrics/src/api/metric-strategy.ts
@@ -1,0 +1,36 @@
+import { AdvancedMetricInterval, AdvancedMetricSummaryEntry, AdvancedMetricType } from "../ui/generated/graphql";
+import { RequestContext } from '@vendure/core';
+import { MetricData } from "./metrics.service";
+
+export interface MetricStrategy<T extends Array> {
+    code: string;
+    /**
+     * We need to know if the chart should format your metrics as
+     *  numbers/amounts or as currency
+     */
+    metricType: AdvancedMetricType;
+
+    /**
+     * Title to display on the chart. 
+     * Ctx can be used to localize the title
+     */
+    getTitle(ctx: RequestContext): string;
+
+    loadData(ctx: RequestContext)
+
+    /**
+     * Calculate the datapoint for the given month
+     * @param ctx 
+     * @param interval 
+     * @param monthNr 
+     * @param data 
+     */
+    calculateDataPoint(
+        ctx: RequestContext,
+        monthNr: number,
+        data: T
+      ): AdvancedMetricSummaryEntry;
+    
+
+
+}


### PR DESCRIPTION
# Description

Custom strategies were removed because of performance reasons. There is still a desire coming from the community to be able to be able to visualize custom metrics on the dashboard (for example Stripe Subscription visualization), so we decided to reintroduce custom strategies, with some changes.

* Metrics can only be show per month
* Only time series are allowed (Orders per month, Products sold per month etc)

:warning: TODO:
* Cache data results for 24 hours (in memory)
* Cache parsed data per month (not the raw `loadData()` result), to prevent recalculating every time
* Show numbers on Angular chart on hove

# Breaking changes

Monthly/weekly filtering is omitted

# Checklist

:pushpin: Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [ ] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed
- [ ] Have you correctly increased the version number to the next [patch/minor/major](https://semver.org/#summary)? _(Only needed for publishable NPM packages)_
