### PR TITLE
Popularity scores can now be set manually

### DIFF
--- a/packages/vendure-plugin-popularity-scores/CHANGELOG.md
+++ b/packages/vendure-plugin-popularity-scores/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0 (2023-12-15)
+
+- Allow manual setting of populairty scores on Products and Collections
+
 # 1.4.0 (2023-11-02)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-popularity-scores/package.json
+++ b/packages/vendure-plugin-popularity-scores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-popularity-scores",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Sort products and collections by popularity based on previously placed orders",
   "icon": "heart",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-popularity-scores/src/popularity-scores.plugin.ts
+++ b/packages/vendure-plugin-popularity-scores/src/popularity-scores.plugin.ts
@@ -33,13 +33,11 @@ export interface PopularityScoresPluginConfig {
       name: 'popularityScore',
       type: 'int',
       defaultValue: 0,
-      readonly: true,
     });
     config.customFields.Collection.push({
       name: 'popularityScore',
       type: 'int',
       defaultValue: 0,
-      readonly: true,
     });
     return config;
   },


### PR DESCRIPTION
# Description

The Changes in this PR allows us to set popularity scores manually.
# Breaking changes

Does this PR include any breaking changes we should be aware of? **NO**

# Screenshots

<img width="1470" alt="Screenshot 2023-12-15 at 11 24 52 AM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/cef94610-2f84-432a-b49c-61e59ac9730a">
<img width="1470" alt="Screenshot 2023-12-15 at 11 25 06 AM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/310ee3d6-0ca7-4182-bc1d-5f40631e4851">

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
