### PR TITLE
Configure Primary Collection Plugin

### DIFF
--- a/packages/vendure-plugin-primary-collection/CHANGELOG.md
+++ b/packages/vendure-plugin-primary-collection/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.0 (2023-10-20)
+
+- Config option `customFieldUITabName` added
+
 # 1.2.2 (2023-10-01)
 
 - Renamed admin ui extention `NgModule` from `SharedExtensionModule` to `PrimaryCollectionSharedExtensionModule`

--- a/packages/vendure-plugin-primary-collection/README.md
+++ b/packages/vendure-plugin-primary-collection/README.md
@@ -14,7 +14,9 @@ Add the plugin to your `vendure-config.ts`:
 
 ```ts
 plugins: [
-  PrimaryCollectionPlugin,
+  PrimaryCollectionPlugin.init({
+    customFieldUITabName: 'Primary Collection',
+  }),
   AdminUiPlugin.init({
     port: 3002,
     route: 'admin',

--- a/packages/vendure-plugin-primary-collection/package.json
+++ b/packages/vendure-plugin-primary-collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-primary-collection",
-  "version": "1.2.2",
+  "version": "1.4.0",
   "description": "Adds a primary collection to all Products by extending vendure's graphql api",
   "author": "Surafel Melese Tariku <surafelmelese09@gmail.com>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-primary-collection/src/primary-collection-plugin.ts
+++ b/packages/vendure-plugin-primary-collection/src/primary-collection-plugin.ts
@@ -3,6 +3,7 @@ import {
   LanguageCode,
   PluginCommonModule,
   RuntimeVendureConfig,
+  Type,
   VendurePlugin,
 } from '@vendure/core';
 import { gql } from 'graphql-tag';
@@ -10,6 +11,13 @@ import { PrimaryCollectionResolver } from './api/primary-collection.resolver';
 import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
 import path from 'path';
 import { PrimaryCollectionHelperService } from './api/primary-collections-helper.service';
+
+export interface PrimaryCollectionPluginConfig {
+  /**
+   * This specifies the admin ui tab name under which the collection dropdown appears
+   */
+  customFieldUITabName?: string;
+}
 
 @VendurePlugin({
   imports: [PluginCommonModule],
@@ -34,6 +42,7 @@ import { PrimaryCollectionHelperService } from './api/primary-collections-helper
       nullable: true,
       ui: {
         component: 'select-primary-collection',
+        tab: PrimaryCollectionPlugin?.config?.customFieldUITabName,
       },
       label: [{ languageCode: LanguageCode.en, value: 'Primary Collection' }],
     });
@@ -41,6 +50,7 @@ import { PrimaryCollectionHelperService } from './api/primary-collections-helper
   },
 })
 export class PrimaryCollectionPlugin {
+  static config: PrimaryCollectionPluginConfig;
   static ui: AdminUiExtension = {
     extensionPath: path.join(__dirname, 'ui'),
     ngModules: [
@@ -51,4 +61,11 @@ export class PrimaryCollectionPlugin {
       },
     ],
   };
+
+  static init(
+    config: PrimaryCollectionPluginConfig
+  ): Type<PrimaryCollectionPlugin> {
+    this.config = config;
+    return this;
+  }
 }

--- a/packages/vendure-plugin-primary-collection/src/ui/select-primary-collection.component.ts
+++ b/packages/vendure-plugin-primary-collection/src/ui/select-primary-collection.component.ts
@@ -38,7 +38,6 @@ export class SelectPrimaryCollectionComponent
     private activatedRoute: ActivatedRoute
   ) {}
   ngOnInit(): void {
-    console.log(this.formControl.value, 'value');
     this.formControl.parent?.parent?.statusChanges.subscribe((s) => {
       if (
         this.formControl.pristine &&


### PR DESCRIPTION
# Description

The changes in this PR allows plugin users to configure the name of the tab of the custom field admin ui component. The config can be passed to the plugin instance like this:
```ts
    PrimaryCollectionPlugin.init({
       customFieldUITabName: 'Primary Collection'
    })
```
This config only becomes relevant if other `CustomFields` are also present on `Product`
# Breaking changes

These changes will not introduce any breaking changes 

# Screenshots

<img width="1470" alt="Screenshot 2023-10-20 at 6 09 37 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/c9e7fe24-f524-4f45-a861-8ed52afa2a0d">

# Checklist

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [X] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [] I have added or updated test cases for important functionality
- [X] I have updated the README if needed

:package: For publishable packages:
- [X] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [X] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
