### PR TITLE
Feat(invoices): Increase length of invoice template field in DB

### DIFF
--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.1.0 (2023-08-14)
 
-- DB migration needed to alter column: Increased length of invoice template column, so that we can store more than 64KB. ([#243](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/243))
+- Allow specifying invoice template storage in DB by specifying DB engine: INVOICES_PLUGIN_DB_ENGINE=mysql ([#243](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/243))

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.1.0 (2023-08-14)
+
+- Expose Stripe publishable key via `eligiblePaymemtMethods.stripeSubscriptionPublishableKey` ([#242](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/242))

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.1.0 (2023-08-14)
 
-- Expose Stripe publishable key via `eligiblePaymemtMethods.stripeSubscriptionPublishableKey` ([#242](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/242))
+- Increase length of invoice template column, so that we can store more than 64KB ([#243](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/243))

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.1.0 (2023-08-14)
 
-- Increase length of invoice template column, so that we can store more than 64KB ([#243](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/243))
+- DB migration needed to alter column: Increased length of invoice template column, so that we can store more than 64KB. ([#243](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/243))

--- a/packages/vendure-plugin-invoices/README.md
+++ b/packages/vendure-plugin-invoices/README.md
@@ -43,13 +43,6 @@ plugins: [
 7. Check the checkbox to `Enable invoice generation` for the current channel on order placement.
 8. A default HTML template is set for you. Click the `Preview` button to view a sample PDF invoice.
 
-If you are using Docker with node:16 or higher as base, you need to add this to your Dockerfile:
-
-```shell
-# PhantomJS fix https://github.com/bazelbuild/rules_closure/issues/351
-ENV OPENSSL_CONF=/dev/null
-```
-
 ## Adding invoices to your order-confirmation email
 
 Add the following link to your email template:
@@ -58,6 +51,17 @@ Add the following link to your email template:
 
 When the customer clicks the link, the server will check if the `ordercode`, `channelCode` and `customer emailaddress`
 match with the requested order. If so, it will return the invoice.
+
+## Increase invoice template DB storage
+
+By default, the plugin uses TypeOrm's `text` to store the invoice template in the DB. This might not be enough, for example when you'd like to add base64 encoded images to your invoices. You can specify your DB engine with an env variable, and the plugin will resolve the correct column type:
+
+```shell
+# E.g. For mysql the column type 'longtext' will be used, which supports up to 4gb
+INVOICES_PLUGIN_DB_ENGINE=longtext
+```
+
+Don't forget to run a DB migration after! Checkout https://orkhan.gitbook.io/typeorm/docs/entities for available databases and column types.
 
 ## Google Storage strategy
 

--- a/packages/vendure-plugin-invoices/README.md
+++ b/packages/vendure-plugin-invoices/README.md
@@ -54,7 +54,7 @@ match with the requested order. If so, it will return the invoice.
 
 ## Increase invoice template DB storage
 
-By default, the plugin uses TypeOrm's `text` to store the invoice template in the DB. This might not be enough, for example when you'd like to add base64 encoded images to your invoices. You can specify your DB engine with an env variable, and the plugin will resolve the correct column type:
+By default, the plugin uses TypeOrm's `text` to store the invoice template in the DB. This might not be enough, for example when you'd like to add base64 encoded images to your invoices. This will result in the error `ER_DATA_TOO_LONG: Data too long for column 'templateString'`. You can specify your DB engine with an env variable, and the plugin will resolve the correct column type:
 
 ```shell
 # E.g. For mysql the column type 'longtext' will be used, which supports up to 4gb

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -14,7 +14,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "start": "yarn ts-node test/dev-server.ts",

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-invoices",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Vendure plugin for invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-invoices/src/api/entities/invoice-config.entity.ts
+++ b/packages/vendure-plugin-invoices/src/api/entities/invoice-config.entity.ts
@@ -11,6 +11,6 @@ export class InvoiceConfigEntity extends VendureEntity {
   channelId!: string;
   @Column({ default: false })
   enabled: boolean = false;
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: 'longtext', nullable: true })
   templateString?: string | null;
 }

--- a/packages/vendure-plugin-invoices/src/api/entities/invoice-config.entity.ts
+++ b/packages/vendure-plugin-invoices/src/api/entities/invoice-config.entity.ts
@@ -7,7 +7,6 @@ import { loggerCtx } from '../../constants';
 export class InvoiceConfigEntity extends VendureEntity {
   constructor(input?: DeepPartial<InvoiceConfigEntity>) {
     super(input);
-    console.log(process.env.INVOICES_PLUGIN_COLUMN_TYPE);
   }
 
   @Column()

--- a/packages/vendure-plugin-invoices/src/api/entities/invoice-config.entity.ts
+++ b/packages/vendure-plugin-invoices/src/api/entities/invoice-config.entity.ts
@@ -1,16 +1,49 @@
-import { Column, Entity } from 'typeorm';
-import { DeepPartial, VendureEntity } from '@vendure/core';
+import { Column, Entity, ColumnType, getMetadataArgsStorage } from 'typeorm';
+import { DeepPartial, Logger, VendureEntity } from '@vendure/core';
+import { InvoicePlugin } from '../../invoice.plugin';
+import { loggerCtx } from '../../constants';
 
 @Entity('invoice_config')
 export class InvoiceConfigEntity extends VendureEntity {
   constructor(input?: DeepPartial<InvoiceConfigEntity>) {
     super(input);
+    console.log(process.env.INVOICES_PLUGIN_COLUMN_TYPE);
   }
 
   @Column()
   channelId!: string;
+
   @Column({ default: false })
   enabled: boolean = false;
-  @Column({ type: 'longtext', nullable: true })
+
+  @Column({ type: resolveTemplateColumnType(), nullable: true })
   templateString?: string | null;
+}
+
+/**
+ * Resolve column type based on the DB engine
+ */
+function resolveTemplateColumnType(): ColumnType {
+  const dbEngine = process.env.INVOICES_PLUGIN_DB_ENGINE;
+  if (!dbEngine) {
+    return 'text';
+  } else if (dbEngine === 'mysql' || 'mariadb') {
+    return 'longtext'; // up to 4GB
+  } else if (dbEngine === 'postgres') {
+    return 'text'; // Up to 1GB
+  } else if (dbEngine === 'cockroachdb') {
+    return 'string';
+  } else if (dbEngine === 'mssql') {
+    return 'text';
+  } else if (dbEngine === 'sqlite') {
+    return 'text';
+  } else if (dbEngine === 'oracle') {
+    return 'clob';
+  } else {
+    Logger.warn(
+      `No large-text column type available for DB engine "${dbEngine}", using "text". ( Contributions welcome )`,
+      loggerCtx
+    );
+  }
+  return 'text';
 }

--- a/packages/vendure-plugin-invoices/src/invoice.plugin.ts
+++ b/packages/vendure-plugin-invoices/src/invoice.plugin.ts
@@ -48,8 +48,10 @@ export interface InvoicePluginConfig {
     resolvers: [InvoiceResolver],
   },
   compatibility: '^2.0.0',
-  configuration: (config: RuntimeVendureConfig) =>
-    InvoicePlugin.configure(config),
+  configuration: (config: RuntimeVendureConfig) => {
+    InvoicePlugin.configure(config);
+    return config;
+  },
 })
 export class InvoicePlugin {
   static config: InvoicePluginConfig;


### PR DESCRIPTION
# Description

By default, the plugin uses TypeOrm's `text` to store the invoice template in the DB. This might not be enough, for example when you'd like to add base64 encoded images to your invoices. This will result in the error `ER_DATA_TOO_LONG: Data too long for column 'templateString'`. You can specify your DB engine with an env variable, and the plugin will resolve the correct column type:

```shell
# E.g. For mysql the column type 'longtext' will be used, which supports up to 4gb
INVOICES_PLUGIN_DB_ENGINE=longtext
```

Don't forget to run a DB migration after! Checkout https://orkhan.gitbook.io/typeorm/docs/entities for available databases and column types.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

:package: For publishable packages:
- [x] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [x] Have you added your changes to the [changelog](https://keepachangelog.com/en/1.0.0/)? 
