### PR TITLE
Return subscriptionPricing also on admin api

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/src/api/graphql-schemas.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/graphql-schemas.ts
@@ -48,15 +48,13 @@ const sharedTypes = gql`
     useProration: Boolean
     autoRenew: Boolean
   }
+  extend type OrderLine {
+    subscriptionPricing: StripeSubscriptionPricing
+  }
 `;
 
 export const shopSchemaExtensions = gql`
   ${sharedTypes}
-
-  extend type OrderLine {
-    subscriptionPricing: StripeSubscriptionPricing
-  }
-
   type StripeSubscriptionPricing {
     variantId: String!
     pricesIncludeTax: Boolean!

--- a/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.plugin.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.plugin.ts
@@ -43,7 +43,11 @@ export interface StripeSubscriptionPluginOptions {
   },
   adminApiExtensions: {
     schema: adminSchemaExtensions,
-    resolvers: [AdminResolver, AdminPriceIncludesTaxResolver],
+    resolvers: [
+      AdminResolver,
+      AdminPriceIncludesTaxResolver,
+      ShopOrderLinePricingResolver,
+    ],
   },
   controllers: [StripeSubscriptionController],
   providers: [


### PR DESCRIPTION
# Description

As requested on #244, this changes should add  `subscriptionPricing` to `OrderLine` by extending the `OrderLine` gql type on admin api.

# Breaking changes

This PR wont introduce any breaking changes.

# Checklist

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [X] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [ ] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [ ] Have you added your changes to the [changelog](https://keepachangelog.com/en/1.0.0/)? 
