### PR TITLE
Google-cloud-tasks v1.5.0 : Prevent data too large error

### DIFF
--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.5.0 (2024-01-16)
+# 1.5.0 (2024-01-30)
 
-- Don't store `job.data` when it's too big for MySQL text
+- Don't store `job.data` when it's too big for MySQL text column
 - Remove jobs older than 30 days on application startup
 
 # 1.4.0 (2023-12-19)

--- a/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
+++ b/packages/vendure-plugin-google-cloud-tasks/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.5.0 (2024-01-16)
+
+- Don't store `job.data` when it's too big for MySQL text
+- Remove jobs older than 30 days on application startup
+
 # 1.4.0 (2023-12-19)
 
 - Allow setting `fallback:true` to fallback to HTTP instead of gRPC to prevent DEADLINE_EXCEEDED errors. For more details see https://github.com/googleapis/nodejs-tasks/issues/397#issuecomment-618580649

--- a/packages/vendure-plugin-google-cloud-tasks/package.json
+++ b/packages/vendure-plugin-google-cloud-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-cloud-tasks",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Vendure plugin for using worker jobs with Google Cloud Tasks",
   "icon": "google-cloud",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-controller.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-controller.ts
@@ -75,7 +75,7 @@ export class CloudTasksController implements OnApplicationBootstrap {
     }
     const days = parseInt(daysString);
     const daysAgo = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-    this.service.removeAllJobs(daysAgo);
+    await this.service.removeAllJobs(daysAgo);
     res.sendStatus(200);
   }
 

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-controller.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-controller.ts
@@ -29,7 +29,7 @@ import { loggerCtx } from '@vendure/core/dist/job-queue/constants';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
 
 @Controller(ROUTE)
