### PR TITLE
fix(selectable-gifts): mysql bugfix

### DIFF
--- a/packages/vendure-plugin-selectable-gifts/CHANGELOG.md
+++ b/packages/vendure-plugin-selectable-gifts/CHANGELOG.md
@@ -1,7 +1,11 @@
-# 1.0.0 (2023-11-22)
+# 1.1.1 (2023-11-22)
 
-- Initial release
+- MySQL bugfix and use stock level service for resolving stock
 
 # 1.1.0 (2023-11-22)
 
 - `eligibleGifts` bug fix as reported in #326
+
+# 1.0.0 (2023-11-22)
+
+- Initial release

--- a/packages/vendure-plugin-selectable-gifts/CHANGELOG.md
+++ b/packages/vendure-plugin-selectable-gifts/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.1 (2023-11-22)
+# 1.1.1 (2024-01-23)
 
 - MySQL bugfix and use stock level service for resolving stock
 

--- a/packages/vendure-plugin-selectable-gifts/package.json
+++ b/packages/vendure-plugin-selectable-gifts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-selectable-gifts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vendure plugin to enable free customer selected gifts",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "repository": "https://github.com/martijnvdbrug/pinelab-vendure-plugins",


### PR DESCRIPTION
# Description

* v1.1.0 is throwing an error on MySQL: 
```
"ER_WRONG_FIELD_WITH_GROUP: Expression #15 of SELECT list is not in GROUP BY clause and contains
nonaggregated column 'wkw-prod.productVariantPrices.createdAt' which is not functionally dependent 
on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by"
```
* Consumers can use a custom [StockAllocationStrategy](https://docs.vendure.io/reference/typescript-api/orders/stock-allocation-strategy/), and by fetching directly from the DB, this strategy isn't used. This makes the plugin less usable for customers that use a custom strategy. The plugin now uses the variant service again. (a little less performant, but better supported)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
