### PR TITLE
Feat/picqer name fallback

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.12
+
+- Set company as name and full name as contactname for placed orders.
+
 # 1.0.11
 
 - Don't throw insufficient stock errors on incoming webhooks, because it will eventually disable the entire webhook in Picqer

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1,11 +1,13 @@
 import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import {
+  OrderAddress,
+  OrderLineInput,
   UpdateProductInput,
   UpdateProductVariantInput,
 } from '@vendure/common/lib/generated-types';
 import {
   Address,
-  Allocation,
+  assertFound,
   AssetService,
   ChannelService,
   ConfigService,
@@ -34,11 +36,12 @@ import {
   StockLocationService,
   StockMovementEvent,
   TransactionalConnection,
-  assertFound,
 } from '@vendure/core';
 import { StockAdjustment } from '@vendure/core/dist/entity/stock-movement/stock-adjustment.entity';
+import { StockMovement } from '@vendure/core/dist/entity/stock-movement/stock-movement.entity';
 import currency from 'currency.js';
-import { PLUGIN_INIT_OPTIONS, loggerCtx } from '../constants';
+import { throwIfTransitionFailed } from '../../../util/src/order-state-util';
+import { loggerCtx, PLUGIN_INIT_OPTIONS } from '../constants';
 import { PicqerOptions } from '../picqer.plugin';
 import {
   PicqerConfig,
@@ -47,6 +50,7 @@ import {
 } from '../ui/generated/graphql';
 import { PicqerConfigEntity } from './picqer-config.entity';
 import { PicqerClient, PicqerClientInput } from './picqer.client';
+import { picqerHandler } from './picqer.handler';
 import {
   AddressInput,
   CustomerData,
@@ -57,13 +61,8 @@ import {
   PickListWebhookData,
   ProductData,
   ProductInput,
-  Stock as PicqerStockLocation,
   WebhookInput,
 } from './types';
-import { OrderLineInput } from '@vendure/common/lib/generated-types';
-import { picqerHandler } from './picqer.handler';
-import { throwIfTransitionFailed } from '../../../util/src/order-state-util';
-import { StockMovement } from '@vendure/core/dist/entity/stock-movement/stock-movement.entity';
 /**
  * Job to push variants from Vendure to Picqer
  */
@@ -1074,49 +1073,71 @@ export class PicqerService implements OnApplicationBootstrap {
     customerId?: number
   ): OrderInput {
     const shippingAddress = order.shippingAddress;
+    const billingAddress = order.billingAddress;
     const customerFullname = [
       order.customer?.firstName,
       order.customer?.lastName,
     ]
       .join(' ')
       .trim();
-    let invoiceData: Partial<OrderInput> = {
-      invoicename:
-        order.billingAddress?.company ||
-        order.billingAddress?.fullName ||
-        undefined,
-      invoicecontactname:
-        order.billingAddress?.fullName === customerFullname
-          ? undefined
-          : order.billingAddress?.fullName,
-      invoiceaddress:
-        order.billingAddress?.streetLine1 || order.billingAddress?.streetLine2
-          ? [order.billingAddress.streetLine1, order.billingAddress.streetLine2]
-              .join(' ')
-              .trim()
-          : undefined,
-      invoicezipcode: order.billingAddress?.postalCode || undefined,
-      invoicecity: order.billingAddress?.city || undefined,
-      invoicecountry:
-        order.billingAddress?.countryCode?.toUpperCase() || undefined,
-    };
-
+    const [deliveryname, deliverycontactname] =
+      this.getAddressName(shippingAddress);
+    const [invoicename, invoicecontactname] =
+      this.getAddressName(billingAddress);
     return {
       idcustomer: customerId, // If none given, this creates a guest order
       reference: order.code,
       emailaddress: order.customer?.emailAddress ?? '',
       telephone: order.customer?.phoneNumber ?? '',
-      deliveryname: shippingAddress.company || shippingAddress.fullName,
-      deliverycontactname:
-        shippingAddress.fullName === customerFullname
-          ? undefined
-          : shippingAddress.fullName,
-      deliveryaddress: `${shippingAddress.streetLine1} ${shippingAddress.streetLine2}`,
+      deliveryname,
+      deliverycontactname,
+      deliveryaddress: this.getFullAddress(shippingAddress),
       deliveryzipcode: shippingAddress.postalCode,
       deliverycity: shippingAddress.city,
       deliverycountry: shippingAddress.countryCode?.toUpperCase(),
+      // use billing if available, otherwise fallback to shipping address
+      invoicename,
+      invoicecontactname,
+      invoiceaddress:
+        this.getFullAddress(billingAddress) ??
+        this.getFullAddress(shippingAddress),
+      invoicezipcode: billingAddress?.postalCode,
+      invoicecity: billingAddress?.city,
+      invoicecountry: order.billingAddress?.countryCode?.toUpperCase(),
       products,
-      ...invoiceData,
     };
+  }
+
+  /**
+   * Combine street and housenumber to get a full readable address.
+   * Returns undefined if address undefined
+   */
+  private getFullAddress(address?: OrderAddress): string | undefined {
+    if (!address?.streetLine1 && !address?.streetLine2) {
+      return undefined;
+    }
+    return [address.streetLine1 ?? '', address.streetLine2 ?? '']
+      .join(' ')
+      .trim();
+  }
+
+  /**
+   * Get name and contactname for given address
+   * returns [name, contactname]
+   *
+   * If a company is given, use the company as name and the full name as contact name
+   * Otherwise, use the full name as name and no explicit contact name
+   */
+  private getAddressName(address?: OrderAddress): [string, string | undefined] {
+    let name;
+    let contactname;
+    if (address?.company) {
+      name = address.company;
+      contactname = address.fullName;
+    } else {
+      name = address?.fullName ?? '';
+      contactname = undefined;
+    }
+    return [name, contactname];
   }
 }

--- a/packages/vendure-plugin-picqer/src/api/types.ts
+++ b/packages/vendure-plugin-picqer/src/api/types.ts
@@ -208,7 +208,7 @@ export interface OrderInput {
   reference: string;
   emailaddress: string;
   telephone: string;
-  deliveryname?: string;
+  deliveryname: string;
   deliverycontactname?: string;
   deliveryaddress?: string;
   deliveryaddress2?: string;
@@ -216,7 +216,7 @@ export interface OrderInput {
   deliverycity?: string;
   deliveryregion?: string;
   deliverycountry?: string;
-  invoicename?: string;
+  invoicename: string;
   invoicecontactname?: string;
   invoiceaddress?: string;
   invoiceaddress2?: any;

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -207,6 +207,7 @@ describe('Picqer plugin', function () {
       {
         input: {
           fullName: "Martinho's friend",
+          company: 'Pinelab',
           streetLine1: 'Remote location',
           streetLine2: '123',
           city: 'Faraway',
@@ -223,12 +224,12 @@ describe('Picqer plugin', function () {
     expect(variant!.stockAllocated).toBe(3);
     expect(picqerOrderRequest.reference).toBe(createdOrder.code);
     expect(picqerOrderRequest.deliveryname).toBeDefined();
-    expect(picqerOrderRequest.deliverycontactname).toBeDefined();
+    expect(picqerOrderRequest.deliverycontactname).toBeUndefined();
     expect(picqerOrderRequest.deliveryaddress).toBeDefined();
     expect(picqerOrderRequest.deliveryzipcode).toBeDefined();
     expect(picqerOrderRequest.deliverycity).toBeDefined();
     expect(picqerOrderRequest.deliverycountry).toBe('NL');
-    expect(picqerOrderRequest.invoicename).toBe("Martinho's friend");
+    expect(picqerOrderRequest.invoicename).toBe('Pinelab');
     expect(picqerOrderRequest.invoicecontactname).toBe("Martinho's friend");
     expect(picqerOrderRequest.invoicecountry).toBe('NL');
     expect(picqerOrderRequest.invoiceaddress).toBe('Remote location 123');


### PR DESCRIPTION
# Description

* Always have an invoicename and deliveryname when sending orders to picqer, to avoid orders being rejected when sending to Picqer.
* Naming cleanup: Only use contactname if a Company is given, otherwise only set fullname as name, and no additional contactname

# Screenshots

Add screenshots if needed.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have reviewed my own PR, fixed all typo's and removed unused/commented code

:zap: Most of the time:
- [x] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] Have you correctly increased the version number in `package.json` to the next [patch/minor/major](https://semver.org/#summary)?
- [x] Have you added your changes to the changelog? [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
