### PR TITLE
Feat/sendcloud fulfilment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,4 +65,5 @@ jobs:
       - name: Build
         run: cd packages/${{ matrix.package }} && yarn build
       - name: Test
-        run: cd packages/${{ matrix.package }} && yarn test
+        # TEST_ADMIN_UI=true enables Admin UI compilation in tests
+        run: TEST_ADMIN_UI=true cd packages/${{ matrix.package }} && yarn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,4 +66,6 @@ jobs:
         run: cd packages/${{ matrix.package }} && yarn build
       - name: Test
         # TEST_ADMIN_UI=true enables Admin UI compilation in tests
-        run: TEST_ADMIN_UI=true cd packages/${{ matrix.package }} && yarn test
+        run: |
+          cd packages/${{ matrix.package }}
+          TEST_ADMIN_UI=true yarn test

--- a/packages/vendure-plugin-e-boekhouden/test/e-boekhouden.spec.ts
+++ b/packages/vendure-plugin-e-boekhouden/test/e-boekhouden.spec.ts
@@ -144,13 +144,15 @@ describe('E-boekhouden plugin', function () {
     expect(payloads[1]).toContain(eBoekhoudenConfig.contraAccount);
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(
-      __dirname,
-      EBoekhoudenPlugin.ui
-    );
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        EBoekhoudenPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
+++ b/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
@@ -399,13 +399,15 @@ describe('Goedgepickt plugin', function () {
     expect(payload).toBeDefined();
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(
-      __dirname,
-      GoedgepicktPlugin.ui
-    );
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        GoedgepicktPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -204,10 +204,12 @@ describe('Invoices plugin', function () {
     expect(res.status).toBe(403);
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(__dirname, InvoicePlugin.ui);
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(__dirname, InvoicePlugin.ui);
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-metrics/test/metrics.spec.ts
+++ b/packages/vendure-plugin-metrics/test/metrics.spec.ts
@@ -117,10 +117,12 @@ describe('Metrics', () => {
     expect(salesPerProduct.series[1].values[12]).toEqual(6);
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(__dirname, MetricsPlugin.ui);
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(__dirname, MetricsPlugin.ui);
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-modify-customer-orders/test/modify-customer-orders.spec.ts
+++ b/packages/vendure-plugin-modify-customer-orders/test/modify-customer-orders.spec.ts
@@ -99,13 +99,15 @@ describe('Customer managed groups', function () {
     }
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(
-      __dirname,
-      ModifyCustomerOrdersPlugin.ui
-    );
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        ModifyCustomerOrdersPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-myparcel/test/e2e.spec.ts
+++ b/packages/vendure-plugin-myparcel/test/e2e.spec.ts
@@ -276,10 +276,12 @@ describe('MyParcel', () => {
     expect(config.updateMyparcelConfig).toEqual(null);
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(__dirname, MyparcelPlugin.ui);
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(__dirname, MyparcelPlugin.ui);
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-order-export/test/order-export.spec.ts
+++ b/packages/vendure-plugin-order-export/test/order-export.spec.ts
@@ -86,13 +86,16 @@ describe('Order export plugin', function () {
     expect(res.headers.get('Content-type')).toContain('text/csv');
     expect(res.body.pipe).toBeDefined();
   });
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(
-      __dirname,
-      OrderExportPlugin.ui
-    );
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        OrderExportPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(() => {
     return server.destroy();

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -449,10 +449,12 @@ describe('Picqer plugin', function () {
     expect(res.status).toBe(403);
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(__dirname, PicqerPlugin.ui);
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(__dirname, PicqerPlugin.ui);
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-primary-collection/test/primary-collection.spec.ts
+++ b/packages/vendure-plugin-primary-collection/test/primary-collection.spec.ts
@@ -159,13 +159,15 @@ describe('Product Primary Collection', function () {
     expect(t3Product.primaryCollection).not.toBeNull();
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(
-      __dirname,
-      PrimaryCollectionPlugin.ui
-    );
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        PrimaryCollectionPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-sendcloud/CHANGELOG.md
+++ b/packages/vendure-plugin-sendcloud/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0 (2023-11-16)
+
+- Fulfill on order placement, to prevent stock levels going out of sync
+
 # 1.1.0 (2023-10-24)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-sendcloud/package.json
+++ b/packages/vendure-plugin-sendcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-sendcloud",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Vendure plugin for syncing orders with SendCloud",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.controller.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.controller.ts
@@ -64,8 +64,7 @@ export class SendcloudController {
     await this.sendcloudService.updateOrderStatus(
       ctx,
       status,
-      body.parcel.order_number,
-      body.parcel.tracking_number
+      body.parcel.order_number
     );
   }
 }

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.handler.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.handler.ts
@@ -9,18 +9,12 @@ export const sendcloudHandler = new FulfillmentHandler({
       value: 'Send order to SendCloud',
     },
   ],
-  args: {
-    trackingNumber: {
-      type: 'string',
-      required: false,
-    },
-  },
+  args: {},
   createFulfillment: async (ctx, orders, orderItems, args) => {
     const orderCodes = orders.map((o) => o.code);
     Logger.info(`Fulfilled orders ${orderCodes.join(',')}`, loggerCtx);
     return {
-      method: `SendCloud - ${args.trackingNumber || orderCodes.join(',')} `,
-      trackingCode: args.trackingNumber,
+      method: `SendCloud - ${orderCodes.join(',')} `,
     };
   },
 });

--- a/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
+++ b/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
@@ -105,7 +105,7 @@ describe('SendCloud', () => {
       return true;
     })
     .reply(200, {
-      parcel: { id: 'test-id', tracking_number: 'test-tracking' },
+      parcel: { id: 'test-id' },
     });
 
   it('Creates shippingmethod with Sendcloud handler', async () => {
@@ -176,7 +176,6 @@ describe('SendCloud', () => {
       action: 'parcel_status_changed',
       parcel: {
         order_number: orderCode,
-        tracking_number: 'test-tracking',
         status: {
           id: 62990,
           message: 'At sorting centre',
@@ -204,7 +203,6 @@ describe('SendCloud', () => {
       action: 'parcel_status_changed',
       parcel: {
         order_number: orderCode,
-        tracking_number: 'test-tracking',
         status: {
           id: 11,
           message: 'Delivered',
@@ -226,13 +224,17 @@ describe('SendCloud', () => {
     const order = await getOrder(adminClient, String(orderId));
     const fulfilment = order?.fulfillments?.[0];
     expect(order?.state).toBe('Delivered');
-    expect(fulfilment?.trackingCode).toBe('test-tracking');
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(__dirname, SendcloudPlugin.ui);
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        SendcloudPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();

--- a/packages/vendure-plugin-stock-monitoring/test/stock.spec.ts
+++ b/packages/vendure-plugin-stock-monitoring/test/stock.spec.ts
@@ -133,17 +133,20 @@ describe('Stock monitoring plugin', function () {
     const files = fs.readdirSync(testEmailDir);
     expect(files.length).toBe(3); // 3 emails should be sent, one for every handler
   });
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(
-      __dirname,
-      StockMonitoringPlugin.ui
-    );
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
 
-  afterAll(async () => {
-    await server.destroy();
-  }, 100000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(
+        __dirname,
+        StockMonitoringPlugin.ui
+      );
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+
+    afterAll(async () => {
+      await server.destroy();
+    }, 100000);
+  }
 });
 
 export const GET_OUT_OF_STOCK_VARIANTS = gql`

--- a/packages/vendure-plugin-webhook/test/e2e.spec.ts
+++ b/packages/vendure-plugin-webhook/test/e2e.spec.ts
@@ -227,10 +227,12 @@ describe('Webhook plugin', function () {
     expect(received.length).toBe(2);
   });
 
-  it('Should compile admin', async () => {
-    const files = await getFilesInAdminUiFolder(__dirname, WebhookPlugin.ui);
-    expect(files?.length).toBeGreaterThan(0);
-  }, 200000);
+  if (process.env.TEST_ADMIN_UI) {
+    it('Should compile admin', async () => {
+      const files = await getFilesInAdminUiFolder(__dirname, WebhookPlugin.ui);
+      expect(files?.length).toBeGreaterThan(0);
+    }, 200000);
+  }
 
   afterAll(async () => {
     await server.destroy();


### PR DESCRIPTION
# Description

* Fulfil on order placement, to prevent stock levels going out of sync. Sendcloud sends multiple webhooks simultaneously to Vendure, which might be causing stock levels to be deducted twice.
* Disabled admin UI compilation in e2e test, unless you set `TEST_ADMIN_UI=true` on commandline

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
