### PR TITLE
patch(picqer): allocated + freestock as stockOnHand

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.4 (2023-11-21)
+
+- Take Picqer allocated stock into account when setting stock on hand
+
 # 2.2.3 (2023-11-21)
 
 - Log order code when order couldn't be added to push-order queue

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -656,13 +656,15 @@ export class PicqerService implements OnApplicationBootstrap {
               variant.id,
               location.id
             );
-          const delta = picqerStock.freestock - stockOnHand;
+          const allocated = picqerStock.reservedallocations ?? 0;
+          const newStockOnHand = allocated + picqerStock.freestock;
+          const delta = newStockOnHand - stockOnHand;
           const res = await this.connection
             .getRepository(ctx, StockLevel)
             .save({
               id: stockLevelId,
-              stockOnHand: picqerStock.freestock,
-              stockAllocated: picqerStock.reservedallocations ?? 0,
+              stockOnHand: newStockOnHand,
+              stockAllocated: allocated,
             });
           // Add stock adjustment
           stockAdjustments.push(


### PR DESCRIPTION
# Description

* Use allocated + freestock for stock on hand in Vendure, because free stock in Vendure will be `stockOnHand - allocated`

# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
