### PR TITLE
Export metric.strategy type definitions

### DIFF
--- a/packages/vendure-plugin-metrics/src/index.ts
+++ b/packages/vendure-plugin-metrics/src/index.ts
@@ -1,4 +1,5 @@
 export * from './metrics.plugin';
+export * from './api/metric-strategy.ts';
 export * from './api/metrics.service';
 export * from './api/metrics.resolver';
 export * from './ui/generated/graphql';


### PR DESCRIPTION
MetricStrategy and NamedDatapoint are not getting exported

# Description

MetricStrategy and NamedDatapoint are not getting exported, therefore we can't import them to create custom metrics.
Right now it has to be done like this:
`import { MetricStrategy, NamedDatapoint } from '@pinelab/vendure-plugin-metrics/dist/api/metric-strategy';`

# Breaking changes

No.

# Screenshots

-

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:package: For publishable packages:
- [ ] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [ ] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
