### PR TITLE
fix(picqer): alwasy push active products and improved logging

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.2.0 (2023-11-02)
+
+- Always created products as active in Picqer
+- Log order code for failed pushes of orders to Picqer
+
 # 2.1.0 (2023-11-02)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import {
   OrderAddress,
-  OrderLineInput,
   UpdateProductInput,
   UpdateProductVariantInput,
 } from '@vendure/common/lib/generated-types';
@@ -16,7 +15,6 @@ import {
   ErrorResult,
   EventBus,
   ForbiddenError,
-  Fulfillment,
   FulfillmentStateTransitionError,
   ID,
   JobQueue,
@@ -25,7 +23,6 @@ import {
   Order,
   OrderPlacedEvent,
   OrderService,
-  OrderStateTransitionError,
   ProductEvent,
   ProductService,
   ProductVariant,
@@ -43,10 +40,8 @@ import {
 import { StockAdjustment } from '@vendure/core/dist/entity/stock-movement/stock-adjustment.entity';
 import { StockMovement } from '@vendure/core/dist/entity/stock-movement/stock-movement.entity';
 import currency from 'currency.js';
-import {
-  fulfillAll,
-  throwIfTransitionFailed,
-} from '../../../util/src/order-state-util';
+import util from 'util';
+import { fulfillAll } from '../../../util/src/order-state-util';
 import { loggerCtx, PLUGIN_INIT_OPTIONS } from '../constants';
 import { PicqerOptions } from '../picqer.plugin';
 import {
@@ -61,17 +56,14 @@ import {
   AddressInput,
   CustomerData,
   CustomerInput,
-  IncomingOrderStatusWebhook,
   IncomingWebhook,
   OrderData,
   OrderInput,
   OrderProductInput,
-  PickListWebhookData,
   ProductData,
   ProductInput,
   WebhookEvent,
 } from './types';
-import util from 'util';
 
 /**
  * Job to push variants from Vendure to Picqer
@@ -89,8 +81,6 @@ interface PushVariantsJob {
 interface PullStockLevelsJob {
   action: 'pull-stock-levels';
   ctx: SerializedRequestContext;
-  variantIds?: ID[];
-  productId?: ID;
 }
 
 /**
@@ -132,32 +122,40 @@ export class PicqerService implements OnApplicationBootstrap {
       name: 'picqer-sync',
       process: async ({ data }) => {
         const ctx = RequestContext.deserialize(data.ctx);
-        try {
-          if (data.action === 'push-variants') {
-            await this.handlePushVariantsJob(
-              ctx,
-              data.variantIds,
-              data.productId
+        if (data.action === 'push-variants') {
+          await this.handlePushVariantsJob(
+            ctx,
+            data.variantIds,
+            data.productId
+          ).catch((e: any) => {
+            throw Error(
+              `Failed to push variants to Picqer (variants: ${data.variantIds?.join(
+                ','
+              )}, product: ${data.productId} }): ${e?.message}`
             );
-          } else if (data.action === 'pull-stock-levels') {
-            await this.handlePullStockLevelsJob(ctx);
-          } else if (data.action === 'push-order') {
-            await this.handlePushOrderToPicqer(ctx, data.orderId);
-          } else {
-            Logger.error(
-              `Invalid job action: ${(data as any).action}`,
-              loggerCtx
+          });
+        } else if (data.action === 'pull-stock-levels') {
+          await this.handlePullStockLevelsJob(ctx).catch((e: any) => {
+            throw Error(
+              `Failed to pull stock levels from  Picqer: ${e?.message}`
             );
-          }
-          Logger.info(`Successfully handled job '${data.action}'`, loggerCtx);
-        } catch (e: any) {
-          // Only log a warning, because this is a background function that will be retried by the JobQueue
-          const orderCode = Logger.warn(
-            `Failed to handle job '${data.action}': ${e?.message}`,
+          });
+        } else if (data.action === 'push-order') {
+          const order = await this.orderService.findOne(ctx, data.orderId);
+          await this.handlePushOrderToPicqer(ctx, data.orderId).catch(
+            (e: any) => {
+              throw Error(
+                `Failed to push order ${order?.code} (${data.orderId}) to Picqer: ${e?.message}`
+              );
+            }
+          );
+        } else {
+          Logger.error(
+            `Invalid job action: ${(data as any).action}`,
             loggerCtx
           );
-          throw e;
         }
+        Logger.info(`Successfully handled job '${data.action}'`, loggerCtx);
       },
     });
     // Listen for Variant creation or update
@@ -170,7 +168,7 @@ export class PicqerService implements OnApplicationBootstrap {
         }
         // Only update in Picqer if one of these fields was updated
         const shouldUpdate = (input as UpdateProductVariantInput[])?.some(
-          (v) => v.enabled ?? v.translations ?? v.price ?? v.taxCategoryId
+          (v) => v.translations ?? v.price ?? v.taxCategoryId
         );
         if (!shouldUpdate) {
           Logger.info(
@@ -1118,7 +1116,7 @@ export class PicqerService implements OnApplicationBootstrap {
       name: variant.name || variant.sku, // use SKU if no name set
       price: currency(variant.price / 100).value, // Convert to float with 2 decimals
       productcode: variant.sku,
-      active: variant.enabled,
+      active: true,
     };
   }
 

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -184,18 +184,6 @@ export class PicqerService implements OnApplicationBootstrap {
           entities.map((v) => v.id)
         );
       });
-    // Listen for Product events. Only push variants when product is enabled/disabled. Other changes are handled by the variant events.
-    this.eventBus
-      .ofType(ProductEvent)
-      .subscribe(async ({ ctx, entity, type, input }) => {
-        // Only push if `enabled` is updated
-        if (
-          type === 'updated' &&
-          (input as UpdateProductInput).enabled !== undefined
-        ) {
-          await this.addPushVariantsJob(ctx, undefined, entity.id);
-        }
-      });
     // Listen for Order placed events
     this.eventBus.ofType(OrderPlacedEvent).subscribe(async ({ ctx, order }) => {
       await this.addPushOrderJob(ctx, order);

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -383,35 +383,6 @@ describe('Picqer plugin', function () {
     expect(updatedProduct!.price).toBe(123.45);
   });
 
-  it('Disables a product in Picqer when disabled in Vendure', async () => {
-    let pushProductPayloads: any[] = [];
-    // Mock vatgroups GET
-    nock(nockBaseUrl)
-      .get('/vatgroups')
-      .reply(200, [{ idvatgroup: 12, percentage: 20 }] as VatGroup[]);
-    // Mock products GET multiple times
-    nock(nockBaseUrl)
-      .get(/.products*/)
-      .reply(200, [])
-      .persist();
-    // Mock product POST multiple times
-    nock(nockBaseUrl)
-      .post(/.products*/, (reqBody) => {
-        pushProductPayloads.push(reqBody);
-        return true;
-      })
-      .reply(200, { idproduct: 'mockId' })
-      .persist();
-    const product = await updateProduct(adminClient, {
-      id: 'T_1',
-      enabled: false,
-    });
-    await new Promise((r) => setTimeout(r, 500)); // Wait for job queue to finish
-    expect(product?.enabled).toBe(false);
-    // expect every variant to be disabled (active=false)
-    expect(pushProductPayloads!.every((p) => p.active === false)).toBe(true);
-  });
-
   it('Should update stock level on incoming webhook', async () => {
     const body = {
       event: 'products.free_stock_changed',


### PR DESCRIPTION
# Description

* Improved logging, so that when a push to Picqer job fails, we can find it by order code
* Always create products as active in Picqer. Disabled in Picqer has a different meaning than disabled in Vendure

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [x] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
