### PR TITLE
Empty Collection Score Calculation Bug fix

### DIFF
--- a/packages/vendure-plugin-popularity-scores/CHANGELOG.md
+++ b/packages/vendure-plugin-popularity-scores/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0(2023-10-30)
+
+- Add condition to check if a collection is empty as specified in (here)[https://github.com/Pinelab-studio/pinelab-vendure-plugins/issues/279]
+
 # 1.1.0
 
 - Remove unused select statement's while calculating product popularity scores to support Postgres

--- a/packages/vendure-plugin-popularity-scores/README.md
+++ b/packages/vendure-plugin-popularity-scores/README.md
@@ -20,7 +20,7 @@ plugins: [
 
 ## How it works
 
-This plugin exposes an endpoint that can be periodically called: `/order-by-popularity/calculate-scores/your-secret`. This will push a job named `calculate-popularity` to the worker. The worker will handle this message and do the following:
+This plugin exposes an endpoint that can be periodically called: `/popularity-scores/:yourchanneltoken/:yoursecret`. This will push a job named `calculate-popularity` to the worker. The worker will handle this message and do the following:
 
 1. Get all orders from the past 12 months. The amount of months should be configurable.
 2. Calculate the amount of times each Variant has been sold.

--- a/packages/vendure-plugin-popularity-scores/package.json
+++ b/packages/vendure-plugin-popularity-scores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-popularity-scores",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "Sort products and collections by popularity based on previously placed orders",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-popularity-scores/src/sort.service.ts
+++ b/packages/vendure-plugin-popularity-scores/src/sort.service.ts
@@ -140,14 +140,15 @@ export class SortService implements OnModuleInit {
         .map((i) => i.product_id);
 
       const uniqueProductIds = [...new Set(productIds)];
-
-      const summedProductsValue = await productSummingQuery
-        .andWhere('product.id IN (:...ids)', { ids: uniqueProductIds })
-        .getRawOne();
-      productScoreSums.push({
-        id: col.collection_id,
-        score: summedProductsValue.productScoreSum,
-      });
+      if (uniqueProductIds.length) {
+        const summedProductsValue = await productSummingQuery
+          .andWhere('product.id IN (:...ids)', { ids: uniqueProductIds })
+          .getRawOne();
+        productScoreSums.push({
+          id: col.collection_id,
+          score: summedProductsValue.productScoreSum,
+        });
+      }
     }
     await collectionsRepo.save(
       productScoreSums.map((collection) => {


### PR DESCRIPTION
# Description

The change in this PR adds an if statement before trying to sum a collection's products scores. It also updates the readme 
# Breaking changes

Does this PR include any breaking changes we should be aware of? **No**

# Checklist

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [X] I have updated the README if needed

:package: For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
