### PR TITLE
Popularity Scores Calculation Fix

### DIFF
--- a/packages/vendure-plugin-popularity-scores/CHANGELOG.md
+++ b/packages/vendure-plugin-popularity-scores/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.0 (2024-01-21)
+
+- Aggregate the child `Product`s of a `Collection` in chunks when calcuating it's `popularityScore`. This adjustment aims to address [this reported issue](https://github.com/Pinelab-studio/pinelab-vendure-plugins/issues/303)
+
 # 1.5.0 (2023-12-15)
 
 - Allow manual setting of populairty scores on Products and Collections

--- a/packages/vendure-plugin-popularity-scores/package.json
+++ b/packages/vendure-plugin-popularity-scores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-popularity-scores",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Sort products and collections by popularity based on previously placed orders",
   "icon": "heart",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-popularity-scores/src/index.ts
+++ b/packages/vendure-plugin-popularity-scores/src/index.ts
@@ -1,2 +1,2 @@
 export * from './popularity-scores.plugin';
-export * from './sort.service';
+export * from './popularity-scores.service';

--- a/packages/vendure-plugin-popularity-scores/src/popularity-scores.plugin.ts
+++ b/packages/vendure-plugin-popularity-scores/src/popularity-scores.plugin.ts
@@ -2,19 +2,25 @@ import { PluginCommonModule, Type, VendurePlugin } from '@vendure/core';
 import { gql } from 'graphql-tag';
 import { PLUGIN_INIT_OPTIONS } from './constants';
 import { OrderByPopularityController } from './popularity.controller';
-import { SortService } from './sort.service';
+import { PopularityScoresService } from './popularity-scores.service';
 
 export interface PopularityScoresPluginConfig {
   /**
    * Prevent unauthenticated requests to the calculation endpoint
    */
   endpointSecret: string;
+  /**
+   * chunk size for product score summing query
+   *
+   * @default 100
+   */
+  chunkSize?: number;
 }
 
 @VendurePlugin({
   imports: [PluginCommonModule],
   providers: [
-    SortService,
+    PopularityScoresService,
     {
       provide: PLUGIN_INIT_OPTIONS,
       useFactory: () => PopularityScoresPlugin.config,
@@ -50,6 +56,9 @@ export class PopularityScoresPlugin {
     config: PopularityScoresPluginConfig
   ): Type<PopularityScoresPlugin> {
     this.config = config;
+    if (!this.config?.chunkSize) {
+      this.config.chunkSize = 100;
+    }
     return this;
   }
 }

--- a/packages/vendure-plugin-popularity-scores/src/popularity-scores.service.ts
+++ b/packages/vendure-plugin-popularity-scores/src/popularity-scores.service.ts
@@ -143,9 +143,9 @@ export class PopularityScoresService implements OnModuleInit {
 
       const uniqueProductIds = [...new Set(productIds)];
       if (uniqueProductIds.length) {
-        var sliceArray = (arr: number[], chunkSize: number): number[][] => {
-          var result = [];
-          for (var i = 0; i < arr.length; i += chunkSize) {
+        const sliceArray = (arr: number[], chunkSize: number): number[][] => {
+          const result = [];
+          for (let i = 0; i < arr.length; i += chunkSize) {
             if (i + chunkSize < arr.length) {
               result.push(arr.slice(i, i + chunkSize));
             } else {

--- a/packages/vendure-plugin-popularity-scores/src/popularity-scores.service.ts
+++ b/packages/vendure-plugin-popularity-scores/src/popularity-scores.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@vendure/core';
 import { PLUGIN_INIT_OPTIONS, loggerCtx } from './constants';
 import { PopularityScoresPluginConfig } from './popularity-scores.plugin';
+import { sliceArray } from './utils';
 @Injectable()
 export class PopularityScoresService implements OnModuleInit {
   private jobQueue!: JobQueue<{
@@ -143,17 +144,6 @@ export class PopularityScoresService implements OnModuleInit {
 
       const uniqueProductIds = [...new Set(productIds)];
       if (uniqueProductIds.length) {
-        const sliceArray = (arr: number[], chunkSize: number): number[][] => {
-          const result = [];
-          for (let i = 0; i < arr.length; i += chunkSize) {
-            if (i + chunkSize < arr.length) {
-              result.push(arr.slice(i, i + chunkSize));
-            } else {
-              result.push(arr.slice(i));
-            }
-          }
-          return result;
-        };
         let score = 0;
         const chunkedProductIds = sliceArray(
           uniqueProductIds,

--- a/packages/vendure-plugin-popularity-scores/src/popularity.controller.ts
+++ b/packages/vendure-plugin-popularity-scores/src/popularity.controller.ts
@@ -7,7 +7,7 @@ import { PopularityScoresService } from './popularity-scores.service';
 @Controller('/popularity-scores')
 export class OrderByPopularityController {
   constructor(
-    private sortService: PopularityScoresService,
+    private popularityScoreService: PopularityScoresService,
     @Inject(PLUGIN_INIT_OPTIONS) private config: PopularityScoresPluginConfig
   ) {}
 
@@ -20,6 +20,6 @@ export class OrderByPopularityController {
     if (secret !== this.config.endpointSecret) {
       throw new UnauthorizedError();
     }
-    await this.sortService.addScoreCalculatingJobToQueue(token, ctx);
+    await this.popularityScoreService.addScoreCalculatingJobToQueue(token, ctx);
   }
 }

--- a/packages/vendure-plugin-popularity-scores/src/popularity.controller.ts
+++ b/packages/vendure-plugin-popularity-scores/src/popularity.controller.ts
@@ -2,12 +2,12 @@ import { Controller, Get, Param, Inject } from '@nestjs/common';
 import { Ctx, RequestContext, UnauthorizedError } from '@vendure/core';
 import { PLUGIN_INIT_OPTIONS } from './constants';
 import { PopularityScoresPluginConfig } from './popularity-scores.plugin';
-import { SortService } from './sort.service';
+import { PopularityScoresService } from './popularity-scores.service';
 
 @Controller('/popularity-scores')
 export class OrderByPopularityController {
   constructor(
-    private sortService: SortService,
+    private sortService: PopularityScoresService,
     @Inject(PLUGIN_INIT_OPTIONS) private config: PopularityScoresPluginConfig
   ) {}
 

--- a/packages/vendure-plugin-popularity-scores/src/utils.ts
+++ b/packages/vendure-plugin-popularity-scores/src/utils.ts
@@ -1,0 +1,11 @@
+export const sliceArray = (arr: number[], chunkSize: number): number[][] => {
+  const result = [];
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    if (i + chunkSize < arr.length) {
+      result.push(arr.slice(i, i + chunkSize));
+    } else {
+      result.push(arr.slice(i));
+    }
+  }
+  return result;
+};

--- a/packages/vendure-plugin-popularity-scores/test/e2e.spec.ts
+++ b/packages/vendure-plugin-popularity-scores/test/e2e.spec.ts
@@ -35,6 +35,7 @@ describe('Sort by Popularity Plugin', function () {
       plugins: [
         PopularityScoresPlugin.init({
           endpointSecret: 'test-secret',
+          chunkSize: 1,
         }),
       ],
       paymentOptions: {


### PR DESCRIPTION
# Description

The modifications in this PR involve aggregating the child `Product`s of a `Collection` in chunks when calculating it's `popularityScore`. This adjustment aims to address [this reported issue](https://github.com/Pinelab-studio/pinelab-vendure-plugins/issues/303). Closes #303 
# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
