### PR TITLE
Feat/stripe subscriptions admin api fix incorrect validations

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.3 (2024-01-18)
+
+- Remove `active` check for admin API create Payment Intent as `Draft` orders are not the same as `active` orders and there is no adequate way to manipulate the `active` state directly.
+
 # 2.4.2 (2024-01-18)
 
 - Allow admin API to create Payment Intent based on specified orderId, since there is no concept of an `activeOrder` for an admin

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "icon": "credit-card-refresh",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.resolver.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.resolver.ts
@@ -131,7 +131,7 @@ export class StripeSubscriptionAdminApiResolver {
     @Ctx() ctx: RequestContext,
     @Args() args: MutationCreateStripeSubscriptionIntentArgs
   ): Promise<GraphqlAdminMutation['createStripeSubscriptionIntent']> {
-    const res = await this.stripeSubscriptionService.createIntentByOrderId(
+    const res = await this.stripeSubscriptionService.createIntentForDraftOrder(
       ctx,
       args.orderId
     );

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -411,9 +411,12 @@ export class StripeSubscriptionService {
     if (!order) {
       throw new EntityNotFoundError('Order', orderId);
     }
-    if (!order.active) {
-      throw new UserInputError('No active order for session');
-    }
+    // TODO this should maybe be removed? Active orders are carts. So when an admin edits an order
+    // a user could finish it in his cart. And the other way around. Not really an issue perhaps unless the admin can change settings
+    // an end user cannot
+    // if (!order.active) {
+    //   throw new UserInputError('No active order for session');
+    // }
     return this.createIntentByOrder(ctx, order);
   }
 

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -403,7 +403,7 @@ export class StripeSubscriptionService {
     return this.createIntentByOrder(ctx, order);
   }
 
-  async createIntentByOrderId(
+  async createIntentForDraftOrder(
     ctx: RequestContext,
     orderId: ID
   ): Promise<StripeSubscriptionIntent> {
@@ -411,12 +411,8 @@ export class StripeSubscriptionService {
     if (!order) {
       throw new EntityNotFoundError('Order', orderId);
     }
-    // TODO this should maybe be removed? Active orders are carts. So when an admin edits an order
-    // a user could finish it in his cart. And the other way around. Not really an issue perhaps unless the admin can change settings
-    // an end user cannot
-    // if (!order.active) {
-    //   throw new UserInputError('No active order for session');
-    // }
+    // TODO Perhaps need an order state check (Draft, ArrangingPayment) here?
+    // But state transition verification will likely be a good place for this as well
     return this.createIntentByOrder(ctx, order);
   }
 


### PR DESCRIPTION
# Description

Removed the incorrect active check on the admin api and rename the admin api intent function to `createIntentForDraftOrder` to make it more explicit for potential additional validation checks to be added

# Breaking changes

No

# Screenshots


# Checklist

📌 Always:
- [x ] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

📦 For publishable packages:
- [x ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
