### PR TITLE
fix(picqer): Complete on `orders.status_changed` webhook

### DIFF
--- a/packages/test/src/shop-utils.ts
+++ b/packages/test/src/shop-utils.ts
@@ -1,4 +1,3 @@
-import { SetOrderBillingAddressMutationVariables } from '@pinelab/vendure-order-client/src';
 import { ErrorResult, Order } from '@vendure/core';
 import { SimpleGraphQLClient } from '@vendure/testing';
 import {
@@ -14,6 +13,7 @@ import {
   TransitionToState,
   TransitionToStateMutation,
   TransitionToStateMutationVariables,
+  SetBillingAddressMutationVariables,
 } from './generated/shop-graphql';
 import { testPaymentMethod } from './test-payment-method';
 
@@ -24,7 +24,7 @@ export async function setAddressAndShipping(
   shopClient: SimpleGraphQLClient,
   shippingMethodId: string | number,
   shippingAddress?: SetShippingAddressMutationVariables,
-  billingAddress?: SetOrderBillingAddressMutationVariables
+  billingAddress?: SetBillingAddressMutationVariables
 ): Promise<void> {
   const finalShippingAddress = shippingAddress ?? {
     input: {
@@ -52,7 +52,7 @@ export async function proceedToArrangingPayment(
   shopClient: SimpleGraphQLClient,
   shippingMethodId: string | number,
   shippingAddress: SetShippingAddressMutationVariables,
-  billingAddress?: SetOrderBillingAddressMutationVariables
+  billingAddress?: SetBillingAddressMutationVariables
 ): Promise<TransitionToStateMutation['transitionOrderToState']> {
   await setAddressAndShipping(
     shopClient,
@@ -118,7 +118,7 @@ export async function createSettledOrder(
     { id: 'T_1', quantity: 1 },
     { id: 'T_2', quantity: 2 },
   ],
-  billingAddress?: SetOrderBillingAddressMutationVariables
+  billingAddress?: SetBillingAddressMutationVariables
 ): Promise<Order> {
   if (authorizeFirst) {
     await shopClient.asUserWithCredentials(

--- a/packages/util/src/order-state-util.ts
+++ b/packages/util/src/order-state-util.ts
@@ -20,7 +20,7 @@ export async function fulfillAll(
   orderService: OrderService,
   order: Order,
   handler: ConfigurableOperationInput
-) {
+): Promise<Fulfillment> {
   const lines = order.lines.map((line) => ({
     orderLineId: line.id,
     quantity: line.quantity,

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0
+
+- Complete orders on `orders.status_changed` webhooks, instead of `picklists.closed` hooks. ([#281](https://github.com/Pinelab-studio/pinelab-vendure-plugins/pull/281))
+
 # 1.0.13
 
 - Patch priority order of names when sending to Picqer: invoicename ?? deliveryname ?? customerFullname

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -3,7 +3,7 @@ import { Logger } from '@vendure/core';
 import { Request } from 'express';
 import { loggerCtx } from '../constants';
 import { PicqerService } from './picqer.service';
-import { OrderCompletedWebhook } from './types';
+import { IncomingWebhook } from './types';
 
 @Controller('picqer')
 export class PicqerController {
@@ -12,7 +12,7 @@ export class PicqerController {
   @Post('hooks/:channelToken')
   async webhook(
     @Req() req: Request,
-    @Body() body: OrderCompletedWebhook,
+    @Body() body: IncomingWebhook,
     @Headers('X-Picqer-Signature') signature: string,
     @Param('channelToken') channelToken: string
   ): Promise<void> {
@@ -34,14 +34,6 @@ export class PicqerController {
         `Error handling incoming hook '${body.event}': ${e.message}`,
         loggerCtx
       );
-
-      // FIXME: For now, don't throw insufficient stock error, to prevent webhook disabling
-      if (
-        e.message ===
-        'INSUFFICIENT_STOCK_ON_HAND_ERROR: INSUFFICIENT_STOCK_ON_HAND_ERROR'
-      ) {
-        return;
-      }
       throw e;
     }
   }

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -31,8 +31,9 @@ export class PicqerController {
         signature,
       });
     } catch (e: any) {
+      const orderCode = (body as any)?.data?.reference;
       Logger.error(
-        `Error handling incoming hook '${body.event}': ${e.message}`,
+        `Error handling incoming hook '${body.event}' (order code: ${orderCode}): ${e.message}`,
         loggerCtx,
         util.inspect(e)
       );

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -3,7 +3,7 @@ import { Logger } from '@vendure/core';
 import { Request } from 'express';
 import { loggerCtx } from '../constants';
 import { PicqerService } from './picqer.service';
-import { IncomingWebhook } from './types';
+import { OrderCompletedWebhook } from './types';
 
 @Controller('picqer')
 export class PicqerController {
@@ -12,7 +12,7 @@ export class PicqerController {
   @Post('hooks/:channelToken')
   async webhook(
     @Req() req: Request,
-    @Body() body: IncomingWebhook,
+    @Body() body: OrderCompletedWebhook,
     @Headers('X-Picqer-Signature') signature: string,
     @Param('channelToken') channelToken: string
   ): Promise<void> {

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -4,6 +4,7 @@ import { Request } from 'express';
 import { loggerCtx } from '../constants';
 import { PicqerService } from './picqer.service';
 import { IncomingWebhook } from './types';
+import util from 'util';
 
 @Controller('picqer')
 export class PicqerController {
@@ -32,7 +33,8 @@ export class PicqerController {
     } catch (e: any) {
       Logger.error(
         `Error handling incoming hook '${body.event}': ${e.message}`,
-        loggerCtx
+        loggerCtx,
+        util.inspect(e)
       );
       throw e;
     }

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -55,7 +55,7 @@ import {
   AddressInput,
   CustomerData,
   CustomerInput,
-  IncomingWebhook,
+  OrderCompletedWebhook,
   OrderInput,
   OrderProductInput,
   PickListWebhookData,
@@ -221,10 +221,7 @@ export class PicqerService implements OnApplicationBootstrap {
     if (!client) {
       return;
     }
-    const eventsToRegister: WebhookInput['event'][] = [
-      'products.free_stock_changed',
-      'picklists.closed',
-    ];
+    const eventsToRegister: WebhookInput['event'][] = ['orders.completed'];
     for (const hookEvent of eventsToRegister) {
       // Use first 4 digits of webhook secret as name, so we can identify the hook
       const webhookName = `Vendure ${client.webhookSecret.slice(0, 4)}`;
@@ -264,7 +261,7 @@ export class PicqerService implements OnApplicationBootstrap {
    */
   async handleHook(input: {
     channelToken: string;
-    body: IncomingWebhook;
+    body: OrderCompletedWebhook;
     rawBody: string;
     signature: string;
   }): Promise<void> {

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -375,7 +375,7 @@ export class PicqerService implements OnApplicationBootstrap {
     }
     if (data.status !== 'cancelled' && data.status !== 'completed') {
       Logger.info(
-        `This plugin doesn't handle incoming status ${data.status}, skipping status for order ${order.code}`,
+        `Not handling incoming status '${data.status}'. Skipping status update for order ${order.code}`,
         loggerCtx
       );
     }

--- a/packages/vendure-plugin-picqer/src/api/types.ts
+++ b/packages/vendure-plugin-picqer/src/api/types.ts
@@ -134,7 +134,7 @@ export interface OrderData {
   full_invoice_address: string;
   telephone: any;
   emailaddress: any;
-  reference: any;
+  reference: string;
   customer_remarks: any;
   pickup_point_data: any;
   partialdelivery: boolean;
@@ -143,7 +143,7 @@ export interface OrderData {
   preferred_delivery_date: any;
   discount: number;
   calculatevat: boolean;
-  status: string;
+  status: 'cancelled' | 'completed' | 'processing' | 'concept' | 'expecteds';
   public_status_page: string;
   created: string;
   updated: string;
@@ -261,87 +261,41 @@ export interface PickLocation {
 
 export interface WebhookInput {
   name: string;
-  event: 'orders.completed';
+  event: WebhookEvent;
   address: string;
   secret: string;
 }
 
 // ------------- Webhook types ------------
 
-export interface OrderCompletedWebhook {
-  idhook: number
-  name: 'orders.completed'
-  event: string
-  event_triggered_at: string
-  data: Data
+export type IncomingWebhook =
+  | IncomingProductWebhook
+  | IncomingOrderStatusWebhook;
+export type WebhookEvent =
+  | 'products.free_stock_changed'
+  | 'orders.status_changed';
+
+export interface WebhookData {
+  idhook: number;
+  name: string;
+  event: WebhookEvent;
+  address: string;
+  active: boolean;
+  secret: boolean | string;
 }
 
-export interface Data {
-  idorder: number
-  idcustomer: number
-  orderid: string
-  deliveryname: string
-  deliverycontactname: string
-  deliveryaddress: string
-  deliveryaddress2: any
-  deliveryzipcode: string
-  deliverycity: string
-  deliveryregion: any
-  deliverycountry: string
-  invoicename: string
-  invoicecontactname: string
-  invoiceaddress: string
-  invoiceaddress2: any
-  invoicezipcode: string
-  invoicecity: string
-  invoiceregion: any
-  invoicecountry: string
-  reference: string
-  partialdelivery: boolean
-  discount: number
-  status: string
-  public_status_page: string
-  created: string
-  updated: string
-  products: Product[]
-  tags: Tags
-  orderfields: Orderfield[]
+export interface IncomingOrderStatusWebhook {
+  idhook: number;
+  name: string;
+  event: 'orders.status_changed';
+  event_triggered_at: string;
+  data: OrderData;
 }
 
-export interface Product {
-  idproduct: number
-  idvatgroup: number
-  productcode: string
-  name: string
-  remarks: string
-  price: number
-  amount: number
-  weight: number
-}
-
-export interface Tags {
-  TopWebshop: TopWebshop
-  SummerProducts: SummerProducts
-}
-
-export interface TopWebshop {
-  idtag: number
-  title: string
-  color: string
-  inherit: boolean
-  textColor: string
-}
-
-export interface SummerProducts {
-  idtag: number
-  title: string
-  color: string
-  inherit: boolean
-  textColor: string
-}
-
-export interface Orderfield {
-  idorderfield: number
-  title: string
-  value: string
+export interface IncomingProductWebhook {
+  idhook: number;
+  name: string;
+  event: 'products.free_stock_changed';
+  event_triggered_at: string;
+  data: ProductData;
 }

--- a/packages/vendure-plugin-picqer/src/api/types.ts
+++ b/packages/vendure-plugin-picqer/src/api/types.ts
@@ -16,42 +16,6 @@ export interface VatGroup {
   percentage: number;
 }
 
-export type WebhookEvent = 'products.free_stock_changed' | 'picklists.closed';
-
-export interface WebhookData {
-  idhook: number;
-  name: string;
-  event: WebhookEvent;
-  address: string;
-  active: boolean;
-  secret: boolean | string;
-}
-
-export interface WebhookInput {
-  name: string;
-  event: WebhookEvent;
-  address: string;
-  secret: string;
-}
-
-export type IncomingWebhook = IncomingProductWebhook | IncomingPicklistWebhook;
-
-export interface IncomingPicklistWebhook {
-  idhook: number;
-  name: string;
-  event: 'picklists.closed';
-  event_triggered_at: string;
-  data: PickListWebhookData;
-}
-
-export interface IncomingProductWebhook {
-  idhook: number;
-  name: string;
-  event: 'products.free_stock_changed';
-  event_triggered_at: string;
-  data: ProductData;
-}
-
 export interface ProductData {
   idproduct: number;
   idvatgroup: number;
@@ -293,4 +257,91 @@ export interface PickLocation {
   idlocation: number;
   name: string;
   amount: number;
+}
+
+export interface WebhookInput {
+  name: string;
+  event: 'orders.completed';
+  address: string;
+  secret: string;
+}
+
+// ------------- Webhook types ------------
+
+export interface OrderCompletedWebhook {
+  idhook: number
+  name: 'orders.completed'
+  event: string
+  event_triggered_at: string
+  data: Data
+}
+
+export interface Data {
+  idorder: number
+  idcustomer: number
+  orderid: string
+  deliveryname: string
+  deliverycontactname: string
+  deliveryaddress: string
+  deliveryaddress2: any
+  deliveryzipcode: string
+  deliverycity: string
+  deliveryregion: any
+  deliverycountry: string
+  invoicename: string
+  invoicecontactname: string
+  invoiceaddress: string
+  invoiceaddress2: any
+  invoicezipcode: string
+  invoicecity: string
+  invoiceregion: any
+  invoicecountry: string
+  reference: string
+  partialdelivery: boolean
+  discount: number
+  status: string
+  public_status_page: string
+  created: string
+  updated: string
+  products: Product[]
+  tags: Tags
+  orderfields: Orderfield[]
+}
+
+export interface Product {
+  idproduct: number
+  idvatgroup: number
+  productcode: string
+  name: string
+  remarks: string
+  price: number
+  amount: number
+  weight: number
+}
+
+export interface Tags {
+  TopWebshop: TopWebshop
+  SummerProducts: SummerProducts
+}
+
+export interface TopWebshop {
+  idtag: number
+  title: string
+  color: string
+  inherit: boolean
+  textColor: string
+}
+
+export interface SummerProducts {
+  idtag: number
+  title: string
+  color: string
+  inherit: boolean
+  textColor: string
+}
+
+export interface Orderfield {
+  idorderfield: number
+  title: string
+  value: string
 }

--- a/packages/vendure-plugin-picqer/test/dev-server.ts
+++ b/packages/vendure-plugin-picqer/test/dev-server.ts
@@ -12,7 +12,7 @@ import {
   registerInitializer,
 } from '@vendure/testing';
 import path from 'path';
-import { updateVariants } from '../../test/src/admin-utils';
+import { updateVariants, addShippingMethod } from '../../test/src/admin-utils';
 import { GlobalFlag } from '../../test/src/generated/admin-graphql';
 import { initialData } from '../../test/src/initial-data';
 import { createSettledOrder } from '../../test/src/shop-utils';
@@ -20,6 +20,7 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
 import { PicqerPlugin } from '../src';
 import { UPSERT_CONFIG } from '../src/ui/queries';
 import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
+import { picqerHandler } from '../dist/vendure-plugin-picqer/src/api/picqer.handler';
 
 (async () => {
   require('dotenv').config();
@@ -57,11 +58,11 @@ import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
       AdminUiPlugin.init({
         port: 3002,
         route: 'admin',
-        app: compileUiExtensions({
-          outputPath: path.join(__dirname, '__admin-ui'),
-          extensions: [PicqerPlugin.ui],
-          devMode: true,
-        }),
+        // app: compileUiExtensions({
+        //   outputPath: path.join(__dirname, '__admin-ui'),
+        //   extensions: [PicqerPlugin.ui],
+        //   devMode: true,
+        // }),
       }),
     ],
   });
@@ -79,6 +80,7 @@ import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
     productsCsvPath: '../test/src/products-import.csv',
   });
   await adminClient.asSuperAdmin();
+  await addShippingMethod(adminClient, picqerHandler.code);
   await adminClient.query(UPSERT_CONFIG, {
     input: {
       enabled: true,
@@ -95,7 +97,7 @@ import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
     { id: 'T_3', trackInventory: GlobalFlag.True },
     { id: 'T_4', trackInventory: GlobalFlag.True },
   ]);
-  const order = await createSettledOrder(shopClient, 1, true, [
+  const order = await createSettledOrder(shopClient, 3, true, [
     { id: 'T_1', quantity: 3 },
   ]);
 })();

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -24,7 +24,7 @@ import { initialData } from '../../test/src/initial-data';
 import { createSettledOrder } from '../../test/src/shop-utils';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
 import { PicqerPlugin } from '../src';
-import { IncomingPicklistWebhook, VatGroup } from '../src';
+import { VatGroup, IncomingOrderStatusWebhook } from '../src';
 import { FULL_SYNC, GET_CONFIG, UPSERT_CONFIG } from '../src/ui/queries';
 import { createSignature } from './test-helpers';
 import { Order } from '@vendure/core';
@@ -144,13 +144,13 @@ describe('Picqer plugin', function () {
   it('Should have created hooks when config was updated', async () => {
     // Expect 1 created hook: stock change
     await expect(createdHooks.length).toBe(2);
-    await expect(createdHooks[0].event).toBe('products.free_stock_changed');
+    await expect(createdHooks[0].event).toBe('orders.status_changed');
     await expect(createdHooks[0].address).toBe(
       `https://example-vendure.io/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`
     );
     await expect(createdHooks[0].secret).toBeDefined();
     await expect(createdHooks[0].name).toBeDefined();
-    await expect(createdHooks[1].event).toBe('picklists.closed');
+    await expect(createdHooks[1].event).toBe('products.free_stock_changed');
   });
 
   it('Should get Picqer config after upsert', async () => {
@@ -220,8 +220,8 @@ describe('Picqer plugin', function () {
     const variant = (await getAllVariants(adminClient)).find(
       (v) => v.id === 'T_1'
     );
-    expect(variant!.stockOnHand).toBe(100);
-    expect(variant!.stockAllocated).toBe(3);
+    expect(variant!.stockOnHand).toBe(97);
+    expect(variant!.stockAllocated).toBe(0);
     expect(picqerOrderRequest.reference).toBe(createdOrder.code);
     expect(picqerOrderRequest.deliveryname).toBeDefined();
     expect(picqerOrderRequest.deliverycontactname).toBeUndefined();
@@ -245,51 +245,14 @@ describe('Picqer plugin', function () {
     });
   });
 
-  it('Should update to "PartiallyDelivered" when 2 of 3 items are shipped', async () => {
+  it('Should update to "Delivered" on incoming order status "completed"', async () => {
     const mockIncomingWebhook = {
-      event: 'picklists.closed',
+      event: 'orders.status_changed',
       data: {
         reference: createdOrder?.code,
-        products: [
-          { productcode: 'L2201308', amountpicked: 2 }, // Only 2 of 3 are picked
-        ],
+        status: 'completed',
       },
-    } as Partial<IncomingPicklistWebhook>;
-    await adminClient.fetch(
-      `http://localhost:3050/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(mockIncomingWebhook),
-        headers: {
-          'X-Picqer-Signature': createSignature(
-            mockIncomingWebhook,
-            'test-api-key'
-          ),
-        },
-      }
-    );
-    const order = await getOrder(adminClient, createdOrder?.id as string);
-    expect(order!.state).toBe('PartiallyDelivered');
-  });
-
-  it('Should have updated stock after 1 item was shipped', async () => {
-    const variant = (await getAllVariants(adminClient)).find(
-      (v) => v.id === 'T_1'
-    );
-    expect(variant!.stockOnHand).toBe(98);
-    expect(variant!.stockAllocated).toBe(1);
-  });
-
-  it('Should update to "Delivered" when 3 of 3 items are shipped', async () => {
-    const mockIncomingWebhook = {
-      event: 'picklists.closed',
-      data: {
-        reference: createdOrder?.code,
-        products: [
-          { productcode: 'L2201308', amountpicked: 1 }, // last one to complete the order
-        ],
-      },
-    } as Partial<IncomingPicklistWebhook>;
+    } as Partial<IncomingOrderStatusWebhook>;
     await adminClient.fetch(
       `http://localhost:3050/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`,
       {
@@ -307,12 +270,29 @@ describe('Picqer plugin', function () {
     expect(order!.state).toBe('Delivered');
   });
 
-  it('Should have updated stock after all items are shipped', async () => {
-    const variant = (await getAllVariants(adminClient)).find(
-      (v) => v.id === 'T_1'
+  it('Should update to "Canceled" on incoming order status "cancelled"', async () => {
+    const mockIncomingWebhook = {
+      event: 'orders.status_changed',
+      data: {
+        reference: createdOrder?.code,
+        status: 'cancelled',
+      },
+    } as Partial<IncomingOrderStatusWebhook>;
+    await adminClient.fetch(
+      `http://localhost:3050/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(mockIncomingWebhook),
+        headers: {
+          'X-Picqer-Signature': createSignature(
+            mockIncomingWebhook,
+            'test-api-key'
+          ),
+        },
+      }
     );
-    expect(variant!.stockOnHand).toBe(97); // 100 - 3 shipped
-    expect(variant!.stockAllocated).toBe(0);
+    const order = await getOrder(adminClient, createdOrder?.id as string);
+    expect(order!.state).toBe('Cancelled');
   });
 
   /**


### PR DESCRIPTION
# Description

Right now we handle order statusses in Vendure based on the `picklist.closed` webhook, but this doesnt always work: Sometimes, products are added/removed in Picqer, and the Vendure order isn't updated.

To not overcomplicate things, we will move Vendure orders based on the `orders.status_changed` webhook.
1. Vendure orders are Fulfilled right after they are placed and sent to Picqer
2. `completed` will move the order to Shipped and then to Delivered in Vendure
3.  `cancelled` will move the order to the Cancelled state.

# Breaking changes

Old `picklists.closed` webhooks need to be manually disabled in Picqer.

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
