### PR TITLE
fix(stripe-subscription): Dont throw errors for non-subscription variants

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.4.1 (2024-12-03)
 
-- Don't throw errors for variants that are not subscriptions
+- Return empty array instead of throwing an error for variants that are not subscriptions
 
 # 2.4.0 (2024-12-02)
 

--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.1 (2024-12-03)
+
+- Don't throw errors for variants that are not subscriptions
+
 # 2.4.0 (2024-12-02)
 
 - Made `isSubscription()` async and passed an instance of `Injector`, so that consumers can fetch additional relations inside `isSubscription()`;

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "icon": "credit-card-refresh",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -276,9 +276,7 @@ export class StripeSubscriptionService {
     }
     const injector = new Injector(this.moduleRef);
     if (!(await this.strategy.isSubscription(ctx, variant, injector))) {
-      throw new UserInputError(
-        `Product variant '${variant.id}' is not a subscription product`
-      );
+      return [];
     }
     const subscriptions = await this.strategy.previewSubscription(
       ctx,
@@ -530,11 +528,20 @@ export class StripeSubscriptionService {
     order: Order
   ): Promise<Subscription[]> {
     const injector = new Injector(this.moduleRef);
+    if (
+      !(await this.strategy.isSubscription(
+        ctx,
+        orderLine.productVariant,
+        injector
+      ))
+    ) {
+      return [];
+    }
     const subs = await this.strategy.defineSubscription(
       ctx,
       injector,
       orderLine.productVariant,
-      orderLine.order,
+      order,
       orderLine.customFields,
       orderLine.quantity
     );

--- a/packages/vendure-plugin-stripe-subscription/test/helpers/default-strategy-test-wrapper.ts
+++ b/packages/vendure-plugin-stripe-subscription/test/helpers/default-strategy-test-wrapper.ts
@@ -1,0 +1,16 @@
+import { RequestContext, ProductVariant } from '@vendure/core';
+import { DefaultSubscriptionStrategy } from '../../src';
+
+/**
+ * Wrapper around the built-int subscription strategy to allow testing
+ */
+export class DefaultStrategyTestWrapper extends DefaultSubscriptionStrategy {
+  isSubscription(ctx: RequestContext, variant: ProductVariant): boolean {
+    // Treat variant 2 as non-subscription
+    if (variant.id === 2) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/packages/vendure-plugin-stripe-subscription/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-stripe-subscription/test/helpers/graphql-helpers.ts
@@ -11,6 +11,22 @@ export const ADD_ITEM_TO_ORDER = gql`
         code
         totalWithTax
         total
+        lines {
+          id
+          stripeSubscriptions {
+            name
+            amountDueNow
+            variantId
+            priceIncludesTax
+            recurring {
+              amount
+              interval
+              intervalCount
+              startDate
+              endDate
+            }
+          }
+        }
       }
       ... on ErrorResult {
         errorCode

--- a/packages/vendure-plugin-stripe-subscription/test/stripe-subscription.spec.ts
+++ b/packages/vendure-plugin-stripe-subscription/test/stripe-subscription.spec.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { getOrder } from '../../test/src/admin-utils';
 import { initialData } from '../../test/src/initial-data';
 import { stripeSubscriptionHandler, StripeSubscriptionPlugin } from '../src';
+import { DefaultStrategyTestWrapper } from './helpers/default-strategy-test-wrapper';
 import {
   ADD_ITEM_TO_ORDER,
   CANCEL_ORDER,
@@ -54,6 +55,7 @@ describe('Stripe Subscription Plugin', function () {
         StripeSubscriptionPlugin.init({
           disableWebhookSignatureChecking: true,
           vendureHost: 'https://public-test-host.io',
+          subscriptionStrategy: new DefaultStrategyTestWrapper(),
         }),
       ],
     });
@@ -178,7 +180,10 @@ describe('Stripe Subscription Plugin', function () {
       await shopClient.query(PREVIEW_SUBSCRIPTIONS_FOR_PRODUCT, {
         productId: 'T_1',
       });
-    expect(subscriptions.length).toBe(4);
+    // T_2 is not a subscription, so it should not be in the preview result
+    const nonSubscription = subscriptions.find((s) => s.variantId === 'T_2');
+    expect(nonSubscription).toBeUndefined();
+    expect(subscriptions.length).toBe(3);
   });
 
   it('Previews subscription for variant for via admin API', async () => {
@@ -207,12 +212,15 @@ describe('Stripe Subscription Plugin', function () {
       await adminClient.query(PREVIEW_SUBSCRIPTIONS_FOR_PRODUCT, {
         productId: 'T_1',
       });
-    expect(subscriptions.length).toBe(4);
+    // T_2 is not a subscription, so it should not be in the preview result
+    const nonSubscription = subscriptions.find((s) => s.variantId === 'T_2');
+    expect(nonSubscription).toBeUndefined();
+    expect(subscriptions.length).toBe(3);
   });
 
   let orderCode;
 
-  it('Adds item to order', async () => {
+  it('Adds a subscription to order', async () => {
     await shopClient.asUserWithCredentials(
       'hayden.zieme12@hotmail.com',
       'test'
@@ -220,12 +228,26 @@ describe('Stripe Subscription Plugin', function () {
     const { addItemToOrder: order } = await shopClient.query(
       ADD_ITEM_TO_ORDER,
       {
-        productVariantId: 'T_1',
+        productVariantId: 'T_1', // Is subscription
         quantity: 1,
       }
     );
     orderCode = order.code;
     expect(order.total).toBe(129900);
+    expect(order.lines[0].stripeSubscriptions.length).toBe(1);
+  });
+
+  it('Adds a non-subscription item to order', async () => {
+    const { addItemToOrder: order } = await shopClient.query(
+      ADD_ITEM_TO_ORDER,
+      {
+        productVariantId: 'T_2', // Is subscription
+        quantity: 1,
+      }
+    );
+    orderCode = order.code;
+    expect(order.lines[0].stripeSubscriptions.length).toBe(1);
+    expect(order.lines[1].stripeSubscriptions.length).toBe(0);
   });
 
   it('Has subscriptions on an order line', async () => {
@@ -280,7 +302,9 @@ describe('Stripe Subscription Plugin', function () {
     expect(intent.intentType).toBe('PaymentIntent');
     expect(paymentIntentInput.setup_future_usage).toBe('off_session');
     expect(paymentIntentInput.customer).toBe('customer-test-id');
-    expect(paymentIntentInput.amount).toBe('156380');
+    // (T_1 + T_2) * tax + shipping
+    const totalDueNow = (129900 + 139900) * 1.2 + 500; // = 324260
+    expect(paymentIntentInput.amount).toBe(String(totalDueNow));
   });
 
   let createdSubscriptions: any[] = [];


### PR DESCRIPTION
# Description

Return empty array instead of throwing an error for variants that are not subscriptions + e2e tests


# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
