### PR TITLE
feat(modify-customer-orders): dont crash server

### DIFF
--- a/packages/vendure-plugin-modify-customer-orders/CHANGELOG.md
+++ b/packages/vendure-plugin-modify-customer-orders/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1 (2024-01-23)
+
+- Deactivate order when an active order already exists, instead of deleting it.
+
 # 1.1.0 (2023-10-24)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-modify-customer-orders/package.json
+++ b/packages/vendure-plugin-modify-customer-orders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-modify-customer-orders",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vendure plugin for converting Active orders to Draft",
   "icon": "file",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-modify-customer-orders/test/modify-customer-orders.spec.ts
+++ b/packages/vendure-plugin-modify-customer-orders/test/modify-customer-orders.spec.ts
@@ -84,14 +84,11 @@ describe('Customer managed groups', function () {
   });
 
   it('Should not change non active order to draft order', async () => {
-    const testNonActiveOrder = await createSettledOrder(shopClient, 1);
+    const testNonActiveOrder = (await createSettledOrder(shopClient, 1)) as any;
     try {
-      const { convertOrderToDraft: draftOrder } = await adminClient.query(
-        convertToDraftMutation,
-        {
-          id: testNonActiveOrder.id,
-        }
-      );
+      await adminClient.query(convertToDraftMutation, {
+        id: testNonActiveOrder.id,
+      });
     } catch (e) {
       expect((e as any).response.errors[0].message).toBe(
         'Only active orders can be changed to a draft order'


### PR DESCRIPTION
# Description

* Always catch any promise errors in listeneres to prevent server crashes.
* Deactivate instead of delete in case of already present active order

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
