### PR TITLE
feat(vendure-order-client): login and active customer

### DIFF
--- a/packages/vendure-order-client/CHANGELOG.md
+++ b/packages/vendure-order-client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 2.7.0 (2023-12-06)
 
+- Added `getActiveCustomer` and `logout()` functions;
+- Removed `$currentUser` and `$eligibleShippingMethods` stores for simplicity. You should manually fetch that data in your project where needed.
+
+# 2.7.0 (2023-12-06)
+
 - Added `getMolliePaymentMethods` query
 
 # 2.6.1 (2023-12-01)

--- a/packages/vendure-order-client/CHANGELOG.md
+++ b/packages/vendure-order-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.7.0 (2023-12-06)
+# 2.8.0 (2024-01-04)
 
 - Added `getActiveCustomer` and `logout()` functions;
 - Removed `$currentUser` and `$eligibleShippingMethods` stores for simplicity. You should manually fetch that data in your project where needed.

--- a/packages/vendure-order-client/package.json
+++ b/packages/vendure-order-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-order-client",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "A tiny, framework agnostic client for managing active orders and checkout with Vendure.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-order-client/src/graphql-generated-types.ts
+++ b/packages/vendure-order-client/src/graphql-generated-types.ts
@@ -5270,6 +5270,43 @@ export interface LoginMutation {
       };
 }
 
+export type LogoutMutationVariables = Exact<Record<string, never>>;
+
+export interface LogoutMutation {
+  __typename?: 'Mutation';
+  logout: { __typename?: 'Success'; success: boolean };
+}
+
+export type ActiveCustomerQueryVariables = Exact<Record<string, never>>;
+
+export interface ActiveCustomerQuery {
+  __typename?: 'Query';
+  activeCustomer?:
+    | {
+        __typename?: 'Customer';
+        id: number | string;
+        createdAt: any;
+        updatedAt: any;
+        title?: string | undefined;
+        firstName: string;
+        lastName: string;
+        phoneNumber?: string | undefined;
+        emailAddress: string;
+        user?:
+          | {
+              __typename?: 'User';
+              id: number | string;
+              createdAt: any;
+              updatedAt: any;
+              identifier: string;
+              verified: boolean;
+              lastLogin?: any | undefined;
+            }
+          | undefined;
+      }
+    | undefined;
+}
+
 export type GetEligibleShippingMethodsQueryVariables = Exact<
   Record<string, never>
 >;

--- a/packages/vendure-order-client/src/queries.ts
+++ b/packages/vendure-order-client/src/queries.ts
@@ -359,6 +359,37 @@ export class GraphqlQueries {
     ${this.CURRENT_USER_FIELDS}
   `;
 
+  LOGOUT = gql`
+    mutation Logout {
+      logout {
+        success
+      }
+    }
+  `;
+
+  ACTIVE_CUSTOMER = gql`
+    query activeCustomer {
+      activeCustomer {
+        id
+        createdAt
+        updatedAt
+        title
+        firstName
+        lastName
+        phoneNumber
+        emailAddress
+        user {
+          id
+          createdAt
+          updatedAt
+          identifier
+          verified
+          lastLogin
+        }
+      }
+    }
+  `;
+
   GET_ELIGIBLE_SHIPPING_METHODS = gql`
     query GetEligibleShippingMethods {
       eligibleShippingMethods {

--- a/packages/vendure-order-client/test/vendure-order-client.spec.ts
+++ b/packages/vendure-order-client/test/vendure-order-client.spec.ts
@@ -40,7 +40,6 @@ class LocalStorageMock {
 
   removeItem(key: string): void {
     this.mockStorage[key] = undefined;
-    console.log('================', this.mockStorage);
   }
 }
 const localStorageMock = new LocalStorageMock();


### PR DESCRIPTION
# Description

- Added `getActiveCustomer` and `logout()` functions;
- Removed `$currentUser` and `$eligibleShippingMethods` stores for simplicity. You should manually fetch that data in your project where needed.

## Why?
`$currentUser` store was removed because it doesn't change based on actions executed, except login/logout, so it's overkill to make this a store. (My bad, I though this would come in handy).

`$eligibleShippingMethods` store was removed, because it's mostly only used in checkouts, and there you can just fetch the eligible shippingmethods when needed instead of on every cart change.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
