### PR TITLE
Fix(Invoices): Dont throw error for active orders and sort DESC

### DIFF
--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.0.2 (2024-02-07)
 
 - Sort by latest invoices first in admin UI
-- Don't throw an error when a user
+- Don't throw error for orders without customer, because the order can be in an active state
 
 # 2.0.1 (2024-01-23)
 

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 2.0.1 (2024-01-32)
+# 2.0.2 (2024-02-07)
+
+- Sort by latest invoices first in admin UI
+- Don't throw an error when a user
+
+# 2.0.1 (2024-01-23)
 
 - Added script for migrating to V2
 - Updated default template to support credit invoices

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-invoices",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Vendure plugin for invoice generation",
   "icon": "receipt",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-invoices/src/api/invoice-common.resolver.ts
+++ b/packages/vendure-plugin-invoices/src/api/invoice-common.resolver.ts
@@ -36,9 +36,7 @@ export class InvoiceCommonResolver {
     );
     await this.entityHydrator.hydrate(ctx, order, { relations: ['customer'] });
     if (!order.customer?.emailAddress) {
-      throw new UserInputError(
-        `Can not fetch invoices for an order without 'customer.emailAddress'`
-      );
+      return [];
     }
     return invoices.map((invoice) => ({
       ...invoice,

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -244,18 +244,15 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
       path: tmpFilePath,
       type: '',
     };
-
-    if (process.env.NODE_ENV === 'test') {
-      pdf.create(document, options).catch((error: any) => {
-        Logger.error(JSON.stringify(error), loggerCtx);
-      });
-    } else {
-      try {
-        await pdf.create(document, options);
-      } catch (e) {
-        Logger.error(JSON.stringify(e), loggerCtx);
-        throw e;
-      }
+    try {
+      await pdf.create(document, options);
+    } catch (e: any) {
+      Logger.error(
+        `Failed to generate invoice: ${e?.message}`,
+        loggerCtx,
+        e.stack
+      );
+      throw e;
     }
 
     return {
@@ -343,7 +340,7 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
       where: {
         orderId: String(orderId),
       },
-      order: { createdAt: 'ASC' },
+      order: { createdAt: 'DESC' },
     });
   }
 

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -337,7 +337,7 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
       where: {
         orderId: String(orderId),
       },
-      order: { createdAt: 'DESC' },
+      order: { invoiceNumber: 'DESC' },
     });
   }
 

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -247,11 +247,8 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
     try {
       await pdf.create(document, options);
     } catch (e: any) {
-      Logger.error(
-        `Failed to generate invoice: ${e?.message}`,
-        loggerCtx,
-        e.stack
-      );
+      // Warning, because this will be retried, or is returned to the user
+      Logger.warn(`Failed to generate invoice: ${e?.message}`, loggerCtx);
       throw e;
     }
 

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -215,14 +215,14 @@ describe('Generate with credit invoicing enabled', function () {
       id: order.id,
     });
     const invoices: Invoice[] = result.invoices;
-    // First invoice
+    // Latest invoice
     expect(invoices.length).toBe(3);
-    expect(invoices[0].invoiceNumber).toBe(1);
+    expect(invoices[2].invoiceNumber).toBe(1);
     // Credit invoice
     expect(invoices[1].invoiceNumber).toBe(2);
     expect(invoices[1].isCreditInvoice).toBe(true);
-    // New invoice
-    expect(invoices[2].invoiceNumber).toBe(3);
+    // First invoice
+    expect(invoices[0].invoiceNumber).toBe(3);
   });
 });
 

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -215,6 +215,7 @@ describe('Generate with credit invoicing enabled', function () {
       id: order.id,
     });
     const invoices: Invoice[] = result.invoices;
+    console.log(JSON.stringify(invoices, null, 2));
     // Latest invoice
     expect(invoices.length).toBe(3);
     expect(invoices[2].invoiceNumber).toBe(1);

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -215,7 +215,6 @@ describe('Generate with credit invoicing enabled', function () {
       id: order.id,
     });
     const invoices: Invoice[] = result.invoices;
-    console.log(JSON.stringify(invoices, null, 2));
     // Latest invoice
     expect(invoices.length).toBe(3);
     expect(invoices[2].invoiceNumber).toBe(1);


### PR DESCRIPTION
# Description

- Sort by latest invoices first in admin UI
- Don't throw error for orders without customer, because the order can be in an active state

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
