### PR TITLE
fix(picqer): dont set contactname if its the same as customer name

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,1 +1,3 @@
-// TODO set correct version number + date and the changes you've made connected to the PR. See this example for the correct format: https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md
+# 1.0.7
+
+- Don't set contact name in Picqer if it's the same as customer name ([#267](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/267))

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1074,13 +1074,21 @@ export class PicqerService implements OnApplicationBootstrap {
     customerId?: number
   ): OrderInput {
     const shippingAddress = order.shippingAddress;
-
+    const customerFullname = [
+      order.customer?.firstName,
+      order.customer?.lastName,
+    ]
+      .join(' ')
+      .trim();
     let invoiceData: Partial<OrderInput> = {
       invoicename:
         order.billingAddress?.company ||
         order.billingAddress?.fullName ||
         undefined,
-      invoicecontactname: order.billingAddress?.fullName || undefined,
+      invoicecontactname:
+        order.billingAddress?.fullName === customerFullname
+          ? undefined
+          : order.billingAddress?.fullName,
       invoiceaddress:
         order.billingAddress?.streetLine1 || order.billingAddress?.streetLine2
           ? [order.billingAddress.streetLine1, order.billingAddress.streetLine2]
@@ -1097,7 +1105,10 @@ export class PicqerService implements OnApplicationBootstrap {
       idcustomer: customerId, // If none given, this creates a guest order
       reference: order.code,
       deliveryname: shippingAddress.company || shippingAddress.fullName,
-      deliverycontactname: shippingAddress.fullName,
+      deliverycontactname:
+        shippingAddress.fullName === customerFullname
+          ? undefined
+          : shippingAddress.fullName,
       deliveryaddress: `${shippingAddress.streetLine1} ${shippingAddress.streetLine2}`,
       deliveryzipcode: shippingAddress.postalCode,
       deliverycity: shippingAddress.city,


### PR DESCRIPTION
# Description

Check if customer firstname + lastname is the same as the given invoice or billing contactname. If they are the same, don't set a separate contact name in Picqer.

# Screenshots

![image](https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/6604455/66f5f6a5-5b28-4407-ab90-ba229f39bd17)
:arrow_up: This is what we prevent with this PR

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

:package: For publishable packages:
- [x] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [x] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
