### PR TITLE
Picqer & Cloud Tasks plugin: Only log errors after retries exceeded

### DIFF
--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0 (2023-11-21)
+
+- Only log error when job is not added to queue after configured retries
+- Apply exponential backoff when adding to queue doesn't work.
+
 # 1.2.0 (2023-10-24)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-google-cloud-tasks/package.json
+++ b/packages/vendure-plugin-google-cloud-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-cloud-tasks",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Vendure plugin for using worker jobs with Google Cloud Tasks",
   "icon": "google-cloud",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -174,10 +174,10 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
           `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
           CloudTasksPlugin.loggerCtx
         );
+        // Exponential backoff after first 3 subsequent attempts
         if (currentAttempt > 3) {
-          // Exponential backoff after first 3 subsequent attempts
           await new Promise((resolve) =>
-            setTimeout(resolve, currentAttempt * 5000)
+            setTimeout(resolve, 1000 * 2 ** currentAttempt)
           );
         }
         if (currentAttempt === (this.options.createTaskRetries ?? 5)) {

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -174,12 +174,6 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
           `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
           CloudTasksPlugin.loggerCtx
         );
-        // Exponential backoff after first 3 subsequent attempts
-        if (currentAttempt > 3) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, 1000 * 2 ** currentAttempt)
-          );
-        }
         if (currentAttempt === (this.options.createTaskRetries ?? 5)) {
           Logger.error(
             `Failed to add task to queue ${queueName} in ${currentAttempt} attempts. Not retrying anymore! Error: ${e?.message}`,
@@ -187,6 +181,12 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
             (e as Error)?.stack
           );
           throw e;
+        }
+        // Exponential backoff after first 3 subsequent attempts
+        if (currentAttempt > 3) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, 1000 * 2 ** currentAttempt)
+          );
         }
       }
     }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -170,12 +170,22 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
         return new Job<any>(jobRecord);
       } catch (e: any) {
         currentAttempt += 1;
-        Logger.error(
-          `Failed to add task to queue ${queueName}: ${e?.message}`,
-          CloudTasksPlugin.loggerCtx,
-          e
+        Logger.warn(
+          `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
+          CloudTasksPlugin.loggerCtx
         );
+        if (currentAttempt > 3) {
+          // Exponential backoff after first 3 subsequent attempts
+          await new Promise((resolve) =>
+            setTimeout(resolve, currentAttempt * 5000)
+          );
+        }
         if (currentAttempt === (this.options.createTaskRetries ?? 5)) {
+          Logger.error(
+            `Failed to add task to queue ${queueName} in ${currentAttempt} attempts. Not retrying anymore! Error: ${e?.message}`,
+            CloudTasksPlugin.loggerCtx,
+            (e as Error)?.stack
+          );
           throw e;
         }
       }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -170,10 +170,6 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
         return new Job<any>(jobRecord);
       } catch (e: any) {
         currentAttempt += 1;
-        Logger.warn(
-          `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
-          CloudTasksPlugin.loggerCtx
-        );
         if (currentAttempt === (this.options.createTaskRetries ?? 5)) {
           Logger.error(
             `Failed to add task to queue ${queueName} in ${currentAttempt} attempts. Not retrying anymore! Error: ${e?.message}`,
@@ -182,6 +178,10 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
           );
           throw e;
         }
+        Logger.warn(
+          `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
+          CloudTasksPlugin.loggerCtx
+        );
         // Exponential backoff after first 3 subsequent attempts
         if (currentAttempt > 3) {
           await new Promise((resolve) =>

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -2,10 +2,11 @@ import {
   PluginCommonModule,
   RuntimeVendureConfig,
   VendurePlugin,
+  Logger,
 } from '@vendure/core';
 import { CloudTasksJobQueueStrategy } from './cloud-tasks-job-queue.strategy';
 import { CloudTasksHandler } from './cloud-tasks.handler';
-import { CloudTaskOptions, ROUTE } from './types';
+import { CloudTaskOptions } from './types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
 
 @VendurePlugin({
@@ -26,6 +27,13 @@ export class CloudTasksPlugin {
 
   static init(options: CloudTaskOptions): typeof CloudTasksPlugin {
     this.options = options;
+    if (this.options?.createTaskRetries > 20) {
+      this.options.createTaskRetries = 20;
+      Logger.warn(
+        `createTaskRetries can be set to a maximum of 20 retries. This is to avoid too many stacked create task retries`,
+        this.loggerCtx
+      );
+    }
     return CloudTasksPlugin;
   }
 }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -27,7 +27,10 @@ export class CloudTasksPlugin {
 
   static init(options: CloudTaskOptions): typeof CloudTasksPlugin {
     this.options = options;
-    if (this.options?.createTaskRetries > 20) {
+    if (
+      this.options?.createTaskRetries &&
+      this.options?.createTaskRetries > 20
+    ) {
       this.options.createTaskRetries = 20;
       Logger.warn(
         `createTaskRetries can be set to a maximum of 20 retries. This is to avoid too many stacked create task retries`,

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -21,7 +21,7 @@ export interface CloudTaskOptions {
    */
   defaultJobRetries?: number;
   /**
-   *Nr of attempts the plugin should try to push a job to the queue, in case it fails. Default is 5
+   * Nr of attempts the plugin should try to push a job to the queue, in case it fails. Default is 5, maximum is 20.
    */
   createTaskRetries?: number;
 }

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.3 (2023-11-21)
+
+- Log order code when order couldn't be added to push-order queue
+
 # 2.2.2 (2023-11-14)
 
 - Remove order lines when removed in Picqer

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -567,14 +567,22 @@ export class PicqerService implements OnApplicationBootstrap {
    * Add a job to the queue to push orders to Picqer
    */
   async addPushOrderJob(ctx: RequestContext, order: Order): Promise<void> {
-    await this.jobQueue.add(
-      {
-        action: 'push-order',
-        ctx: ctx.serialize(),
-        orderId: order.id,
-      },
-      { retries: 10 }
-    );
+    await this.jobQueue
+      .add(
+        {
+          action: 'push-order',
+          ctx: ctx.serialize(),
+          orderId: order.id,
+        },
+        { retries: 10 }
+      )
+      .catch((e) => {
+        Logger.error(
+          `Failed to add job to 'push-order' queue for order ${order.code}: ${e?.message}`,
+          loggerCtx
+        );
+        throw e;
+      });
     Logger.info(
       `Added job to the 'push-order' queue for order ${order.code}`,
       loggerCtx

--- a/packages/vendure-plugin-stock-monitoring/CHANGELOG.md
+++ b/packages/vendure-plugin-stock-monitoring/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.` (2023-11-21)
+
+- Fixed link to products from stock widget
+
 # 1.3.0 (2023-11-09)
 
 - Fixed `reduceSum` function call bug

--- a/packages/vendure-plugin-stock-monitoring/CHANGELOG.md
+++ b/packages/vendure-plugin-stock-monitoring/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.3.` (2023-11-21)
+# 1.3.1 (2023-11-21)
 
 - Fixed link to products from stock widget
 

--- a/packages/vendure-plugin-stock-monitoring/package.json
+++ b/packages/vendure-plugin-stock-monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stock-monitoring",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Vendure plugin for monitoring stock levels through a widget or by email",
   "icon": "alert-decagram",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-stock-monitoring/src/ui/stock-widget.ts
+++ b/packages/vendure-plugin-stock-monitoring/src/ui/stock-widget.ts
@@ -15,16 +15,9 @@ import gql from 'graphql-tag';
           class="left align-middle"
           [class.out-of-stock]="!variant.stockOnHand"
         >
-          <a
-            [routerLink]="[
-              '/catalog',
-              'products',
-              variant.productId,
-              'variants',
-              variant.id
-            ]"
-            >{{ variant.name }}</a
-          >
+          <a [routerLink]="['/catalog', 'inventory', variant.productId]">{{
+            variant.name
+          }}</a>
         </td>
         <td
           class="left align-middle"


### PR DESCRIPTION
# Description

* Cloud tasks: Only log errors when a job couldn't be added to the queue after its retries
* Cloud tasks: Implemented exponential backoff, so that there is a delay after which when a job will be retried
* Picqer: Log order code when a job failed to add to push-order queue, so that we can easily find which order its about

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
