### PR TITLE
Picqer: Expose stock level sync function

### DIFF
--- a/packages/test/src/admin.graphql
+++ b/packages/test/src/admin.graphql
@@ -146,6 +146,7 @@ query GetVariants {
       outOfStockThreshold
       trackInventory
       stockAllocated
+      stockLevel
     }
     totalItems
   }

--- a/packages/test/src/generated/admin-graphql.ts
+++ b/packages/test/src/generated/admin-graphql.ts
@@ -2477,6 +2477,36 @@ export type ManualPaymentStateError = ErrorResult & {
   message: Scalars['String'];
 };
 
+export enum MetricInterval {
+  Daily = 'Daily'
+}
+
+export type MetricSummary = {
+  __typename?: 'MetricSummary';
+  entries: Array<MetricSummaryEntry>;
+  interval: MetricInterval;
+  title: Scalars['String'];
+  type: MetricType;
+};
+
+export type MetricSummaryEntry = {
+  __typename?: 'MetricSummaryEntry';
+  label: Scalars['String'];
+  value: Scalars['Float'];
+};
+
+export type MetricSummaryInput = {
+  interval: MetricInterval;
+  refresh?: InputMaybe<Scalars['Boolean']>;
+  types: Array<MetricType>;
+};
+
+export enum MetricType {
+  AverageOrderValue = 'AverageOrderValue',
+  OrderCount = 'OrderCount',
+  OrderTotal = 'OrderTotal'
+}
+
 export type MimeTypeError = ErrorResult & {
   __typename?: 'MimeTypeError';
   errorCode: ErrorCode;
@@ -2777,6 +2807,8 @@ export type Mutation = {
   transitionFulfillmentToState: TransitionFulfillmentToStateResult;
   transitionOrderToState?: Maybe<TransitionOrderToStateResult>;
   transitionPaymentToState: TransitionPaymentToStateResult;
+  /** Push all products to, and pull all stock levels from Picqer */
+  triggerPicqerFullSync: Scalars['Boolean'];
   /** Update the active (currently logged-in) Administrator */
   updateActiveAdministrator: Administrator;
   /** Update an existing Administrator */
@@ -2832,6 +2864,8 @@ export type Mutation = {
   updateTaxRate: TaxRate;
   /** Update an existing Zone */
   updateZone: Zone;
+  /** Upsert Picqer config for the current channel */
+  upsertPicqerConfig: PicqerConfig;
 };
 
 
@@ -3647,6 +3681,11 @@ export type MutationUpdateZoneArgs = {
   input: UpdateZoneInput;
 };
 
+
+export type MutationUpsertPicqerConfigArgs = {
+  input: PicqerConfigInput;
+};
+
 export type NativeAuthInput = {
   password: Scalars['String'];
   username: Scalars['String'];
@@ -4267,6 +4306,8 @@ export enum Permission {
   DeleteZone = 'DeleteZone',
   /** Owner means the user owns this entity, e.g. a Customer's own Order */
   Owner = 'Owner',
+  /** Allows setting Picqer config and triggering Picqer full sync */
+  Picqer = 'Picqer',
   /** Public means any unauthenticated user may perform the operation */
   Public = 'Public',
   /** Grants permission to read Administrator */
@@ -4368,6 +4409,23 @@ export type PermissionDefinition = {
   assignable: Scalars['Boolean'];
   description: Scalars['String'];
   name: Scalars['String'];
+};
+
+export type PicqerConfig = {
+  __typename?: 'PicqerConfig';
+  apiEndpoint?: Maybe<Scalars['String']>;
+  apiKey?: Maybe<Scalars['String']>;
+  enabled?: Maybe<Scalars['Boolean']>;
+  storefrontUrl?: Maybe<Scalars['String']>;
+  supportEmail?: Maybe<Scalars['String']>;
+};
+
+export type PicqerConfigInput = {
+  apiEndpoint?: InputMaybe<Scalars['String']>;
+  apiKey?: InputMaybe<Scalars['String']>;
+  enabled?: InputMaybe<Scalars['Boolean']>;
+  storefrontUrl?: InputMaybe<Scalars['String']>;
+  supportEmail?: InputMaybe<Scalars['String']>;
 };
 
 export type PreviewCollectionVariantsInput = {
@@ -4850,12 +4908,16 @@ export type Query = {
   facets: FacetList;
   fulfillmentHandlers: Array<ConfigurableOperationDefinition>;
   globalSettings: GlobalSettings;
+  /** Test Picqer config against the Picqer API */
+  isPicqerConfigValid: Scalars['Boolean'];
   job?: Maybe<Job>;
   jobBufferSize: Array<JobBufferSize>;
   jobQueues: Array<JobQueue>;
   jobs: JobList;
   jobsById: Array<Job>;
   me?: Maybe<CurrentUser>;
+  /** Get metrics for the given interval and metric types. */
+  metricSummary: Array<MetricSummary>;
   order?: Maybe<Order>;
   orders: OrderList;
   paymentMethod?: Maybe<PaymentMethod>;
@@ -4863,6 +4925,7 @@ export type Query = {
   paymentMethodHandlers: Array<ConfigurableOperationDefinition>;
   paymentMethods: PaymentMethodList;
   pendingSearchIndexUpdates: Scalars['Int'];
+  picqerConfig?: Maybe<PicqerConfig>;
   /** Used for real-time previews of the contents of a Collection */
   previewCollectionVariants: ProductVariantList;
   /** Get a Product either by id or slug. If neither id nor slug is specified, an error will result. */
@@ -4996,6 +5059,11 @@ export type QueryFacetsArgs = {
 };
 
 
+export type QueryIsPicqerConfigValidArgs = {
+  input: TestPicqerInput;
+};
+
+
 export type QueryJobArgs = {
   jobId: Scalars['ID'];
 };
@@ -5013,6 +5081,11 @@ export type QueryJobsArgs = {
 
 export type QueryJobsByIdArgs = {
   jobIds: Array<Scalars['ID']>;
+};
+
+
+export type QueryMetricSummaryArgs = {
+  input?: InputMaybe<MetricSummaryInput>;
 };
 
 
@@ -5974,6 +6047,13 @@ export type TestEligibleShippingMethodsInput = {
   shippingAddress: CreateAddressInput;
 };
 
+export type TestPicqerInput = {
+  apiEndpoint: Scalars['String'];
+  apiKey: Scalars['String'];
+  storefrontUrl: Scalars['String'];
+  supportEmail: Scalars['String'];
+};
+
 export type TestShippingMethodInput = {
   calculator: ConfigurableOperationInput;
   checker: ConfigurableOperationInput;
@@ -6435,7 +6515,7 @@ export type UpdateProductMutation = { __typename?: 'Mutation', updateProduct: { 
 export type GetVariantsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetVariantsQuery = { __typename?: 'Query', productVariants: { __typename?: 'ProductVariantList', totalItems: number, items: Array<{ __typename?: 'ProductVariant', name: string, id: string, sku: string, stockOnHand: number, price: any, priceWithTax: any, outOfStockThreshold: number, trackInventory: GlobalFlag, stockAllocated: number }> } };
+export type GetVariantsQuery = { __typename?: 'Query', productVariants: { __typename?: 'ProductVariantList', totalItems: number, items: Array<{ __typename?: 'ProductVariant', name: string, id: string, sku: string, stockOnHand: number, price: any, priceWithTax: any, outOfStockThreshold: number, trackInventory: GlobalFlag, stockAllocated: number, stockLevel: string }> } };
 
 export type CreatePromotionMutationVariables = Exact<{
   input: CreatePromotionInput;
@@ -6592,6 +6672,7 @@ export const GetVariants = gql`
       outOfStockThreshold
       trackInventory
       stockAllocated
+      stockLevel
     }
     totalItems
   }

--- a/packages/test/src/generated/shop-graphql.ts
+++ b/packages/test/src/generated/shop-graphql.ts
@@ -2423,6 +2423,8 @@ export enum Permission {
   DeleteZone = 'DeleteZone',
   /** Owner means the user owns this entity, e.g. a Customer's own Order */
   Owner = 'Owner',
+  /** Allows setting Picqer config and triggering Picqer full sync */
+  Picqer = 'Picqer',
   /** Public means any unauthenticated user may perform the operation */
   Public = 'Public',
   /** Grants permission to read Administrator */

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.2.4 (2023-11-21)
+# 2.2.5 (2023-11-28)
+
+- Expose `PicqerService.createStockLevelJobs(ctx)` to allow consumers to only trigger stock level updates
+
+- # 2.2.4 (2023-11-21)
 
 - Take Picqer allocated stock into account when setting stock on hand
 

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.3.0 (2023-11-28)
 
 - Expose endpoint to periodically pull stock levels
-- Load
+- Install order process that allows skipping fulfillments when transitioning to Shipped or Delivered
 
 - # 2.2.4 (2023-11-21)
 

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 2.2.5 (2023-11-28)
+# 2.3.0 (2023-11-28)
 
-- Expose `PicqerService.createStockLevelJobs(ctx)` to allow consumers to only trigger stock level updates
+- Expose endpoint to periodically pull stock levels
+- Load
 
 - # 2.2.4 (2023-11-21)
 

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -77,21 +77,19 @@ curl -H "Authorization: Bearer abcde-your-apikey" `http://localhost:3000/picqer/
 
 ### Order process override
 
-This plugin installs the default order process with `checkFulfillmentStates: false` configured, so that orders can be transitioned to Shipped and Delivered without the need of fulfilment. Fulfilment is the responsibility of Picqer, so we wont handle that in Vendure when using this plugin.
+This plugin installs the default order process with `checkFulfillmentStates: false` configured, so that orders can be transitioned to Shipped and Delivered without the need of fulfillment. Fulfillment is the responsibility of Picqer, so we won't handle that in Vendure when using this plugin.
 
 ![!image](https://www.plantuml.com/plantuml/png/VOv1IyD048Nl-HNl1rH9Uog1I8iNRnQYtfVCn0nkPkFk1F7VIvgjfb2yBM_VVEyx97FHfi4NZrvO3NSFU6EbANA58n4iO0Sn7jBy394u5hbmrUrTmhP4ij1-87JBoIteoNt3AI6ncUT_Y4VlG-kCB_lL0d_M9wTKRyiDN6vGlLiJJj9-SgpGiDB2XuMSuaki3vEXctmdVc2r8l-ijvjv2TD8ytuNcSz1lR_7wvA9NifmwKfil_OgRy5VejCa9a7_x9fUnf5fy-lNHdOc-fv5pwQfECoCmVy0)
 
-- Without incoming stock from Picqer, items would be allocated indefinitely. Picqer has to tell Vendure what the stock levels of items are.
+- Without incoming stock from Picqer, either via webhook or pulled from the Picqer API, items would be allocated indefinitely. Picqer has to tell Vendure what the stock level of products are.
 
 ## Orders
 
 1. Orders are pushed to Picqer with status `processing` when an order is placed in Vendure.
-2. The order is immediately fulfilled on order placement.
-3. On incoming `order.completed` event from Picqer, the order is transitioned to `Shipped`.
-4. There currently is no way of telling when an order is `Deliverd` based on Picqer events, so we automatically transition to `Delivered`.
+2. On incoming `order.completed` event from Picqer, the order is transitioned to `Shipped`.
+3. There currently is no way of telling when an order is `Delivered` based on Picqer events, so we automatically transition to `Delivered`.
 
 ## Caveats
 
 - Due to limitation of the Picqer API, the plugin only uploads images if no images exist for the product in Picqer.
-- Stock is updated directly on a variant, so no `StockMovementEvents` are emitted by Vendure when variants are updated in Vendure by the full sync.
 - This plugin automatically creates webhooks and deactivates old ones. Webhooks are created when you save your config.

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -60,7 +60,8 @@ Start the server and set the fulfillment handler to `picqer: Fulfill with Picqer
 Stock levels are updated in Vendure on
 
 1. Full sync via the Admin UI
-2. Or, on incoming webhook from Picqer
+2. On incoming webhook from Picqer
+3. Or, on trigger of the GET endpoint `/picqer/pull-stock/<channeltoken>`. You will need to pass your api key as auth header when you call this endpoint: `Authorization: "Bearer 1134090403msfksdl"`
 
 This plugin will mirror the stock locations from Picqer. Non-Picqer stock locations will automatically be deleted by the plugin, to keep stock in sync with Picqer. Vendure's internal allocated stock will be ignored, because this is handled by Picqer.
 

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -75,11 +75,11 @@ You can call the endpoint `/picqer/pull-stock-levels/<channeltoken>`, with your 
 curl -H "Authorization: Bearer abcde-your-apikey" `http://localhost:3000/picqer/pull-stock-levels/your-channel-token`
 ```
 
-### Custom fulfillment process
+### Order process override
 
-This plugin installs a custom fulfillment process in your Vendure instance, because Picqer will be responsible for fulfilling and thus for allocating/releasing stock. The custom fulfillment process makes sure an order is always fulfillable, stock synchronization with Picqer handles the stock levels.
+This plugin installs the default order process with `checkFulfillmentStates: false`, so that orders can be transitioned to Shipped and Delivered without the need of fulfilment. Fulfilment is the responsibility of Picqer, so we wont handle that in Vendure when using this plugin.
 
-![!image](https://www.plantuml.com/plantuml/png/VOt1IeP054RtynJV0rIeAn4C9OXs2L7xmRdIq7McPkuiUlkqKVW5SNUvd7E-BeeEacPMJsp92UuVyK7Ef40DUcCW7XMiq1pNqmT3GMt0WVtK4MM1A7xyWf-oSXOTz2-qCuWamdHHx9dzg8Ns_IR7NztBehTbSGUz4QQjJWlFYIVBd3UkzS6EFnGEzjkA8tsR1S4KYFuVRVs0z_opReUXuw5UtyOBrQtKp4hz0G00)
+![!image](https://www.plantuml.com/plantuml/png/VOv1IyD048Nl-HNl1rH9Uog1I8iNRnQYtfVCn0nkPkFk1F7VIvgjfb2yBM_VVEyx97FHfi4NZrvO3NSFU6EbANA58n4iO0Sn7jBy394u5hbmrUrTmhP4ij1-87JBoIteoNt3AI6ncUT_Y4VlG-kCB_lL0d_M9wTKRyiDN6vGlLiJJj9-SgpGiDB2XuMSuaki3vEXctmdVc2r8l-ijvjv2TD8ytuNcSz1lR_7wvA9NifmwKfil_OgRy5VejCa9a7_x9fUnf5fy-lNHdOc-fv5pwQfECoCmVy0)
 
 - Without incoming stock from Picqer, items would be allocated indefinitely. Picqer has to tell Vendure what the stock levels of items are.
 

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -77,7 +77,7 @@ curl -H "Authorization: Bearer abcde-your-apikey" `http://localhost:3000/picqer/
 
 ### Order process override
 
-This plugin installs the default order process with `checkFulfillmentStates: false`, so that orders can be transitioned to Shipped and Delivered without the need of fulfilment. Fulfilment is the responsibility of Picqer, so we wont handle that in Vendure when using this plugin.
+This plugin installs the default order process with `checkFulfillmentStates: false` configured, so that orders can be transitioned to Shipped and Delivered without the need of fulfilment. Fulfilment is the responsibility of Picqer, so we wont handle that in Vendure when using this plugin.
 
 ![!image](https://www.plantuml.com/plantuml/png/VOv1IyD048Nl-HNl1rH9Uog1I8iNRnQYtfVCn0nkPkFk1F7VIvgjfb2yBM_VVEyx97FHfi4NZrvO3NSFU6EbANA58n4iO0Sn7jBy394u5hbmrUrTmhP4ij1-87JBoIteoNt3AI6ncUT_Y4VlG-kCB_lL0d_M9wTKRyiDN6vGlLiJJj9-SgpGiDB2XuMSuaki3vEXctmdVc2r8l-ijvjv2TD8ytuNcSz1lR_7wvA9NifmwKfil_OgRy5VejCa9a7_x9fUnf5fy-lNHdOc-fv5pwQfECoCmVy0)
 

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -69,7 +69,7 @@ You can use a custom [StockLocationStrategy](https://github.com/vendure-ecommerc
 
 ### Periodical stock level sync
 
-You can call the endpoint `/picqer/pull-stock-levels/<channeltoken>`, with your Picqer API key as bearer token, to trigger a full stock level sync. This will pull stock levels from Picqer, and update them in Picqer.
+You can call the endpoint `/picqer/pull-stock-levels/<channeltoken>`, with your Picqer API key as bearer token, to trigger a full stock level sync. This will pull stock levels from Picqer, and update them in Vendure.
 
 ```
 curl -H "Authorization: Bearer abcde-your-apikey" `http://localhost:3000/picqer/pull-stock-levels/your-channel-token`

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -6,6 +6,7 @@ import {
   Post,
   Req,
   BadRequestException,
+  Get,
 } from '@nestjs/common';
 import { ChannelService, Logger, RequestContext } from '@vendure/core';
 import { Request } from 'express';
@@ -51,7 +52,7 @@ export class PicqerController {
     }
   }
 
-  @Post('pull-stock-levels/:channelToken')
+  @Get('pull-stock-levels/:channelToken')
   async pullStockLevels(
     @Headers('Authorization') authHeader: string,
     @Param('channelToken') channelToken: string

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -51,7 +51,7 @@ export class PicqerController {
     }
   }
 
-  @Post('pull-stock/:channelToken')
+  @Post('pull-stock-levels/:channelToken')
   async pullStockLevels(
     @Headers('Authorization') authHeader: string,
     @Param('channelToken') channelToken: string

--- a/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.controller.ts
@@ -1,14 +1,25 @@
-import { Body, Controller, Headers, Param, Post, Req } from '@nestjs/common';
-import { Logger } from '@vendure/core';
+import {
+  Controller,
+  ForbiddenException,
+  Headers,
+  Param,
+  Post,
+  Req,
+  BadRequestException,
+} from '@nestjs/common';
+import { ChannelService, Logger, RequestContext } from '@vendure/core';
 import { Request } from 'express';
+import util from 'util';
 import { loggerCtx } from '../constants';
 import { PicqerService } from './picqer.service';
 import { IncomingWebhook } from './types';
-import util from 'util';
 
 @Controller('picqer')
 export class PicqerController {
-  constructor(private picqerService: PicqerService) {}
+  constructor(
+    private picqerService: PicqerService,
+    private channelService: ChannelService
+  ) {}
 
   @Post('hooks/:channelToken')
   async webhook(
@@ -38,5 +49,33 @@ export class PicqerController {
       );
       throw e;
     }
+  }
+
+  @Post('pull-stock/:channelToken')
+  async pullStockLevels(
+    @Headers('Authorization') authHeader: string,
+    @Param('channelToken') channelToken: string
+  ): Promise<void> {
+    if (!authHeader) {
+      throw new ForbiddenException('No bearer token provided');
+    }
+    const channel = await this.channelService.getChannelFromToken(channelToken);
+    if (!channel) {
+      throw new BadRequestException(
+        `No channel found for token ${channelToken}`
+      );
+    }
+    const apiKey = authHeader.replace('Bearer ', '').replace('bearer ', '');
+    const ctx = new RequestContext({
+      apiType: 'admin',
+      isAuthorized: true,
+      authorizedAsOwnerOnly: false,
+      channel,
+    });
+    const picqerConfig = await this.picqerService.getConfig(ctx);
+    if (picqerConfig?.apiKey !== apiKey) {
+      throw new ForbiddenException('Invalid bearer token');
+    }
+    await this.picqerService.createStockLevelJobs(ctx);
   }
 }

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -544,7 +544,7 @@ export class PicqerService implements OnApplicationBootstrap {
           await this.connection.getRepository(ctx, StockLevel).save({
             id: stockLevelId,
             stockOnHand: picqerStock.freestock,
-            stockAllocated: 0, // Reset allocations based on Picqer events, because of our custom fulfilmentproces
+            stockAllocated: 0, // Reset allocations, because we skip fulfillment with this plugin
           });
           // Add stock adjustment
           stockAdjustments.push(

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -302,7 +302,10 @@ export class PicqerService implements OnApplicationBootstrap {
     Logger.info(`Successfully handled hook ${input.body.event}`, loggerCtx);
   }
 
-  async triggerFullSync(ctx: RequestContext): Promise<boolean> {
+  /**
+   * Create jobs to push all Vendure variants as products to Picqer
+   */
+  async createPushProductsJob(ctx: RequestContext): Promise<void> {
     const variantIds: ID[] = [];
     let skip = 0;
     const take = 1000;
@@ -334,6 +337,12 @@ export class PicqerService implements OnApplicationBootstrap {
     while (variantIds.length) {
       await this.addPushVariantsJob(ctx, variantIds.splice(0, batchSize));
     }
+  }
+
+  /**
+   * Create job to pull stock levels of all products from Picqer
+   */
+  async createStockLevelJobs(ctx: RequestContext): Promise<void> {
     await this.jobQueue.add(
       {
         action: 'pull-stock-levels',
@@ -342,7 +351,6 @@ export class PicqerService implements OnApplicationBootstrap {
       { retries: 10 }
     );
     Logger.info(`Added 'pull-stock-levels' job to queue`, loggerCtx);
-    return true;
   }
 
   /**

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -667,13 +667,11 @@ export class PicqerService implements OnApplicationBootstrap {
           const allocated = picqerStock.reservedallocations ?? 0;
           const newStockOnHand = allocated + picqerStock.freestock;
           const delta = newStockOnHand - stockOnHand;
-          const res = await this.connection
-            .getRepository(ctx, StockLevel)
-            .save({
-              id: stockLevelId,
-              stockOnHand: newStockOnHand,
-              stockAllocated: allocated,
-            });
+          await this.connection.getRepository(ctx, StockLevel).save({
+            id: stockLevelId,
+            stockOnHand: picqerStock.freestock,
+            stockAllocated: 0, // Reset allocations based on Picqer events, because of our custom fulfilmentproces
+          });
           // Add stock adjustment
           stockAdjustments.push(
             new StockAdjustment({

--- a/packages/vendure-plugin-picqer/src/picqer.plugin.ts
+++ b/packages/vendure-plugin-picqer/src/picqer.plugin.ts
@@ -1,4 +1,5 @@
 import {
+  configureDefaultOrderProcess,
   Order,
   PluginCommonModule,
   ProductVariant,
@@ -74,6 +75,9 @@ export interface PicqerOptions {
     });
     config.authOptions.customPermissions.push(picqerPermission);
     config.shippingOptions.fulfillmentHandlers.push(picqerHandler);
+    config.orderOptions.process = [
+      configureDefaultOrderProcess({ checkFulfillmentStates: false }),
+    ];
     return config;
   },
   compatibility: '^2.0.0',

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -456,34 +456,6 @@ describe('Product synchronization', function () {
   });
 });
 
-describe('Periodical stock updates', function () {
-  it('Throws forbidden for invalid api key', async () => {
-    const res = await adminClient.fetch(
-      `http://localhost:3050/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: 'Bearer this is not right',
-        },
-      }
-    );
-    expect(res.status).toBe(403);
-  });
-
-  it('Creates full sync jobs on calling of endpoint', async () => {
-    const res = await adminClient.fetch(
-      `http://localhost:3050/picqer/pull-stock-levels/${E2E_DEFAULT_CHANNEL_TOKEN}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: 'Bearer test-api-key',
-        },
-      }
-    );
-    expect(res.status).toBe(201);
-  });
-});
-
 describe('Order modification', function () {
   it('Update stock again', async () => {
     const variants = await updateVariants(adminClient, [
@@ -498,12 +470,12 @@ describe('Order modification', function () {
 
   it('Should create settled order', async () => {
     // Shipping method 3 should be our created Picqer handler method
-    createdOrder = await createSettledOrder(shopClient, 3, true, [
+    createdOrder = (await createSettledOrder(shopClient, 3, true, [
       { id: 'T_1', quantity: 1 },
       { id: 'T_2', quantity: 1 },
-    ]);
-    expect(createdOrder.code).toBeDefined();
-    expect(createdOrder.state).toBe('PaymentSettled');
+    ])) as any;
+    expect(createdOrder?.code).toBeDefined();
+    expect(createdOrder?.state).toBe('PaymentSettled');
   });
 
   it('Should update order when order line is removed in Picqer', async () => {
@@ -544,13 +516,13 @@ describe('Order modification', function () {
 
   it('Should create another settled order', async () => {
     // Shipping method 3 should be our created Picqer handler method
-    createdOrder = await createSettledOrder(shopClient, 3, true, [
+    createdOrder = (await createSettledOrder(shopClient, 3, true, [
       { id: 'T_1', quantity: 3 },
       { id: 'T_2', quantity: 1 },
-    ]);
+    ])) as any;
     await new Promise((r) => setTimeout(r, 500)); // Wait for job queue to finish
-    expect(createdOrder.code).toBeDefined();
-    expect(createdOrder.state).toBe('PaymentSettled');
+    expect(createdOrder?.code).toBeDefined();
+    expect(createdOrder?.state).toBe('PaymentSettled');
   });
 
   it('Should update quantity when quantity is adjusted in Picqer', async () => {
@@ -590,6 +562,34 @@ describe('Order modification', function () {
     expect(order?.lines[0].quantity).toBe(1);
     expect(order?.lines[1].productVariant.sku).toBe('L2201508');
     expect(order?.lines[1].quantity).toBe(1);
+  });
+});
+
+describe('Periodical stock updates', function () {
+  it('Throws forbidden for invalid api key', async () => {
+    const res = await adminClient.fetch(
+      `http://localhost:3050/picqer/pull-stock-levels/${E2E_DEFAULT_CHANNEL_TOKEN}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer this is not right',
+        },
+      }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('Creates full sync jobs on calling of endpoint', async () => {
+    const res = await adminClient.fetch(
+      `http://localhost:3050/picqer/pull-stock-levels/${E2E_DEFAULT_CHANNEL_TOKEN}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer test-api-key',
+        },
+      }
+    );
+    expect(res.status).toBe(200);
   });
 });
 

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -21,6 +21,7 @@ import {
   GetVariantsQuery,
   GlobalFlag,
 } from '../../test/src/generated/admin-graphql';
+import { AddPaymentToOrderMutation } from '../../test/src/generated/shop-graphql';
 import { initialData } from '../../test/src/initial-data';
 import { createSettledOrder } from '../../test/src/shop-utils';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
@@ -202,7 +203,7 @@ describe('Order placement', function () {
       })
       .reply(200, { idordder: 'mockOrderId' });
     // Shipping method 3 should be our created Picqer handler method
-    createdOrder = await createSettledOrder(
+    createdOrder = (await createSettledOrder(
       shopClient,
       3,
       true,
@@ -218,14 +219,14 @@ describe('Order placement', function () {
           countryCode: 'NL',
         },
       }
-    );
+    )) as any;
     await new Promise((r) => setTimeout(r, 500)); // Wait for job queue to finish
     const variant = (await getAllVariants(adminClient)).find(
       (v) => v.id === 'T_1'
     );
-    expect(variant!.stockOnHand).toBe(97);
-    expect(variant!.stockAllocated).toBe(0);
-    expect(picqerOrderRequest.reference).toBe(createdOrder.code);
+    expect(variant!.stockOnHand).toBe(100);
+    expect(variant!.stockAllocated).toBe(3);
+    expect(picqerOrderRequest.reference).toBe(createdOrder?.code);
     expect(picqerOrderRequest.deliveryname).toBeDefined();
     expect(picqerOrderRequest.deliverycontactname).toBeUndefined();
     expect(picqerOrderRequest.deliveryaddress).toBeDefined();
@@ -453,115 +454,6 @@ describe('Product synchronization', function () {
       }
     );
     expect(res.status).toBe(403);
-  });
-});
-
-describe('Order modification', function () {
-  it('Update stock again', async () => {
-    const variants = await updateVariants(adminClient, [
-      { id: 'T_1', stockLevels: [{ stockLocationId: '2', stockOnHand: 10 }] },
-      { id: 'T_2', stockLevels: [{ stockLocationId: '2', stockOnHand: 10 }] },
-    ]);
-    expect(variants[0]?.stockOnHand).toBe(10);
-    expect(variants[1]?.stockOnHand).toBe(10);
-  });
-
-  let createdOrder: Order | undefined;
-
-  it('Should create settled order', async () => {
-    // Shipping method 3 should be our created Picqer handler method
-    createdOrder = (await createSettledOrder(shopClient, 3, true, [
-      { id: 'T_1', quantity: 1 },
-      { id: 'T_2', quantity: 1 },
-    ])) as any;
-    expect(createdOrder?.code).toBeDefined();
-    expect(createdOrder?.state).toBe('PaymentSettled');
-  });
-
-  it('Should update order when order line is removed in Picqer', async () => {
-    const mockIncomingWebhook = {
-      event: 'orders.status_changed',
-      data: {
-        reference: createdOrder?.code,
-        status: 'completed',
-        products: [
-          {
-            productcode: 'L2201308',
-            amount: 1,
-          },
-          // Variant T_2 is missing here
-        ],
-      },
-    } as Partial<IncomingOrderStatusWebhook>;
-    await adminClient.fetch(
-      `http://localhost:3050/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(mockIncomingWebhook),
-        headers: {
-          'X-Picqer-Signature': createSignature(
-            mockIncomingWebhook,
-            'test-api-key'
-          ),
-        },
-      }
-    );
-    await new Promise((r) => setTimeout(r, 500)); // Wait for job queue to finish
-    const order = await getOrder(adminClient, createdOrder?.id as string);
-    expect(order?.lines[0].productVariant.sku).toBe('L2201308');
-    expect(order?.lines[0].quantity).toBe(1);
-    expect(order?.lines[1].productVariant.sku).toBe('L2201508');
-    expect(order?.lines[1].quantity).toBe(0);
-  });
-
-  it('Should create another settled order', async () => {
-    // Shipping method 3 should be our created Picqer handler method
-    createdOrder = (await createSettledOrder(shopClient, 3, true, [
-      { id: 'T_1', quantity: 3 },
-      { id: 'T_2', quantity: 1 },
-    ])) as any;
-    await new Promise((r) => setTimeout(r, 500)); // Wait for job queue to finish
-    expect(createdOrder?.code).toBeDefined();
-    expect(createdOrder?.state).toBe('PaymentSettled');
-  });
-
-  it('Should update quantity when quantity is adjusted in Picqer', async () => {
-    const mockIncomingWebhook = {
-      event: 'orders.status_changed',
-      data: {
-        reference: createdOrder?.code,
-        status: 'completed',
-        products: [
-          {
-            productcode: 'L2201308',
-            amount: 1, // Adjusted from 3
-          },
-          {
-            productcode: 'L2201508',
-            amount: 1,
-          },
-        ],
-      },
-    } as Partial<IncomingOrderStatusWebhook>;
-    await adminClient.fetch(
-      `http://localhost:3050/picqer/hooks/${E2E_DEFAULT_CHANNEL_TOKEN}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(mockIncomingWebhook),
-        headers: {
-          'X-Picqer-Signature': createSignature(
-            mockIncomingWebhook,
-            'test-api-key'
-          ),
-        },
-      }
-    );
-    const order = await getOrder(adminClient, createdOrder?.id as string);
-    expect(order?.lines.length).toBe(2);
-    expect(order?.lines[0].productVariant.sku).toBe('L2201308');
-    expect(order?.lines[0].quantity).toBe(1);
-    expect(order?.lines[1].productVariant.sku).toBe('L2201508');
-    expect(order?.lines[1].quantity).toBe(1);
   });
 });
 


### PR DESCRIPTION
# Description

* Expose endpoint to periodically pull stock levels: `/picqer/stock-sync`
* Custom order process:
   * This plugin installs the default order process with `checkFulfillmentStates: false`, so that orders can be transitioned to Shipped and Delivered without the need of fulfilment. Fulfilment is the responsibility of Picqer, so we wont handle that in Vendure when using this plugin.

![!image](https://www.plantuml.com/plantuml/png/VOv1IyD048Nl-HNl1rH9Uog1I8iNRnQYtfVCn0nkPkFk1F7VIvgjfb2yBM_VVEyx97FHfi4NZrvO3NSFU6EbANA58n4iO0Sn7jBy394u5hbmrUrTmhP4ij1-87JBoIteoNt3AI6ncUT_Y4VlG-kCB_lL0d_M9wTKRyiDN6vGlLiJJj9-SgpGiDB2XuMSuaki3vEXctmdVc2r8l-ijvjv2TD8ytuNcSz1lR_7wvA9NifmwKfil_OgRy5VejCa9a7_x9fUnf5fy-lNHdOc-fv5pwQfECoCmVy0)
* The custom order process, together with a frequent full stock-sync, should make sure that:
   * Vendure stock is always up-to-date
   * Orders are always fulfillable after placement


# Checklist

:pushpin: Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

:zap: Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

:package: For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
