### PR TITLE
Vendure order client updates

### DIFF
--- a/packages/vendure-order-client/CHANGELOG.md
+++ b/packages/vendure-order-client/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.6.0 (2023-13-09)
+
+- Make VendureOrderClient.updateEligibleShippingMethods public
+- export the store helpers
+
 # 2.5.0 (2023-13-09)
 
 - Export vendure graphql types

--- a/packages/vendure-order-client/package.json
+++ b/packages/vendure-order-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-order-client",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A tiny, framework agnostic client for managing active orders and checkout with Vendure.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-order-client/src/index.ts
+++ b/packages/vendure-order-client/src/index.ts
@@ -1,3 +1,4 @@
 export * from './vendure-order-client';
 export * from './vendure-order-events';
 export * from './graphql-generated-types';
+export * from './store-helpers';

--- a/packages/vendure-order-client/src/vendure-order-client.ts
+++ b/packages/vendure-order-client/src/vendure-order-client.ts
@@ -147,7 +147,7 @@ export class VendureOrderClient<A = unknown> {
       productVariantIds: [productVariantId],
       quantity,
     });
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -190,12 +190,12 @@ export class VendureOrderClient<A = unknown> {
         quantity: -adjustment, // adjustment is negative, so invert it
       });
     }
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
   async removeOrderLine(orderLineId: Id): Promise<ActiveOrder<A>> {
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return await this.adjustOrderLine(orderLineId, 0);
   }
 
@@ -218,7 +218,7 @@ export class VendureOrderClient<A = unknown> {
       productVariantIds: allVariantIds,
       quantity: totalQuantity,
     });
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -235,7 +235,7 @@ export class VendureOrderClient<A = unknown> {
     this.eventBus.emit('coupon-code-applied', {
       couponCode,
     });
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -257,7 +257,7 @@ export class VendureOrderClient<A = unknown> {
     this.eventBus.emit('coupon-code-removed', {
       couponCode,
     });
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -273,7 +273,7 @@ export class VendureOrderClient<A = unknown> {
       setCustomerForOrder as ActiveOrder<A>
     );
     setResult(this.$activeOrder, activeOrder);
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -289,7 +289,7 @@ export class VendureOrderClient<A = unknown> {
       setOrderShippingAddress as ActiveOrder<A>
     );
     setResult(this.$activeOrder, activeOrder);
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -303,7 +303,7 @@ export class VendureOrderClient<A = unknown> {
       setOrderBillingAddress as ActiveOrder<A>
     );
     setResult(this.$activeOrder, activeOrder);
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -319,7 +319,7 @@ export class VendureOrderClient<A = unknown> {
       setOrderShippingMethod as ActiveOrder<A>
     );
     setResult(this.$activeOrder, activeOrder);
-    void this.updateEligibleShippingMehods();
+    void this.updateEligibleShippingMethods();
     return activeOrder;
   }
 
@@ -479,7 +479,7 @@ export class VendureOrderClient<A = unknown> {
   }
 
   @HandleLoadingState('$eligibleShippingMethods')
-  private async updateEligibleShippingMehods(): Promise<void> {
+  async updateEligibleShippingMethods(): Promise<void> {
     const { eligibleShippingMethods } = await this.rawRequest<{
       eligibleShippingMethods: ShippingMethodQuote[];
     }>(this.queries.GET_ELIGIBLE_SHIPPING_METHODS);


### PR DESCRIPTION
# Description

The changes in this PR export the store helpers (`setResult`  and `HandleLoadingState`) and also makes `VendureOrderClient.updateEligibleShippingMethods` method public.
# Breaking changes

Does this PR include any breaking changes we should be aware of? **NO**

# Checklist

:pushpin: Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
