### PR TITLE
Fix/log warning picer no order

### DIFF
--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -357,7 +357,7 @@ export class PicqerService implements OnApplicationBootstrap {
       'lines.productVariant',
     ]);
     if (!order) {
-      Logger.error(
+      Logger.warn(
         `No order found for code ${data.reference}. Not processing this hook any further`,
         loggerCtx
       );


### PR DESCRIPTION
# Description

Log warnings instead of errors when no order is found for given order code from incoming Picqer webhook. Picqer could be connected to multiple webshops, so this isn't necessarily an error.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed
- [x] Have you correctly increased the version number to the next [patch/minor/major](https://semver.org/#summary)? _(Only needed for publishable NPM packages)_