-export class CloudTasksHandler implements OnApplicationBootstrap {
+export class CloudTasksController implements OnApplicationBootstrap {
   private jobRecordRepository: Repository<JobRecord>;
   private applicationBootstrapped = false;
 

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-controller.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-controller.ts
@@ -1,33 +1,18 @@
-import { Request, Response } from 'express';
 import {
   Controller,
-  Post,
-  Req,
   Get,
-  Res,
   OnApplicationBootstrap,
   Param,
+  Post,
+  Req,
+  Res,
 } from '@nestjs/common';
-import {
-  ConfigService,
-  Ctx,
-  Job,
-  JsonCompatible,
-  Logger,
-  RequestContext,
-  TransactionalConnection,
-} from '@vendure/core';
-import { JobState } from '@vendure/common/lib/generated-types';
-import { CloudTaskMessage, ROUTE } from './types';
-import { Repository } from 'typeorm';
-import { CloudTasksPlugin } from './cloud-tasks.plugin';
-import {
-  CloudTasksJobQueueStrategy,
-  PROCESS_MAP,
-} from './cloud-tasks-job-queue.strategy';
-import { loggerCtx } from '@vendure/core/dist/job-queue/constants';
-import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
+import { Logger } from '@vendure/core';
+import { Request, Response } from 'express';
 import { CloudTasksService } from './cloud-tasks-service';
+import { CloudTasksPlugin } from './cloud-tasks.plugin';
+import { loggerCtx } from './constants';
+import { CloudTaskMessage, ROUTE } from './types';
 
 @Controller(ROUTE)
 export class CloudTasksController implements OnApplicationBootstrap {

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -19,7 +19,7 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
   async add<Data extends JobData<Data> = {}>(
     job: Job<Data>
   ): Promise<Job<Data>> {
-    return this.service.add(job);
+    return await this.service.add(job);
   }
 
   /**
@@ -29,7 +29,7 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
     originalQueueName: string,
     process: (job: Job<Data>) => Promise<any>
   ) {
-    this.service.start(originalQueueName, process);
+    await this.service.start(originalQueueName, process);
   }
 
   /**
@@ -39,29 +39,31 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
     queueName: string,
     _process: (job: Job<Data>) => Promise<any>
   ) {
-    this.service.stop(queueName, _process);
+    await this.service.stop(queueName, _process);
   }
 
-  findOne(id: ID): Promise<Job<any> | undefined> {
-    return this.service.findJob(id);
+  async findOne(id: ID): Promise<Job<any> | undefined> {
+    return await this.service.findJob(id);
   }
-  findMany(
+
+  async findMany(
     options?: JobListOptions | undefined
   ): Promise<PaginatedList<Job<any>>> {
-    return this.service.findJobs(options);
-  }
-  findManyById(ids: ID[]): Promise<Job<any>[]> {
-    return this.service.findJobsById(ids);
+    return await this.service.findJobs(options);
   }
 
-  removeSettledJobs(
+  async findManyById(ids: ID[]): Promise<Job<any>[]> {
+    return await this.service.findJobsById(ids);
+  }
+
+  async removeSettledJobs(
     queueNames?: string[] | undefined,
     olderThan?: Date | undefined
   ): Promise<number> {
-    return this.service.removeSettledJobs(queueNames || [], olderThan);
+    return await this.service.removeSettledJobs(queueNames || [], olderThan);
   }
 
-  cancelJob(jobId: ID): Promise<Job<any> | undefined> {
-    return this.service.cancelJob(jobId);
+  async cancelJob(jobId: ID): Promise<Job<any> | undefined> {
+    return await this.service.cancelJob(jobId);
   }
 }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -1,29 +1,13 @@
-import { CloudTasksClient } from '@google-cloud/tasks';
+import { JobListOptions } from '@vendure/common/lib/generated-types';
 import {
   ID,
   Injector,
   InspectableJobQueueStrategy,
   Job,
   JobData,
-  JobQueueStrategy,
-  ListQueryBuilder,
-  Logger,
   PaginatedList,
-  TransactionalConnection,
-  User,
-  UserInputError,
 } from '@vendure/core';
-import { CloudTasksPlugin } from './cloud-tasks.plugin';
-import { CloudTaskMessage, CloudTaskOptions } from './types';
-import { In, LessThan, Repository, DataSource } from 'typeorm';
-import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
-import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
 import { CloudTasksService } from './cloud-tasks-service';
-
-const LIVE_QUEUES = new Set<string>();
-
-export type QueueProcessFunction = (job: Job) => Promise<any>;
-export const PROCESS_MAP = new Map<string, QueueProcessFunction>();
 
 export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
   private service!: CloudTasksService;

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-job-queue.strategy.ts
@@ -18,6 +18,7 @@ import { CloudTaskMessage, CloudTaskOptions } from './types';
 import { In, LessThan, Repository, DataSource } from 'typeorm';
 import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
+import { CloudTasksService } from './cloud-tasks-service';
 
 const LIVE_QUEUES = new Set<string>();
 
@@ -28,8 +29,10 @@ export class CloudTasksJobQueueStrategy implements InspectableJobQueueStrategy {
   private client: CloudTasksClient;
   private listQueryBuilder: ListQueryBuilder | undefined;
   private jobRecordRepository!: Repository<JobRecord>;
+  private service!: CloudTasksService;
 
   init(injector: Injector): void | Promise<void> {
+    this.service = injector.get(CloudTasksService);
     this.listQueryBuilder = injector.get(ListQueryBuilder);
     this.jobRecordRepository = injector
       .get(DataSource)

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
@@ -1,32 +1,278 @@
 
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { CloudTasksClient } from '@google-cloud/tasks';
 import {
-    ActiveOrderService,
-    ChannelService,
-    EntityHydrator,
-    ErrorResult,
+    ID,
+    Injector,
+    InspectableJobQueueStrategy,
+    Job,
+    JobData,
+    JobQueueStrategy,
     ListQueryBuilder,
     Logger,
-    OrderService,
-    OrderStateTransitionError,
-    PaymentMethodService,
-    RequestContext,
+    PaginatedList,
+    TransactionalConnection,
+    User,
+    UserInputError,
 } from '@vendure/core';
-import { coinbaseHandler } from './coinbase.handler';
-import { loggerCtx } from './constants';
-import { CoinbaseClient } from './coinbase.client';
-import { Repository, DataSource } from 'typeorm';
+import { CloudTasksPlugin } from './cloud-tasks.plugin';
+import { CloudTaskMessage, CloudTaskOptions } from './types';
+import { In, LessThan, Repository, DataSource } from 'typeorm';
+import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
+import { PLUGIN_INIT_OPTIONS } from './constants';
+
+type QueueProcessFunction = (job: Job) => Promise<any>;
 
 @Injectable()
 export class CloudTasksService {
 
+
+    LIVE_QUEUES = new Set<string>();
+    PROCESS_MAP = new Map<string, QueueProcessFunction>();
+    readonly jobRecordRepository: Repository<JobRecord>;
+
     constructor(
         private readonly listQueryBuilder: ListQueryBuilder,
-        private readonly dataSource: DataSource
-    )
+        @Inject(PLUGIN_INIT_OPTIONS) private readonly options: CloudTaskOptions,
+        dataSource: DataSource,
+
+    ) {
+        this.jobRecordRepository = dataSource.getRepository(JobRecord);
+    }
 
 
-    private  | undefined;
-    private jobRecordRepository!: Repository<JobRecord>;
+    async findOne(id: ID): Promise<Job<any> | undefined> {
+        if (!this.jobRecordRepository) {
+            throw new UserInputError('TransactionalConnection is not available');
+        }
+        const jobRecord = await this.jobRecordRepository.findOne({ where: { id } });
+        if (!jobRecord) {
+            throw new UserInputError(`No JobRecord with id ${id} exists`);
+        }
+        return new Job(jobRecord);
+    }
+
+    async findMany(
+        options?: JobListOptions | undefined
+    ): Promise<PaginatedList<Job<any>>> {
+        if (!this.listQueryBuilder) {
+            throw new UserInputError('ListQueryBuilder is not available');
+        }
+        return this.listQueryBuilder
+            .build(JobRecord, options)
+            .getManyAndCount()
+            .then(([items, totalItems]) => ({
+                items: items.map(this.fromRecord),
+                totalItems,
+            }));
+    }
+
+    async findManyById(ids: ID[]): Promise<Job<any>[]> {
+        if (!this.jobRecordRepository) {
+            throw new UserInputError('TransactionalConnection is not available');
+        }
+        return this.jobRecordRepository
+            .find({ where: { id: In(ids) } })
+            .then((records) => records.map(this.fromRecord));
+    }
+
+    async removeSettledJobs(
+        queueNames: string[],
+        olderThan?: Date | undefined
+    ): Promise<number> {
+        if (!this.jobRecordRepository) {
+            throw new UserInputError('TransactionalConnection is not available');
+        }
+        const result = await this.jobRecordRepository.delete({
+            ...(0 < queueNames.length ? { queueName: In(queueNames) } : {}),
+            isSettled: true,
+            settledAt: LessThan(olderThan ?? new Date()),
+        });
+        return result.affected || 0;
+    }
+
+    /**
+     * Remove all jobs older than given date.
+     * All queues, settled or unsettled
+     */
+    async removeAllJobs(olderThan: Date): Promise<void> {
+        if (!this.jobRecordRepository) {
+            throw new UserInputError('TransactionalConnection is not available');
+        }
+        await this.jobRecordRepository.delete({
+            createdAt: LessThan(olderThan),
+        });
+    }
+
+    async cancelJob(jobId: ID): Promise<Job<any> | undefined> {
+        await this.jobRecordRepository.delete({ id: jobId });
+        return;
+    }
+
+    private fromRecord(this: void, jobRecord: JobRecord): Job<any> {
+        return new Job<any>(jobRecord);
+    }
+
+    async add<Data extends JobData<Data> = {}>(
+        job: Job<Data>
+    ): Promise<Job<Data>> {
+        const queueName = this.getQueueName(job.queueName);
+        if (!this.LIVE_QUEUES.has(queueName)) {
+            await this.createQueue(queueName);
+        }
+        const retries = job.retries || this.options.defaultJobRetries || 3;
+        // Store record saying that the task is PENDING, because we don't distinguish between pending and running
+        const jobRecord = await this.saveWithRetry(
+            new JobRecord({
+                queueName: queueName,
+                data: job.data,
+                attempts: job.attempts,
+                state: JobState.PENDING,
+                startedAt: job.startedAt,
+                createdAt: job.createdAt,
+                isSettled: false,
+                retries,
+                progress: 0,
+            })
+        );
+        const cloudTaskMessage: CloudTaskMessage = {
+            id: jobRecord.id,
+            queueName: queueName,
+            data: job.data,
+            createdAt: job.createdAt,
+            maxRetries: retries,
+        };
+        const parent = this.getQueuePath(queueName);
+        const task = {
+            httpRequest: {
+                httpMethod: 'POST' as const,
+                headers: {
+                    'Content-type': 'application/json',
+                    Authorization: `Bearer ${this.options.authSecret}`,
+                },
+                url: `${this.options.taskHandlerHost}/cloud-tasks/handler`,
+                body: Buffer.from(JSON.stringify(cloudTaskMessage)).toString('base64'),
+            },
+        };
+        const request = { parent, task };
+        let currentAttempt = 0;
+        while (true) {
+            try {
+                const res = await this.client.createTask(request, {
+                    maxRetries: cloudTaskMessage.maxRetries,
+                });
+                Logger.debug(
+                    `Added job with retries=${cloudTaskMessage.maxRetries} to queue ${queueName}: ${cloudTaskMessage.id} for ${task.httpRequest.url}`,
+                    CloudTasksPlugin.loggerCtx
+                );
+                return new Job<any>(jobRecord);
+            } catch (e: any) {
+                currentAttempt += 1;
+                if (currentAttempt === (this.options.createTaskRetries ?? 5)) {
+                    Logger.error(
+                        `Failed to add task to queue ${queueName} in ${currentAttempt} attempts. Not retrying anymore! Error: ${e?.message}`,
+                        CloudTasksPlugin.loggerCtx,
+                        (e as Error)?.stack
+                    );
+                    throw e;
+                }
+                Logger.warn(
+                    `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
+                    CloudTasksPlugin.loggerCtx
+                );
+                // Exponential backoff after first 3 subsequent attempts
+                if (currentAttempt > 3) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, 1000 * 2 ** currentAttempt)
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Starts the job queue.
+     * We want to make this AS FAST AS POSSIBLE in order to reduce startup times.
+     * Therefore we lazily create the queue in the `add` method.
+     */
+    async start<Data extends JobData<Data> = {}>(
+        originalQueueName: string,
+        process: (job: Job<Data>) => Promise<any>
+    ) {
+        const queueName = this.getQueueName(originalQueueName);
+        PROCESS_MAP.set(queueName, process);
+        Logger.info(`Started queue ${queueName}`, CloudTasksPlugin.loggerCtx);
+    }
+
+    getAllQueueNames(): string[] {
+        return Array.from(PROCESS_MAP.keys());
+    }
+
+    /**
+     * Stops the job queue
+     */
+    async stop<Data extends JobData<Data> = {}>(
+        queueName: string,
+        _process: (job: Job<Data>) => Promise<any>
+    ) {
+        PROCESS_MAP.delete(this.getQueueName(queueName));
+        Logger.info(
+            `Stopped queue ${this.getQueueName(queueName)}`,
+            CloudTasksPlugin.loggerCtx
+        );
+    }
+
+    private async saveWithRetry(jobRecord: JobRecord): Promise<JobRecord> {
+        try {
+            return await this.jobRecordRepository.save(jobRecord);
+        } catch (e: any) {
+            if (e?.message?.indexOf('ER_DATA_TOO_LONG') > -1) {
+                // Save job without data
+                jobRecord.data = undefined;
+                return await this.jobRecordRepository.save(jobRecord);
+            }
+            throw e;
+        }
+    }
+
+    private getQueueName(name: string): string {
+        return this.options.queueSuffix
+            ? `${name}-${this.options.queueSuffix}`
+            : name;
+    }
+
+    private getQueuePath(queueName: string): string {
+        return this.client.queuePath(
+            this.options.projectId,
+            this.options.location,
+            queueName
+        );
+    }
+
+    private async createQueue(queueName: string): Promise<void> {
+        if (LIVE_QUEUES.has(queueName)) {
+            return; // Already added
+        }
+        try {
+            await this.client.createQueue({
+                parent: this.client.locationPath(
+                    this.options.projectId,
+                    this.options.location
+                ),
+                queue: { name: this.getQueuePath(queueName) },
+            });
+            LIVE_QUEUES.add(queueName);
+        } catch (error: any) {
+            if (error?.message?.indexOf('ALREADY_EXISTS') > -1) {
+                LIVE_QUEUES.add(queueName);
+                Logger.debug(
+                    `Queue ${queueName} already exists`,
+                    CloudTasksPlugin.loggerCtx
+                );
+            } else {
+                throw error;
+            }
+        }
+    }
 }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
@@ -9,7 +9,6 @@ import {
   ListQueryBuilder,
   Logger,
   PaginatedList,
-  UserInputError,
 } from '@vendure/core';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
 import { DataSource, In, LessThan, Repository } from 'typeorm';
@@ -50,12 +49,9 @@ export class CloudTasksService implements OnApplicationBootstrap {
   }
 
   async findJob(id: ID): Promise<Job<any> | undefined> {
-    if (!this.jobRecordRepository) {
-      throw new UserInputError('TransactionalConnection is not available');
-    }
     const jobRecord = await this.jobRecordRepository.findOne({ where: { id } });
     if (!jobRecord) {
-      throw new UserInputError(`No JobRecord with id ${id} exists`);
+      return undefined;
     }
     return new Job(jobRecord);
   }
@@ -95,9 +91,6 @@ export class CloudTasksService implements OnApplicationBootstrap {
    * All queues, settled or unsettled
    */
   async removeAllJobs(olderThan: Date): Promise<void> {
-    if (!this.jobRecordRepository) {
-      throw new UserInputError('TransactionalConnection is not available');
-    }
     await this.jobRecordRepository.delete({
       createdAt: LessThan(olderThan),
     });

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
@@ -1,0 +1,32 @@
+
+import { Injectable } from '@nestjs/common';
+import {
+    ActiveOrderService,
+    ChannelService,
+    EntityHydrator,
+    ErrorResult,
+    ListQueryBuilder,
+    Logger,
+    OrderService,
+    OrderStateTransitionError,
+    PaymentMethodService,
+    RequestContext,
+} from '@vendure/core';
+import { coinbaseHandler } from './coinbase.handler';
+import { loggerCtx } from './constants';
+import { CoinbaseClient } from './coinbase.client';
+import { Repository, DataSource } from 'typeorm';
+import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
+
+@Injectable()
+export class CloudTasksService {
+
+    constructor(
+        private readonly listQueryBuilder: ListQueryBuilder,
+        private readonly dataSource: DataSource
+    )
+
+
+    private  | undefined;
+    private jobRecordRepository!: Repository<JobRecord>;
+}

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
@@ -1,278 +1,373 @@
-
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, OnApplicationBootstrap } from '@nestjs/common';
 import { CloudTasksClient } from '@google-cloud/tasks';
 import {
-    ID,
-    Injector,
-    InspectableJobQueueStrategy,
-    Job,
-    JobData,
-    JobQueueStrategy,
-    ListQueryBuilder,
-    Logger,
-    PaginatedList,
-    TransactionalConnection,
-    User,
-    UserInputError,
+  ID,
+  Injector,
+  InspectableJobQueueStrategy,
+  Job,
+  JobData,
+  JobQueueStrategy,
+  JsonCompatible,
+  ListQueryBuilder,
+  Logger,
+  PaginatedList,
+  TransactionalConnection,
+  User,
+  UserInputError,
 } from '@vendure/core';
 import { CloudTasksPlugin } from './cloud-tasks.plugin';
 import { CloudTaskMessage, CloudTaskOptions } from './types';
 import { In, LessThan, Repository, DataSource } from 'typeorm';
 import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
-import { PLUGIN_INIT_OPTIONS } from './constants';
+import { loggerCtx, PLUGIN_INIT_OPTIONS } from './constants';
 
 type QueueProcessFunction = (job: Job) => Promise<any>;
 
 @Injectable()
-export class CloudTasksService {
+export class CloudTasksService implements OnApplicationBootstrap {
+  LIVE_QUEUES = new Set<string>();
+  PROCESS_MAP = new Map<string, QueueProcessFunction>();
+  readonly jobRecordRepository: Repository<JobRecord>;
+  readonly client: CloudTasksClient;
 
+  constructor(
+    private readonly listQueryBuilder: ListQueryBuilder,
+    @Inject(PLUGIN_INIT_OPTIONS) private readonly options: CloudTaskOptions,
+    dataSource: DataSource
+  ) {
+    this.jobRecordRepository = dataSource.getRepository(JobRecord);
+    this.client = new CloudTasksClient(options.clientOptions);
+  }
 
-    LIVE_QUEUES = new Set<string>();
-    PROCESS_MAP = new Map<string, QueueProcessFunction>();
-    readonly jobRecordRepository: Repository<JobRecord>;
+  onApplicationBootstrap() {
+    const daysAgo30 = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    this.removeAllJobs(daysAgo30)
+      .then(() => {
+        Logger.info(`Removed settled jobs`, loggerCtx);
+      })
+      .catch((e: any) => {
+        Logger.error(
+          `Failed to remove settled jobs: ${e?.message}`,
+          CloudTasksPlugin.loggerCtx,
+          e?.stack
+        );
+      });
+  }
 
-    constructor(
-        private readonly listQueryBuilder: ListQueryBuilder,
-        @Inject(PLUGIN_INIT_OPTIONS) private readonly options: CloudTaskOptions,
-        dataSource: DataSource,
-
-    ) {
-        this.jobRecordRepository = dataSource.getRepository(JobRecord);
+  async findJob(id: ID): Promise<Job<any> | undefined> {
+    if (!this.jobRecordRepository) {
+      throw new UserInputError('TransactionalConnection is not available');
     }
-
-
-    async findOne(id: ID): Promise<Job<any> | undefined> {
-        if (!this.jobRecordRepository) {
-            throw new UserInputError('TransactionalConnection is not available');
-        }
-        const jobRecord = await this.jobRecordRepository.findOne({ where: { id } });
-        if (!jobRecord) {
-            throw new UserInputError(`No JobRecord with id ${id} exists`);
-        }
-        return new Job(jobRecord);
+    const jobRecord = await this.jobRecordRepository.findOne({ where: { id } });
+    if (!jobRecord) {
+      throw new UserInputError(`No JobRecord with id ${id} exists`);
     }
+    return new Job(jobRecord);
+  }
 
-    async findMany(
-        options?: JobListOptions | undefined
-    ): Promise<PaginatedList<Job<any>>> {
-        if (!this.listQueryBuilder) {
-            throw new UserInputError('ListQueryBuilder is not available');
-        }
-        return this.listQueryBuilder
-            .build(JobRecord, options)
-            .getManyAndCount()
-            .then(([items, totalItems]) => ({
-                items: items.map(this.fromRecord),
-                totalItems,
-            }));
+  async findJobs(
+    options?: JobListOptions | undefined
+  ): Promise<PaginatedList<Job<any>>> {
+    return this.listQueryBuilder
+      .build(JobRecord, options)
+      .getManyAndCount()
+      .then(([items, totalItems]) => ({
+        items: items.map(this.fromRecord),
+        totalItems,
+      }));
+  }
+
+  async findJobsById(ids: ID[]): Promise<Job<any>[]> {
+    return this.jobRecordRepository
+      .find({ where: { id: In(ids) } })
+      .then((records) => records.map(this.fromRecord));
+  }
+
+  async removeSettledJobs(
+    queueNames: string[],
+    olderThan?: Date | undefined
+  ): Promise<number> {
+    const result = await this.jobRecordRepository.delete({
+      ...(0 < queueNames.length ? { queueName: In(queueNames) } : {}),
+      isSettled: true,
+      settledAt: LessThan(olderThan ?? new Date()),
+    });
+    return result.affected || 0;
+  }
+
+  /**
+   * Remove all jobs older than given date.
+   * All queues, settled or unsettled
+   */
+  async removeAllJobs(olderThan: Date): Promise<void> {
+    if (!this.jobRecordRepository) {
+      throw new UserInputError('TransactionalConnection is not available');
     }
+    await this.jobRecordRepository.delete({
+      createdAt: LessThan(olderThan),
+    });
+  }
 
-    async findManyById(ids: ID[]): Promise<Job<any>[]> {
-        if (!this.jobRecordRepository) {
-            throw new UserInputError('TransactionalConnection is not available');
-        }
-        return this.jobRecordRepository
-            .find({ where: { id: In(ids) } })
-            .then((records) => records.map(this.fromRecord));
+  async cancelJob(jobId: ID): Promise<Job<any> | undefined> {
+    await this.jobRecordRepository.delete({ id: jobId });
+    return;
+  }
+
+  async add<Data extends JobData<Data> = {}>(
+    job: Job<Data>
+  ): Promise<Job<Data>> {
+    const queueName = this.getQueueName(job.queueName);
+    if (!this.LIVE_QUEUES.has(queueName)) {
+      await this.createQueue(queueName);
     }
-
-    async removeSettledJobs(
-        queueNames: string[],
-        olderThan?: Date | undefined
-    ): Promise<number> {
-        if (!this.jobRecordRepository) {
-            throw new UserInputError('TransactionalConnection is not available');
-        }
-        const result = await this.jobRecordRepository.delete({
-            ...(0 < queueNames.length ? { queueName: In(queueNames) } : {}),
-            isSettled: true,
-            settledAt: LessThan(olderThan ?? new Date()),
+    const retries = job.retries || this.options.defaultJobRetries || 3;
+    // Store record saying that the task is PENDING, because we don't distinguish between pending and running
+    const jobRecord = await this.saveWithRetry(
+      new JobRecord({
+        queueName: queueName,
+        data: job.data,
+        attempts: job.attempts,
+        state: JobState.PENDING,
+        startedAt: job.startedAt,
+        createdAt: job.createdAt,
+        isSettled: false,
+        retries,
+        progress: 0,
+      })
+    );
+    const cloudTaskMessage: CloudTaskMessage = {
+      id: jobRecord.id,
+      queueName: queueName,
+      data: job.data,
+      createdAt: job.createdAt,
+      maxRetries: retries,
+    };
+    const parent = this.getQueuePath(queueName);
+    const task = {
+      httpRequest: {
+        httpMethod: 'POST' as const,
+        headers: {
+          'Content-type': 'application/json',
+          Authorization: `Bearer ${this.options.authSecret}`,
+        },
+        url: `${this.options.taskHandlerHost}/cloud-tasks/handler`,
+        body: Buffer.from(JSON.stringify(cloudTaskMessage)).toString('base64'),
+      },
+    };
+    const request = { parent, task };
+    let currentAttempt = 0;
+    while (true) {
+      try {
+        const res = await this.client.createTask(request, {
+          maxRetries: cloudTaskMessage.maxRetries,
         });
-        return result.affected || 0;
-    }
-
-    /**
-     * Remove all jobs older than given date.
-     * All queues, settled or unsettled
-     */
-    async removeAllJobs(olderThan: Date): Promise<void> {
-        if (!this.jobRecordRepository) {
-            throw new UserInputError('TransactionalConnection is not available');
-        }
-        await this.jobRecordRepository.delete({
-            createdAt: LessThan(olderThan),
-        });
-    }
-
-    async cancelJob(jobId: ID): Promise<Job<any> | undefined> {
-        await this.jobRecordRepository.delete({ id: jobId });
-        return;
-    }
-
-    private fromRecord(this: void, jobRecord: JobRecord): Job<any> {
+        Logger.debug(
+          `Added job (${cloudTaskMessage.id}) with retries=${cloudTaskMessage.maxRetries} to queue ${queueName} for ${task.httpRequest.url}`,
+          loggerCtx
+        );
         return new Job<any>(jobRecord);
-    }
-
-    async add<Data extends JobData<Data> = {}>(
-        job: Job<Data>
-    ): Promise<Job<Data>> {
-        const queueName = this.getQueueName(job.queueName);
-        if (!this.LIVE_QUEUES.has(queueName)) {
-            await this.createQueue(queueName);
+      } catch (e: any) {
+        currentAttempt += 1;
+        if (currentAttempt === (this.options.createTaskRetries ?? 5)) {
+          Logger.error(
+            `Failed to add task to queue ${queueName} in ${currentAttempt} attempts. Not retrying anymore! Error: ${e?.message}`,
+            loggerCtx,
+            (e as Error)?.stack
+          );
+          throw e;
         }
-        const retries = job.retries || this.options.defaultJobRetries || 3;
-        // Store record saying that the task is PENDING, because we don't distinguish between pending and running
-        const jobRecord = await this.saveWithRetry(
-            new JobRecord({
-                queueName: queueName,
-                data: job.data,
-                attempts: job.attempts,
-                state: JobState.PENDING,
-                startedAt: job.startedAt,
-                createdAt: job.createdAt,
-                isSettled: false,
-                retries,
-                progress: 0,
-            })
+        Logger.warn(
+          `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
+          loggerCtx
         );
-        const cloudTaskMessage: CloudTaskMessage = {
-            id: jobRecord.id,
-            queueName: queueName,
-            data: job.data,
-            createdAt: job.createdAt,
-            maxRetries: retries,
-        };
-        const parent = this.getQueuePath(queueName);
-        const task = {
-            httpRequest: {
-                httpMethod: 'POST' as const,
-                headers: {
-                    'Content-type': 'application/json',
-                    Authorization: `Bearer ${this.options.authSecret}`,
-                },
-                url: `${this.options.taskHandlerHost}/cloud-tasks/handler`,
-                body: Buffer.from(JSON.stringify(cloudTaskMessage)).toString('base64'),
-            },
-        };
-        const request = { parent, task };
-        let currentAttempt = 0;
-        while (true) {
-            try {
-                const res = await this.client.createTask(request, {
-                    maxRetries: cloudTaskMessage.maxRetries,
-                });
-                Logger.debug(
-                    `Added job with retries=${cloudTaskMessage.maxRetries} to queue ${queueName}: ${cloudTaskMessage.id} for ${task.httpRequest.url}`,
-                    CloudTasksPlugin.loggerCtx
-                );
-                return new Job<any>(jobRecord);
-            } catch (e: any) {
-                currentAttempt += 1;
-                if (currentAttempt === (this.options.createTaskRetries ?? 5)) {
-                    Logger.error(
-                        `Failed to add task to queue ${queueName} in ${currentAttempt} attempts. Not retrying anymore! Error: ${e?.message}`,
-                        CloudTasksPlugin.loggerCtx,
-                        (e as Error)?.stack
-                    );
-                    throw e;
-                }
-                Logger.warn(
-                    `Failed to add task to queue ${queueName} in attempt nr ${currentAttempt}: ${e?.message}`,
-                    CloudTasksPlugin.loggerCtx
-                );
-                // Exponential backoff after first 3 subsequent attempts
-                if (currentAttempt > 3) {
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, 1000 * 2 ** currentAttempt)
-                    );
-                }
-            }
+        // Exponential backoff after first 3 subsequent attempts
+        if (currentAttempt > 3) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, 1000 * 2 ** currentAttempt)
+          );
         }
+      }
     }
