### PR TITLE
feat: allow option to trigger additional actions when a processing er…

### DIFF
--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,1 +1,3 @@
-// TODO set correct version number + date and the changes you've made connected to the PR. See this example for the correct format: https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md
+# 1.1.2 (2023-09-26)
+
+- Added custom error handler to inspect errors from failed jobs([#262](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/262))

--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.1.2 (2023-09-26)
 
-- Added custom error handler to inspect errors from failed jobs([#262](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/262))
+- Added `onJobFailure` option to inspect errors from failed jobs([#262](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/262))

--- a/packages/vendure-plugin-google-cloud-tasks/package.json
+++ b/packages/vendure-plugin-google-cloud-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-cloud-tasks",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Vendure plugin for using worker jobs with Google Cloud Tasks",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.handler.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.handler.ts
@@ -111,12 +111,12 @@ export class CloudTasksHandler implements OnApplicationBootstrap {
       res.sendStatus(200);
       return;
     } catch (error: any) {
-      if (CloudTasksPlugin.options.errorHandler) {
+      if (CloudTasksPlugin.options.onJobFailure) {
         try {
-          await CloudTasksPlugin.options.errorHandler(error);
+          await CloudTasksPlugin.options.onJobFailure(error);
         } catch (e: any) {
           Logger.error(
-            `Error in 'errorHandler': ${e}`,
+            `Error in 'onJobFailure': ${e}`,
             CloudTasksPlugin.loggerCtx
           );
         }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.handler.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.handler.ts
@@ -134,7 +134,6 @@ export class CloudTasksHandler implements OnApplicationBootstrap {
           })
         );
         res.sendStatus(200); // Return 200 to prevent more retries
-        return;
       } else {
         // More attempts remain, so return 500 to trigger a retry
         Logger.warn(
@@ -142,8 +141,11 @@ export class CloudTasksHandler implements OnApplicationBootstrap {
           CloudTasksPlugin.loggerCtx
         );
         res.sendStatus(500);
-        return;
       }
+      if (CloudTasksPlugin.options.onProcessingError) {
+        CloudTasksPlugin.options.onProcessingError(error);
+      }
+      return;
     }
   }
 

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.handler.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.handler.ts
@@ -111,6 +111,16 @@ export class CloudTasksHandler implements OnApplicationBootstrap {
       res.sendStatus(200);
       return;
     } catch (error: any) {
+      if (CloudTasksPlugin.options.errorHandler) {
+        try {
+          await CloudTasksPlugin.options.errorHandler(error);
+        } catch (e: any) {
+          Logger.error(
+            `Error in 'errorHandler': ${e}`,
+            CloudTasksPlugin.loggerCtx
+          );
+        }
+      }
       if (attempts === job.retries) {
         // This was the final attempt, so mark the job as failed
         Logger.error(
@@ -141,9 +151,6 @@ export class CloudTasksHandler implements OnApplicationBootstrap {
           CloudTasksPlugin.loggerCtx
         );
         res.sendStatus(500);
-      }
-      if (CloudTasksPlugin.options.onProcessingError) {
-        CloudTasksPlugin.options.onProcessingError(error);
       }
       return;
     }

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -7,7 +7,7 @@ export interface CloudTaskOptions {
    * Custom error handler for when a job fails.
    * Useful for when you'd like to inspect specific errors in your project.
    */
-  errorHandler?: (error: any) => void | Promise<void>;
+  onJobFailure?: (error: any) => void | Promise<void>;
   /**
    * Optional suffix, I.E. for differentiating between test, acc and prod queues
    */

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -3,7 +3,11 @@ export interface CloudTaskOptions {
   projectId: string;
   location: string;
   authSecret: string;
-  onProcessingError: (error: any) => void;
+  /**
+   * Custom error handler for when a job fails.
+   * Useful for when you'd like to inspect specific errors in your project.
+   */
+  errorHandler?: (error: any) => void | Promise<void>;
   /**
    * Optional suffix, I.E. for differentiating between test, acc and prod queues
    */

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -3,6 +3,7 @@ export interface CloudTaskOptions {
   projectId: string;
   location: string;
   authSecret: string;
+  onProcessingError: (error: any) => void;
   /**
    * Optional suffix, I.E. for differentiating between test, acc and prod queues
    */

--- a/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
@@ -39,7 +39,7 @@ describe('CloudTasks job queue e2e', () => {
       authSecret: 'some-secret',
       queueSuffix: 'plugin-test',
       defaultJobRetries: 50,
-      onJobFailed: async (error) => {
+      onJobFailure: async (error) => {
         console.log('Custom error handler', error);
       },
     })

--- a/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
@@ -39,7 +39,7 @@ describe('CloudTasks job queue e2e', () => {
       authSecret: 'some-secret',
       queueSuffix: 'plugin-test',
       defaultJobRetries: 50,
-      errorHandler: async (error) => {
+      onJobFailed: async (error) => {
         console.log('Custom error handler', error);
       },
     })

--- a/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
@@ -39,6 +39,9 @@ describe('CloudTasks job queue e2e', () => {
       authSecret: 'some-secret',
       queueSuffix: 'plugin-test',
       defaultJobRetries: 50,
+      errorHandler: async (error) => {
+        console.log('Custom error handler', error);
+      },
     })
   );
   testConfig.plugins.push(DefaultSearchPlugin);


### PR DESCRIPTION
# Description

We need to inspect the error that was thrown while processing a job. This error has specific details that I want to log. Since the cloud tasks plugin catches all errors this is hard to do now. If I can pass a hook that will be called with the original error then I can log / inspect that.

I haven't added test yet or a package version, because I wanted to check the rough idea with you first
