### PR TITLE
Fix: Picqer email for guests

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.8
+
+- Send telephone and email address to Picqer for guest orders
+
 # 1.0.7
 
 - Don't set contact name in Picqer if it's the same as customer name ([#267](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/267))

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1104,6 +1104,8 @@ export class PicqerService implements OnApplicationBootstrap {
     return {
       idcustomer: customerId, // If none given, this creates a guest order
       reference: order.code,
+      emailaddress: order.customer?.emailAddress ?? '',
+      telephone: order.customer?.phoneNumber ?? '',
       deliveryname: shippingAddress.company || shippingAddress.fullName,
       deliverycontactname:
         shippingAddress.fullName === customerFullname

--- a/packages/vendure-plugin-picqer/src/api/types.ts
+++ b/packages/vendure-plugin-picqer/src/api/types.ts
@@ -206,6 +206,8 @@ export interface Product {
 export interface OrderInput {
   idcustomer?: number;
   reference: string;
+  emailaddress: string;
+  telephone: string;
   deliveryname?: string;
   deliverycontactname?: string;
   deliveryaddress?: string;


### PR DESCRIPTION
# Description

* Picqer uses a customers email when a registered customer is added to a picqer order. However, for guest orders no customer is connected, so no emailaddress is known to picqer. 
* This PR makes sure emailaddress and telephone numer are added to the order object, not just a customer

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [ ] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [ ] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
