### PR TITLE
feat(google-cloud-tasks): fallback option

### DIFF
--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.4.0 (2023-12-19)
 
-- Allow setting `fallback:true` to fallback to HTTP instead of gRPC to prevent DEADLINE_EXCEEDED errors
+- Allow setting `fallback:true` to fallback to HTTP instead of gRPC to prevent DEADLINE_EXCEEDED errors. For more details see https://github.com/googleapis/nodejs-tasks/issues/397#issuecomment-618580649
 - Allow setting of all Google Cloud Tasks Client options via `clientOptions: ...`
 - Removed `bodySizeLimit` option, because body-parser is loaded by NestJs since Vendure V2
 

--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.0 (2023-12-19)
+
+- Allow setting `fallback:true` to fallback to HTTP instead of gRPC to prevent DEADLINE_EXCEEDED errors
+- Allow setting of all Google Cloud Tasks Client options via `clientOptions: ...`
+- Removed `bodySizeLimit` option, because body-parser is loaded by NestJs since Vendure V2
+
 # 1.3.0 (2023-11-21)
 
 - Only log error when job is not added to queue after configured retries

--- a/packages/vendure-plugin-google-cloud-tasks/README.md
+++ b/packages/vendure-plugin-google-cloud-tasks/README.md
@@ -50,3 +50,18 @@ curl -H "Authorization: Bearer some-secret-to-authenticate-cloud-tasks" "http://
 Will clear all jobs older than 1 day.
 
 <!-- (Use this to edit the diagram on plantuml.com: `//www.plantuml.com/plantuml/png/jL0zJyCm4DtzAzu8Kf2wi7H0HHsec4h9ZanyQGqN6tntLFdtEAb49If6Dkjz-DvxAr5Vr0PsRitPGklbNHxpwvEHqRCMhxGVSNE7X_NsvNC2bxWF0LK2pPWHzyDDmlCt6vy2KrbYQtB0MtLyHOzDssxTXUWFv_o8QO_UHwRGG38AQHbn5NjuLHe-LC3KQuEi1oh7A0JE9uSLWfSfx8wwNCBrvU5VtNQaLXBgAcg2syMYmJm5Zf4PbWALogM0g4X4uPIc9lpl4GXYNKSYlJ6FpLJntCkv5QLW0ty3`) -->
+
+# FAQ
+
+## DEADLINE_EXCEEDED errors when pushing tasks to queue
+
+When pushing multiple tasks concurrently to a queue in serverless environments, you might see `DEADLINE_EXCEEDED` errors. If that happens, you can instantiate the plugin with `fallback: true` to make the Google Cloud Tasks client fallback to HTTP instead of GRPC. For more details see https://github.com/googleapis/nodejs-tasks/issues/397#issuecomment-618580649
+
+```ts
+    CloudTasksPlugin.init({
+      ...
+      clientOptions: {
+        fallback: true
+      }
+    });
+```

--- a/packages/vendure-plugin-google-cloud-tasks/package.json
+++ b/packages/vendure-plugin-google-cloud-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-cloud-tasks",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Vendure plugin for using worker jobs with Google Cloud Tasks",
   "icon": "google-cloud",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -37,7 +37,7 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
   }
 
   constructor(private options: CloudTaskOptions) {
-    this.client = new CloudTasksClient();
+    this.client = new CloudTasksClient(options.clientOptions);
   }
 
   async findOne(id: ID): Promise<Job<any> | undefined> {

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -1,3 +1,5 @@
+import { ClientOptions } from 'google-gax';
+
 export interface CloudTaskOptions {
   taskHandlerHost: string;
   projectId: string;
@@ -13,10 +15,6 @@ export interface CloudTaskOptions {
    */
   queueSuffix?: string;
   /**
-   * Optional size limit to be passed to `body-parser/json`
-   */
-  bodySizeLimit?: string;
-  /**
    * Default nr of retries a job should attempt if no job.retries is given
    */
   defaultJobRetries?: number;
@@ -24,6 +22,10 @@ export interface CloudTaskOptions {
    * Nr of attempts the plugin should try to push a job to the queue, in case it fails. Default is 5, maximum is 20.
    */
   createTaskRetries?: number;
+  /**
+   * These options will be passed into the Google cloud task client.
+   */
+  clientOptions?: ClientOptions;
 }
 
 export interface CloudTaskMessage {

--- a/packages/vendure-plugin-google-cloud-tasks/test/dev-server.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/test/dev-server.ts
@@ -24,6 +24,9 @@ import { CloudTasksPlugin } from '../src/cloud-tasks.plugin';
       location: process.env.TASKQUEUE_LOCATION!,
       authSecret: 'some-secret-to-authenticate-cloud-tasks',
       queueSuffix: 'plugin-test2',
+      clientOptions: {
+        fallback: true,
+      },
     })
   );
   testConfig.plugins.push(AdminUiPlugin.init({ route: 'admin', port: 3002 }));

--- a/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/test/e2e.spec.ts
@@ -42,6 +42,9 @@ describe('CloudTasks job queue e2e', () => {
       onJobFailure: async (error) => {
         console.log('Custom error handler', error);
       },
+      clientOptions: {
+        fallback: true,
+      },
     })
   );
   testConfig.plugins.push(DefaultSearchPlugin);


### PR DESCRIPTION
# Description

- Allow setting `fallback:true` to fallback to HTTP instead of gRPC to prevent DEADLINE_EXCEEDED errors. For more details see https://github.com/googleapis/nodejs-tasks/issues/397#issuecomment-618580649
- Allow setting of all Google Cloud Tasks Client options via `clientOptions: ...`
- Removed `bodySizeLimit` option, because body-parser is loaded by NestJs since Vendure V2

# Breaking changes

Removed `bodySizeLimit` option, because body-parser is loaded by NestJs since Vendure V2

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
