### PR TITLE
Feat/stripe subscription proxy

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.0 (2023-09-08)
+
+- Expose proxy function to retrieve all subscriptions for current channel ([#255](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/255))
+
 # 1.3.2 (2023-09-06)
 
 - Fixed selecting schedules on a variant ([#253](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/253))

--- a/packages/vendure-plugin-stripe-subscription/README.md
+++ b/packages/vendure-plugin-stripe-subscription/README.md
@@ -66,8 +66,7 @@ plugins: [
 6. Start the Vendure server and login to the admin UI
 7. Go to `Settings > Subscriptions` and create a Schedule.
 8. Create a variant and select a schedule in the variant detail screen in the admin UI.
-9. Create a payment method with the code `stripe-subscription-payment` and select `stripe-subscription` as handler. **
-   Your payment method MUST have 'stripe-subscription' in the code field**
+9. Create a payment method with the code `stripe-subscription-payment` and select `stripe-subscription` as handler. You can (and should) have only 1 payment method with the Stripe Subscription handler per channel.
 10. Set your API key from Stripe in the apiKey field.
 11. Get the webhook secret from you Stripe dashboard and save it on the payment method.
 

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.controller.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.controller.ts
@@ -256,7 +256,7 @@ export class StripeSubscriptionController {
       }
       // Validate signature
       const { stripeClient } =
-        await this.stripeSubscriptionService.getStripeHandler(ctx, order.id);
+        await this.stripeSubscriptionService.getStripeContext(ctx);
       if (!this.options?.disableWebhookSignatureChecking) {
         stripeClient.validateWebhookSignature(request.rawBody, signature);
       }

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.handler.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.handler.ts
@@ -6,22 +6,10 @@ import {
   Logger,
   PaymentMethodHandler,
   SettlePaymentResult,
-  UserInputError,
 } from '@vendure/core';
-import { RequestContext } from '@vendure/core/dist/api/common/request-context';
-import { Order, Payment, PaymentMethod } from '@vendure/core/dist/entity';
-import {
-  CancelPaymentErrorResult,
-  CancelPaymentResult,
-} from '@vendure/core/dist/config/payment/payment-method-handler';
-import {
-  OrderLineWithSubscriptionFields,
-  OrderWithSubscriptionFields,
-} from './subscription-custom-fields';
-import { StripeSubscriptionService } from './stripe-subscription.service';
-import { StripeClient } from './stripe.client';
 import { loggerCtx } from '../constants';
 import { printMoney } from './pricing.helper';
+import { StripeSubscriptionService } from './stripe-subscription.service';
 
 let service: StripeSubscriptionService;
 export const stripeSubscriptionHandler = new PaymentMethodHandler({
@@ -111,7 +99,7 @@ export const stripeSubscriptionHandler = new PaymentMethodHandler({
     payment,
     args
   ): Promise<CreateRefundResult> {
-    const { stripeClient } = await service.getStripeHandler(ctx, order.id);
+    const { stripeClient } = await service.getStripeContext(ctx);
     const refund = await stripeClient.refunds.create({
       payment_intent: payment.transactionId,
       amount,

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -259,6 +259,17 @@ export class StripeSubscriptionService {
     return stripeClient.subscriptions.list(params, options);
   }
 
+  /**
+   * Get a subscription directly from Stripe
+   */
+  async getSubscription(
+    ctx: RequestContext,
+    subscriptionId: string
+  ): Promise<Stripe.Response<Stripe.Subscription>> {
+    const { stripeClient } = await this.getStripeContext(ctx);
+    return stripeClient.subscriptions.retrieve(subscriptionId);
+  }
+
   async createPaymentIntent(ctx: RequestContext): Promise<string> {
     let order = (await this.activeOrderService.getActiveOrder(
       ctx,

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -244,6 +244,13 @@ export class StripeSubscriptionService {
     }
   }
 
+  /**
+   * 
+   */
+  async getSubscriptions(ctx: RequestContext) {
+
+  }
+
   async createPaymentIntent(ctx: RequestContext): Promise<string> {
     let order = (await this.activeOrderService.getActiveOrder(
       ctx,

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -63,6 +63,7 @@ import { hasSubscriptions } from './has-stripe-subscription-products-payment-che
 import { StripeSubscriptionPayment } from './stripe-subscription-payment.entity';
 import { StripeInvoice } from './types/stripe-invoice';
 import { StripePaymentIntent } from './types/stripe-payment-intent';
+import Stripe from 'stripe';
 
 export interface StripeContext {
   paymentMethod: PaymentMethod;
@@ -245,9 +246,18 @@ export class StripeSubscriptionService {
   }
 
   /**
-   *
+   * Proxy to Stripe to retrieve subscriptions created for the current channel.
+   * Proxies to the Stripe api, so you can use the same filtering, parameters and options as defined here
+   * https://stripe.com/docs/api/subscriptions/list
    */
-  async getSubscriptions(ctx: RequestContext) {}
+  async getAllSubscriptions(
+    ctx: RequestContext,
+    params?: Stripe.SubscriptionListParams,
+    options?: Stripe.RequestOptions
+  ): Promise<Stripe.ApiListPromise<Stripe.Subscription>> {
+    const { stripeClient } = await this.getStripeContext(ctx);
+    return stripeClient.subscriptions.list(params, options);
+  }
 
   async createPaymentIntent(ctx: RequestContext): Promise<string> {
     let order = (await this.activeOrderService.getActiveOrder(

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe.client.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe.client.ts
@@ -21,14 +21,14 @@ interface SubscriptionInput {
  */
 export class StripeClient extends Stripe {
   constructor(
-    private webhookSecret: string,
+    public webhookSecret: string,
     apiKey: string,
     config: Stripe.StripeConfig
   ) {
     super(apiKey, config);
   }
 
-  async getOrCreateClient(
+  async getOrCreateCustomer(
     customer: CustomerWithSubscriptionFields
   ): Promise<Stripe.Customer> {
     if (customer.customFields?.stripeSubscriptionCustomerId) {

--- a/packages/vendure-plugin-stripe-subscription/test/dev-server.ts
+++ b/packages/vendure-plugin-stripe-subscription/test/dev-server.ts
@@ -9,6 +9,7 @@ import {
   LanguageCode,
   LogLevel,
   mergeConfig,
+  RequestContextService,
 } from '@vendure/core';
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { StripeTestCheckoutPlugin } from './stripe-test-checkout.plugin';
@@ -24,7 +25,11 @@ import {
 import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
 import * as path from 'path';
 import { UPSERT_SCHEDULES } from '../src/ui/queries';
-import { SubscriptionInterval, SubscriptionStartMoment } from '../src';
+import {
+  StripeSubscriptionService,
+  SubscriptionInterval,
+  SubscriptionStartMoment,
+} from '../src';
 
 // Test published version
 import { StripeSubscriptionPlugin } from '../src/stripe-subscription.plugin';
@@ -224,4 +229,9 @@ export let clientSecret = 'test';
   );
   clientSecret = secret;
   console.log(`Go to http://localhost:3050/checkout/ to test your intent`);
+
+  // Uncomment these lines to list all subscriptions created in Stripe
+  // const ctx = await server.app.get(RequestContextService).create({apiType: 'admin'});
+  // const subscriptions = await server.app.get(StripeSubscriptionService).getAllSubscriptions(ctx);
+  // console.log(JSON.stringify(subscriptions));
 })();


### PR DESCRIPTION
# Description

* Added a proxy function for retrieving created subscriptions in the current channel. 
* The function proxies incoming arguments to the Stripe client. See available parameters here: https://stripe.com/docs/api/subscriptions/list
* Example usage:
```ts
import { StripeSubscriptionService } from `@pinelab/vendure-plugin-stripe-subscriptions`;

// There are multiple ways to onbtain an injector instance in your current context. See https://docs.vendure.io/typescript-api/common/injector/
injector.get(StripeSubscriptionService).getAllSubscriptions(ctx);

// Or, get a single subscription
injector.get(StripeSubscriptionService).getSubscription(ctx, 'sub_1No3b9225jfF0VNwOedpxA2l');

```

* StripeClient can now be obtained with just a RequestContext, no order ID needed anymore.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

:package: For publishable packages:
- [x] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [x] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
