### PR TITLE
Primary collection adder script

### DIFF
--- a/packages/vendure-plugin-primary-collection/CHANGELOG.md
+++ b/packages/vendure-plugin-primary-collection/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added index barrel file to export plugin ([#261](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/261))
 
-# 1.0.2 (2023-09-28)
+# 1.1.1 (2023-09-28)
 
 - Products will have a `primaryCollection` as a custom field which can be selected via Admin UI.
+
+# 1.2.1 (2023-10-01)
+
+- Export the service class `PrimaryCollectionHelperService` which can be used to assign `primaryCollection`s to products without existing value

--- a/packages/vendure-plugin-primary-collection/README.md
+++ b/packages/vendure-plugin-primary-collection/README.md
@@ -6,6 +6,8 @@ To construct breadcrumbs and URL's it's useful to have a primary collection for 
 
 Primary collections can be selected in the Admin UI's product detail view.
 
+This Plugin also exports `PrimaryCollectionHelperService` which can be used to assign `primaryCollection`'s to products without existing values by running `PrimaryCollectionHelperService.setPrimaryCollectionForAllProducts`.
+
 ## Getting started
 
 Add the plugin to your `vendure-config.ts`:

--- a/packages/vendure-plugin-primary-collection/package.json
+++ b/packages/vendure-plugin-primary-collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-primary-collection",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Adds a primary collection to all Products by extending vendure's graphql api",
   "author": "Surafel Melese Tariku <surafelmelese09@gmail.com>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
+++ b/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
@@ -20,15 +20,22 @@ export class PrimaryCollectionHelperService {
       .leftJoinAndSelect('product.variants', 'variant')
       .leftJoinAndSelect('variant.collections', 'collection')
       .getMany();
+    const updatedProducts: Partial<Product>[] = [];
     for (let product of allProducts) {
       if (!product.customFields.primaryCollection) {
         const variantWithCollection = product.variants?.find(
           (v) => v.collections?.length
         );
-        product.customFields.primaryCollection =
-          variantWithCollection?.collections[0]!;
+        if (variantWithCollection?.collections[0]!) {
+          updatedProducts.push({
+            id: product.id,
+            customFields: {
+              primaryCollection: variantWithCollection?.collections[0]!,
+            },
+          });
+        }
       }
     }
-    await productsRepository.save(allProducts);
+    await productsRepository.save(updatedProducts);
   }
 }

--- a/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
+++ b/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import {
+  Product,
+  ProductService,
+  RequestContext,
+  TransactionalConnection,
+} from '@vendure/core';
+
+@Injectable()
+export class PrimaryCollectionHelperService {
+  constructor(
+    private conn: TransactionalConnection,
+    private productService: ProductService
+  ) {}
+
+  async setPrimaryCollectionForAllProducts(ctx: RequestContext) {
+    const productsRepository = this.conn.getRepository(ctx, Product);
+    const allProducts = await productsRepository
+      .createQueryBuilder('product')
+      .leftJoinAndSelect('product.variants', 'variant')
+      .leftJoinAndSelect('variant.collections', 'collection')
+      .getMany();
+    for (let product of allProducts) {
+      if (!product.customFields.primaryCollection) {
+        const variantWithCollection = product.variants?.find(
+          (v) => v.collections?.length
+        );
+        product.customFields.primaryCollection =
+          variantWithCollection?.collections[0]!;
+      }
+    }
+    await productsRepository.save(allProducts);
+  }
+}

--- a/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
+++ b/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
@@ -1,17 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import {
   Product,
-  ProductService,
   RequestContext,
   TransactionalConnection,
 } from '@vendure/core';
 
 @Injectable()
 export class PrimaryCollectionHelperService {
-  constructor(
-    private conn: TransactionalConnection,
-    private productService: ProductService
-  ) {}
+  constructor(private conn: TransactionalConnection) {}
 
   async setPrimaryCollectionForAllProducts(ctx: RequestContext) {
     const productsRepository = this.conn.getRepository(ctx, Product);

--- a/packages/vendure-plugin-primary-collection/src/primary-collection-plugin.ts
+++ b/packages/vendure-plugin-primary-collection/src/primary-collection-plugin.ts
@@ -10,9 +10,11 @@ import { PrimaryCollectionResolver } from './api/primary-collection.resolver';
 import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
 import path from 'path';
 import '../types.ts';
+import { PrimaryCollectionHelperService } from './api/primary-collections-helper.service';
 
 @VendurePlugin({
   imports: [PluginCommonModule],
+  providers: [PrimaryCollectionHelperService],
   shopApiExtensions: {
     schema: gql`
       extend type Product {
@@ -21,6 +23,7 @@ import '../types.ts';
     `,
     resolvers: [PrimaryCollectionResolver],
   },
+  exports: [PrimaryCollectionHelperService],
   compatibility: '^2.0.0',
   configuration: (config: RuntimeVendureConfig) => {
     config.customFields.Product.push({


### PR DESCRIPTION
# Description

This changes included in this PR will give developers the ability to run `PrimaryCollectionHelperService.setPrimaryCollectionForAllProducts` and assign default `primaryCollection` to products which don't have existing values. Since `PrimaryCollectionHelperService` is exported from `PrimaryCollectionPlugin`, it can be injected to service classes of any vendure plugin that imports  `PrimaryCollectionPlugin`.

# Breaking changes

This PR won't introduce any breaking changes.

# Screenshots

Add screenshots if needed.

# Checklist

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [X] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [X] I have added or updated test cases for important functionality
- [X] I have updated the README if needed

:package: For publishable packages:
- [X] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [X] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
