### PR TITLE
fix(picqer): dont publish events if no variants are updated

### DIFF
--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -511,7 +511,6 @@ export class PicqerService implements OnApplicationBootstrap {
       picqerProducts.map((p) => p.productcode)
     );
     const stockAdjustments: StockAdjustment[] = [];
-    let updateCount = 0; // Nr of variants that were updated
     // Loop over variants to determine new stock level per variant and update in DB
     await Promise.all(
       vendureVariants.map(async (variant) => {
@@ -567,13 +566,22 @@ export class PicqerService implements OnApplicationBootstrap {
               productVariant: { id: variant.id },
             })
           );
-          updateCount++;
         }
       })
     );
+    if (!stockAdjustments.length) {
+      Logger.warn(
+        `No stock levels updated. This means none of the products in Picqer exist in Vendure yet.`,
+        loggerCtx
+      );
+      return;
+    }
     await this.removeNonPicqerStockLocations(ctx);
     await this.eventBus.publish(new StockMovementEvent(ctx, stockAdjustments));
-    Logger.info(`Updated stock levels of ${updateCount} variants`, loggerCtx);
+    Logger.info(
+      `Updated stock levels of ${stockAdjustments.length} variants`,
+      loggerCtx
+    );
   }
 
   /**


### PR DESCRIPTION
# Description

When no stock levels or variants are updated: 
* Log a warning, because this means none of the products in Picqer exist in Vendure, which is strange
* Don't publish events or do any other actions

# Checklist

:pushpin: Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [ ] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed
- [ ] Have you correctly increased the version number to the next [patch/minor/major](https://semver.org/#summary)? _(Only needed for publishable NPM packages)_