+  }
 
-    /**
-     * Starts the job queue.
-     * We want to make this AS FAST AS POSSIBLE in order to reduce startup times.
-     * Therefore we lazily create the queue in the `add` method.
-     */
-    async start<Data extends JobData<Data> = {}>(
-        originalQueueName: string,
-        process: (job: Job<Data>) => Promise<any>
-    ) {
-        const queueName = this.getQueueName(originalQueueName);
-        PROCESS_MAP.set(queueName, process);
-        Logger.info(`Started queue ${queueName}`, CloudTasksPlugin.loggerCtx);
+  /**
+   * Starts the job queue.
+   * We want to make this AS FAST AS POSSIBLE in order to reduce startup times.
+   * Therefore we lazily create the queue in the `add` method.
+   */
+  async start<Data extends JobData<Data> = {}>(
+    originalQueueName: string,
+    process: (job: Job<Data>) => Promise<any>
+  ) {
+    const queueName = this.getQueueName(originalQueueName);
+    this.PROCESS_MAP.set(queueName, process);
+    Logger.info(`Started queue ${queueName}`, loggerCtx);
+  }
+
+  getAllQueueNames(): string[] {
+    return Array.from(this.PROCESS_MAP.keys());
+  }
+
+  /**
+   * Handle incoming Cloud task message. Returns the HTTP status code to return to the Cloud Task.
+   */
+  async handleIncomingJob(
+    message: CloudTaskMessage,
+    attemptsHeader?: string
+  ): Promise<200 | 500> {
+    Logger.debug(`Received Cloud Task message ${message.id}`, loggerCtx);
+    const processFn = this.PROCESS_MAP.get(message.queueName);
+    if (!processFn) {
+      Logger.error(
+        `No process function found for queue ${message.queueName}`,
+        loggerCtx
+      );
+      return 500;
     }
-
-    getAllQueueNames(): string[] {
-        return Array.from(PROCESS_MAP.keys());
-    }
-
-    /**
-     * Stops the job queue
-     */
-    async stop<Data extends JobData<Data> = {}>(
-        queueName: string,
-        _process: (job: Job<Data>) => Promise<any>
-    ) {
-        PROCESS_MAP.delete(this.getQueueName(queueName));
-        Logger.info(
-            `Stopped queue ${this.getQueueName(queueName)}`,
-            CloudTasksPlugin.loggerCtx
-        );
-    }
-
-    private async saveWithRetry(jobRecord: JobRecord): Promise<JobRecord> {
+    const attempts = attemptsHeader ? parseInt(attemptsHeader) : 0;
+    const job = new Job({
+      id: message.id,
+      queueName: message.queueName,
+      data: message.data as JsonCompatible<unknown>,
+      attempts: attempts,
+      state: JobState.RUNNING,
+      startedAt: new Date(),
+      createdAt: message.createdAt,
+      retries: message.maxRetries,
+    });
+    try {
+      await processFn(job);
+      // The job was completed successfully
+      Logger.debug(
+        `Successfully handled ${message.id} after ${attempts} attempts`,
+        loggerCtx
+      );
+      await this.saveWithRetry(
+        new JobRecord({
+          id: job.id,
+          queueName: job.queueName,
+          data: job.data,
+          attempts: job.attempts,
+          state: JobState.COMPLETED,
+          startedAt: job.startedAt,
+          createdAt: job.createdAt,
+          retries: job.retries,
+          isSettled: true,
+          settledAt: new Date(),
+          progress: 100,
+        })
+      );
+      return 200;
+    } catch (error: any) {
+      if (this.options.onJobFailure) {
         try {
-            return await this.jobRecordRepository.save(jobRecord);
+          await this.options.onJobFailure(error);
         } catch (e: any) {
-            if (e?.message?.indexOf('ER_DATA_TOO_LONG') > -1) {
-                // Save job without data
-                jobRecord.data = undefined;
-                return await this.jobRecordRepository.save(jobRecord);
-            }
-            throw e;
+          Logger.error(`Error in 'onJobFailure': ${e}`, loggerCtx);
         }
-    }
-
-    private getQueueName(name: string): string {
-        return this.options.queueSuffix
-            ? `${name}-${this.options.queueSuffix}`
-            : name;
-    }
-
-    private getQueuePath(queueName: string): string {
-        return this.client.queuePath(
-            this.options.projectId,
-            this.options.location,
-            queueName
+      }
+      if (attempts === job.retries) {
+        // This was the final attempt, so mark the job as failed
+        Logger.error(
+          `Failed to handle message ${message.id} after final attempt (${attempts} attempts made). Marking with status 200 to prevent retries: ${error}`,
+          loggerCtx
         );
+        // Log failed job in DB
+        await this.saveWithRetry(
+          new JobRecord({
+            queueName: job.queueName,
+            data: job.data,
+            attempts: job.attempts,
+            state: JobState.FAILED,
+            startedAt: job.startedAt,
+            createdAt: job.createdAt,
+            retries: job.retries,
+            isSettled: true,
+            settledAt: new Date(),
+            progress: 0,
+            result: error?.message ?? error.toString(),
+          })
+        ).catch((e: any) => {
+          Logger.error(`Failed `, loggerCtx);
+        });
+        return 200; // Return 200 to prevent more retries
+      } else {
+        // More attempts remain, so return 500 to trigger a retry
+        Logger.warn(
+          `Failed to handle message ${message.id} after ${attempts} attempts. Retrying... ${error}`,
+          loggerCtx
+        );
+        return 500;
+      }
     }
+  }
 
-    private async createQueue(queueName: string): Promise<void> {
-        if (LIVE_QUEUES.has(queueName)) {
-            return; // Already added
-        }
-        try {
-            await this.client.createQueue({
-                parent: this.client.locationPath(
-                    this.options.projectId,
-                    this.options.location
-                ),
-                queue: { name: this.getQueuePath(queueName) },
-            });
-            LIVE_QUEUES.add(queueName);
-        } catch (error: any) {
-            if (error?.message?.indexOf('ALREADY_EXISTS') > -1) {
-                LIVE_QUEUES.add(queueName);
-                Logger.debug(
-                    `Queue ${queueName} already exists`,
-                    CloudTasksPlugin.loggerCtx
-                );
-            } else {
-                throw error;
-            }
-        }
+  /**
+   * Stops the job queue
+   */
+  async stop<Data extends JobData<Data> = {}>(
+    queueName: string,
+    _process: (job: Job<Data>) => Promise<any>
+  ) {
+    this.PROCESS_MAP.delete(this.getQueueName(queueName));
+    Logger.info(`Stopped queue ${this.getQueueName(queueName)}`, loggerCtx);
+  }
+
+  /**
+   * Save the job record with a retry when the data is too long
+   */
+  private async saveWithRetry(jobRecord: JobRecord): Promise<JobRecord> {
+    try {
+      return await this.jobRecordRepository.save(jobRecord);
+    } catch (e: any) {
+      if (e?.message?.indexOf('ER_DATA_TOO_LONG') > -1) {
+        // Save job without data
+        jobRecord.data = undefined;
+        return await this.jobRecordRepository.save(jobRecord);
+      }
+      throw e;
     }
+  }
+
+  private getQueueName(name: string): string {
+    return this.options.queueSuffix
+      ? `${name}-${this.options.queueSuffix}`
+      : name;
+  }
+
+  private getQueuePath(queueName: string): string {
+    return this.client.queuePath(
+      this.options.projectId,
+      this.options.location,
+      queueName
+    );
+  }
+
+  private fromRecord(this: void, jobRecord: JobRecord): Job<any> {
+    return new Job<any>(jobRecord);
+  }
+
+  private async createQueue(queueName: string): Promise<void> {
+    if (this.LIVE_QUEUES.has(queueName)) {
+      return; // Already added
+    }
+    try {
+      await this.client.createQueue({
+        parent: this.client.locationPath(
+          this.options.projectId,
+          this.options.location
+        ),
+        queue: { name: this.getQueuePath(queueName) },
+      });
+      this.LIVE_QUEUES.add(queueName);
+    } catch (error: any) {
+      if (error?.message?.indexOf('ALREADY_EXISTS') > -1) {
+        this.LIVE_QUEUES.add(queueName);
+        Logger.debug(`Queue ${queueName} already exists`, loggerCtx);
+      } else {
+        throw error;
+      }
+    }
+  }
 }

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
@@ -1,26 +1,20 @@
-import { Injectable, Inject, OnApplicationBootstrap } from '@nestjs/common';
 import { CloudTasksClient } from '@google-cloud/tasks';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import {
   ID,
-  Injector,
-  InspectableJobQueueStrategy,
   Job,
   JobData,
-  JobQueueStrategy,
   JsonCompatible,
   ListQueryBuilder,
   Logger,
   PaginatedList,
-  TransactionalConnection,
-  User,
   UserInputError,
 } from '@vendure/core';
-import { CloudTasksPlugin } from './cloud-tasks.plugin';
-import { CloudTaskMessage, CloudTaskOptions } from './types';
-import { In, LessThan, Repository, DataSource } from 'typeorm';
-import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
+import { DataSource, In, LessThan, Repository } from 'typeorm';
 import { loggerCtx, PLUGIN_INIT_OPTIONS } from './constants';
+import { CloudTaskMessage, CloudTaskOptions } from './types';
 
 type QueueProcessFunction = (job: Job) => Promise<any>;
 
@@ -49,7 +43,7 @@ export class CloudTasksService implements OnApplicationBootstrap {
       .catch((e: any) => {
         Logger.error(
           `Failed to remove settled jobs: ${e?.message}`,
-          CloudTasksPlugin.loggerCtx,
+          loggerCtx,
           e?.stack
         );
       });

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks-service.ts
@@ -112,6 +112,7 @@ export class CloudTasksService implements OnApplicationBootstrap {
     // Store record saying that the task is PENDING, because we don't distinguish between pending and running
     const jobRecord = await this.saveWithRetry(
       new JobRecord({
+        id: job.id,
         queueName: queueName,
         data: job.data,
         attempts: job.attempts,
@@ -263,6 +264,7 @@ export class CloudTasksService implements OnApplicationBootstrap {
         // Log failed job in DB
         await this.saveWithRetry(
           new JobRecord({
+            id: job.id,
             queueName: job.queueName,
             data: job.data,
             attempts: job.attempts,

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -9,7 +9,7 @@ import { CloudTasksController } from './cloud-tasks-controller';
 import { CloudTasksService } from './cloud-tasks-service';
 import { CloudTaskOptions } from './types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
-import { PLUGIN_INIT_OPTIONS } from './constants';
+import { loggerCtx, PLUGIN_INIT_OPTIONS } from './constants';
 
 @VendurePlugin({
   imports: [PluginCommonModule],
@@ -29,7 +29,6 @@ import { PLUGIN_INIT_OPTIONS } from './constants';
   compatibility: '^2.0.0',
 })
 export class CloudTasksPlugin {
-  static loggerCtx = 'CloudTaskPlugin';
   static options: CloudTaskOptions;
 
   static init(options: CloudTaskOptions): typeof CloudTasksPlugin {
@@ -41,7 +40,7 @@ export class CloudTasksPlugin {
       this.options.createTaskRetries = 20;
       Logger.warn(
         `createTaskRetries can be set to a maximum of 20 retries. This is to avoid too many stacked create task retries`,
-        this.loggerCtx
+        loggerCtx
       );
     }
     return CloudTasksPlugin;

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -16,15 +16,14 @@ import { PLUGIN_INIT_OPTIONS } from './constants';
   controllers: [CloudTasksController],
   entities: [JobRecord],
   providers: [
+    CloudTasksService,
     {
       provide: PLUGIN_INIT_OPTIONS,
       useFactory: () => CloudTasksPlugin.options,
     },
   ],
   configuration: (config: RuntimeVendureConfig) => {
-    config.jobQueueOptions.jobQueueStrategy = new CloudTasksJobQueueStrategy(
-      CloudTasksPlugin.options
-    );
+    config.jobQueueOptions.jobQueueStrategy = new CloudTasksJobQueueStrategy();
     return config;
   },
   compatibility: '^2.0.0',

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -9,11 +9,18 @@ import { CloudTasksController } from './cloud-tasks-controller';
 import { CloudTasksService } from './cloud-tasks-service';
 import { CloudTaskOptions } from './types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
+import { PLUGIN_INIT_OPTIONS } from './constants';
 
 @VendurePlugin({
   imports: [PluginCommonModule],
   controllers: [CloudTasksController],
   entities: [JobRecord],
+  providers: [
+    {
+      provide: PLUGIN_INIT_OPTIONS,
+      useFactory: () => CloudTasksPlugin.options,
+    },
+  ],
   configuration: (config: RuntimeVendureConfig) => {
     config.jobQueueOptions.jobQueueStrategy = new CloudTasksJobQueueStrategy(
       CloudTasksPlugin.options

--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -5,13 +5,14 @@ import {
   Logger,
 } from '@vendure/core';
 import { CloudTasksJobQueueStrategy } from './cloud-tasks-job-queue.strategy';
-import { CloudTasksHandler } from './cloud-tasks.handler';
+import { CloudTasksController } from './cloud-tasks-controller';
+import { CloudTasksService } from './cloud-tasks-service';
 import { CloudTaskOptions } from './types';
 import { JobRecord } from '@vendure/core/dist/plugin/default-job-queue-plugin/job-record.entity';
 
 @VendurePlugin({
   imports: [PluginCommonModule],
-  controllers: [CloudTasksHandler],
+  controllers: [CloudTasksController],
   entities: [JobRecord],
   configuration: (config: RuntimeVendureConfig) => {
     config.jobQueueOptions.jobQueueStrategy = new CloudTasksJobQueueStrategy(

--- a/packages/vendure-plugin-google-cloud-tasks/src/constants.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/constants.ts
@@ -1,0 +1,2 @@
+export const loggerCtx = 'CloudTaskPlugin';
+export const PLUGIN_INIT_OPTIONS = Symbol('PLUGIN_INIT_OPTIONS');


### PR DESCRIPTION
# Description

Sometimes job.data is too large to save in MySQL's text column, this fails job record savind, which in turn failed job processing.
* This PR retries saving without job.data when that happens
* This PR makes the plugin remove jobs older than 30 days on application startup
Needs to be deployed for Cantastic and WKW

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
