### PR TITLE
feat(sendcloud): fix transitioning to delivered

### DIFF
--- a/packages/util/src/order-state-util.ts
+++ b/packages/util/src/order-state-util.ts
@@ -48,7 +48,7 @@ export async function transitionToShipped(
   ctx: RequestContext,
   order: Order,
   handler: ConfigurableOperationInput
-): Promise<Fulfillment> {
+): Promise<Fulfillment | FulfillmentStateTransitionError> {
   const fulfillment = await fulfillAll(ctx, orderService, order, handler);
   const result = await orderService.transitionFulfillmentToState(
     ctx,
@@ -67,20 +67,31 @@ export async function transitionToDelivered(
   ctx: RequestContext,
   order: Order,
   handler: ConfigurableOperationInput
-): Promise<Fulfillment> {
-  const fulfillment = await transitionToShipped(
+): Promise<(Fulfillment | FulfillmentStateTransitionError)[]> {
+  const shippedResult = await transitionToShipped(
     orderService,
     ctx,
     order,
     handler
   );
-  const result = await orderService.transitionFulfillmentToState(
-    ctx,
-    fulfillment.id,
-    'Delivered'
-  );
-  throwIfTransitionFailed(result);
-  return result as Fulfillment;
+  let fulfillments: Fulfillment[] = [];
+  if ((shippedResult as FulfillmentStateTransitionError).errorCode) {
+    fulfillments = await orderService.getOrderFulfillments(ctx, order);
+  } else {
+    // if not an error, shippedResult is the only fulfillment
+    fulfillments.push(shippedResult as Fulfillment);
+  }
+  const results: (Fulfillment | FulfillmentStateTransitionError)[] = [];
+  for (const fulfillment of fulfillments) {
+    const result = await orderService.transitionFulfillmentToState(
+      ctx,
+      fulfillment.id,
+      'Delivered'
+    );
+    throwIfTransitionFailed(result);
+    results.push(result);
+  }
+  return results;
 }
 
 /**

--- a/packages/util/src/order-state-util.ts
+++ b/packages/util/src/order-state-util.ts
@@ -56,7 +56,7 @@ export async function transitionToShipped(
     'Shipped'
   );
   throwIfTransitionFailed(result);
-  return result as Fulfillment;
+  return result;
 }
 
 /**
@@ -96,6 +96,8 @@ export async function transitionToDelivered(
 
 /**
  * Throws the error result if the transition failed
+ * Ignores transition errors where from and to state are the same,
+ * because that still results in the situation we want
  */
 export function throwIfTransitionFailed(
   result:

--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1 (2024-01-16)
+
+- Updated vendure to 2.1.1
+
 # 1.1.0 (2023-10-24)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "icon": "truck",

--- a/packages/vendure-plugin-sendcloud/CHANGELOG.md
+++ b/packages/vendure-plugin-sendcloud/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.1 (2022-01-16)
+
+- Correctly transition order to Delivered after it has been Shipped
+
 # 1.2.0 (2023-11-16)
 
 - Fulfill on order placement, to prevent stock levels going out of sync

--- a/packages/vendure-plugin-sendcloud/package.json
+++ b/packages/vendure-plugin-sendcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-sendcloud",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Vendure plugin for syncing orders with SendCloud",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.service.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.service.ts
@@ -164,7 +164,7 @@ export class SendcloudService implements OnApplicationBootstrap {
     if (sendcloudStatus.orderState === 'Shipped') {
       await this.shipAll(ctx, order);
       return Logger.info(
-        `Successfully update order ${orderCode} to ${sendcloudStatus.orderState}`,
+        `Successfully updated order ${orderCode} to Shipped`,
         loggerCtx
       );
     }
@@ -177,7 +177,7 @@ export class SendcloudService implements OnApplicationBootstrap {
         arguments: [],
       });
       return Logger.info(
-        `Successfully update order ${orderCode} to ${sendcloudStatus.orderState}`,
+        `Successfully updated order ${orderCode} to Delivered`,
         loggerCtx
       );
     }

--- a/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
+++ b/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
@@ -222,7 +222,6 @@ describe('SendCloud', () => {
       }
     );
     const order = await getOrder(adminClient, String(orderId));
-    const fulfilment = order?.fulfillments?.[0];
     expect(order?.state).toBe('Delivered');
   });
 


### PR DESCRIPTION
# Description

Closes #312 

* Orders weren't being transitioned to Delivered after they had been shipped, because of a false type assertions.

See issue #312 for more details

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
