### PR TITLE
WIP Make Stripe Subscription History List Entry Work

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0 (2023-11-06)
+
+- extended the `HistoryEntryList` enum to make stripe subscription  custom history entry component work
+
 # 2.1.0 (2023-11-02)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.1.0",
+  "version": "2.2x.0",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-stripe-subscription/src/api/graphql-schema.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/graphql-schema.ts
@@ -60,3 +60,9 @@ export const shopSchemaExtensions = gql`
     createStripeSubscriptionIntent: StripeSubscriptionIntent!
   }
 `;
+
+export const adminApiExtension = gql`
+  extend enum HistoryEntryType {
+    STRIPE_SUBSCRIPTION_NOTIFICATION
+  }
+`;

--- a/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.plugin.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/stripe-subscription.plugin.ts
@@ -1,7 +1,7 @@
 import { PluginCommonModule, VendurePlugin } from '@vendure/core';
 import { PLUGIN_INIT_OPTIONS } from './constants';
 import { SubscriptionStrategy } from './api/strategy/subscription-strategy';
-import { shopSchemaExtensions } from './api/graphql-schema';
+import { adminApiExtension, shopSchemaExtensions } from './api/graphql-schema';
 import { rawBodyMiddleware } from '../../util/src/raw-body.middleware';
 import { DefaultSubscriptionStrategy } from './api/strategy/default-subscription-strategy';
 import path from 'path';
@@ -28,6 +28,9 @@ export interface StripeSubscriptionPluginOptions {
   shopApiExtensions: {
     schema: shopSchemaExtensions,
     resolvers: [StripeSubscriptionShopResolver],
+  },
+  adminApiExtensions: {
+    schema: adminApiExtension,
   },
   controllers: [StripeSubscriptionController],
   providers: [


### PR DESCRIPTION
# Description

The change in this PR adds an api extension to admin-api to make stripe subscription history list Entry work. 

# Breaking changes

Does this PR include any breaking changes we should be aware of? **NO**

# Screenshots

<img width="919" alt="Screenshot 2023-11-06 at 11 55 55 AM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/78721ea5-b300-4542-94c8-481fe4c35466">

# Checklist

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
