### PR TITLE
RequestContext should also be an argument to ShippingExtensionsOptions.weightCalculationFunction

### DIFF
--- a/packages/vendure-plugin-shipping-extensions/CHANGELOG.md
+++ b/packages/vendure-plugin-shipping-extensions/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.1 (2024-02-26)
+
+- Include `RequestContext` as an additional argument to `ShippingExtensionsOptions.weightCalculationFunction`
+
 # 2.5.0 (2024-02-19)
 
 - Made `ShippingExtensionsOptions.weightCalculationFunction` async and accept `Injector` as an additional argument

--- a/packages/vendure-plugin-shipping-extensions/package.json
+++ b/packages/vendure-plugin-shipping-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-shipping-extensions",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Vendure plugin for configurable shipping calculators and eligibility checkers.",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-shipping-extensions/src/config/weight-and-country-checker.ts
+++ b/packages/vendure-plugin-shipping-extensions/src/config/weight-and-country-checker.ts
@@ -125,6 +125,7 @@ export const weightAndCountryChecker = new ShippingEligibilityChecker({
     if (ShippingExtensionsPlugin.options?.weightCalculationFunction) {
       totalOrderWeight =
         await ShippingExtensionsPlugin.options.weightCalculationFunction(
+          ctx,
           order,
           injector
         );

--- a/packages/vendure-plugin-shipping-extensions/src/shipping-extensions.plugin.ts
+++ b/packages/vendure-plugin-shipping-extensions/src/shipping-extensions.plugin.ts
@@ -3,6 +3,7 @@ import {
   LanguageCode,
   Order,
   PluginCommonModule,
+  RequestContext,
   VendurePlugin,
 } from '@vendure/core';
 import { weightAndCountryChecker } from './config/weight-and-country-checker';
@@ -30,6 +31,7 @@ export interface ShippingExtensionsOptions {
    * By default the shipping eligibility checker will use the weight custom fields.
    */
   weightCalculationFunction?: (
+    ctx: RequestContext,
     order: Order,
     injector: Injector
   ) => Promise<number>;


### PR DESCRIPTION
# Description

The changes in this PR adds `RequestContext` as an additional argument to `ShippingExtensionsOptions.weightCalculationFunction`
# Breaking changes

We will need to pass `RequestContext` when calling `ShippingExtensionsOptions.weightCalculationFunction`
# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced shipping weight calculation by including request context for more accurate and context-aware calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->