### PR TITLE
Limit Variant per Order Plugin Adjustments

### DIFF
--- a/packages/vendure-plugin-limit-variant-per-order/CHANGELOG.md
+++ b/packages/vendure-plugin-limit-variant-per-order/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0 (2024-03-08)
+
+- Added support for adding a multiple of `onlyAllowPer` of a `ProductVariant` per `Order`
+
 # 1.1.0 (2023-10-24)
 
 - Updated vendure to 2.1.1

--- a/packages/vendure-plugin-limit-variant-per-order/README.md
+++ b/packages/vendure-plugin-limit-variant-per-order/README.md
@@ -14,6 +14,6 @@ plugins: [LimitVariantPerOrderPlugin];
 ```
 
 2. Start Vendure, login and go to the product you want to limit.
-3. Set the custom field `Maximum amount per order` on a variant and update the product
+3. Set the custom field `Maximum amount per order` and `Multiple of per order` on a variant and update the product
 4. Customers can now only buy X amount of the variant per order. The same customer can still order the product again in
    a new order.

--- a/packages/vendure-plugin-limit-variant-per-order/package.json
+++ b/packages/vendure-plugin-limit-variant-per-order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-limit-variant-per-order",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Vendure plugin to limit the amount of a specific product that can be ordered per order.",
   "icon": "shield-lock",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-limit-variant-per-order/src/add-item-override.resolver.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/add-item-override.resolver.ts
@@ -70,7 +70,7 @@ export class AddItemOverrideResolver extends ShopOrderResolver {
     const onlyAllowPer = orderLine.productVariant.customFields.onlyAllowPer;
     if (
       (maxPerOrder && orderLine.quantity > maxPerOrder) ||
-      (onlyAllowPer && orderLine.quantity % onlyAllowPer === 1)
+      (onlyAllowPer && orderLine.quantity % onlyAllowPer !== 0)
     ) {
       const maxPerOrderMessage = maxPerOrder ? `max ${maxPerOrder}` : '';
       const and = maxPerOrder && onlyAllowPer ? ' and ' : '';

--- a/packages/vendure-plugin-limit-variant-per-order/src/add-item-override.resolver.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/add-item-override.resolver.ts
@@ -66,15 +66,23 @@ export class AddItemOverrideResolver extends ShopOrderResolver {
     const orderLine = order.lines.find(
       (line) => line.productVariant.id == variantId
     )!;
-    const maxPerOrder = (orderLine.productVariant.customFields as any)
-      .maxPerOrder;
-    if (maxPerOrder && orderLine.quantity > maxPerOrder) {
+    const maxPerOrder = orderLine.productVariant.customFields.maxPerOrder;
+    const onlyAllowPer = orderLine.productVariant.customFields.onlyAllowPer;
+    if (
+      (maxPerOrder && orderLine.quantity > maxPerOrder) ||
+      (onlyAllowPer && orderLine.quantity % onlyAllowPer === 1)
+    ) {
+      const maxPerOrderMessage = maxPerOrder ? `max ${maxPerOrder}` : '';
+      const and = maxPerOrder && onlyAllowPer ? ' and ' : '';
+      const onlyAllowMultipleOfMessage = onlyAllowPer
+        ? `a multiple of ${onlyAllowPer}`
+        : '';
       Logger.warn(
-        `There can be only max ${maxPerOrder} of ${orderLine.productVariant.name} per order, throwing error to prevent this item from being added.`,
+        `There can be only ${maxPerOrderMessage}${and}${onlyAllowMultipleOfMessage} of ${orderLine.productVariant.name} per order, throwing error to prevent this item from being added.`,
         loggerCtx
       );
       throw new GraphQLError(
-        `You are only allowed to order max ${maxPerOrder} of ${orderLine.productVariant.name}`,
+        `You are only allowed to order ${maxPerOrderMessage}${and}${onlyAllowMultipleOfMessage} of ${orderLine.productVariant.name}`,
         { extensions: { code: maxItemsErrorCode } }
       );
       // Throwing an error is sufficient, because it prevents the transaction form being committed, so no items are added

--- a/packages/vendure-plugin-limit-variant-per-order/src/limit-variant-per-order.plugin.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/limit-variant-per-order.plugin.ts
@@ -31,7 +31,25 @@ import { AddItemOverrideResolver } from './add-item-override.resolver';
             'Limit how many of this product can be bought in a single order. Empty or 0 means a customer can order as many as he wants',
         },
       ],
-      //      ui: { tab: "pickup" }
+    });
+    config.customFields.ProductVariant.push({
+      name: 'onlyAllowPer',
+      type: 'int',
+      public: true,
+      nullable: true,
+      label: [
+        {
+          languageCode: LanguageCode.en,
+          value: 'Only Allow per order',
+        },
+      ],
+      description: [
+        {
+          languageCode: LanguageCode.en,
+          value:
+            'The customer will only be allowed to add a multiple of "onlyAllowPer" of this product per order. Empty or 0 means a customer can order as many as he wants',
+        },
+      ],
     });
     return config;
   },

--- a/packages/vendure-plugin-limit-variant-per-order/src/limit-variant-per-order.plugin.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/limit-variant-per-order.plugin.ts
@@ -40,7 +40,7 @@ import { AddItemOverrideResolver } from './add-item-override.resolver';
       label: [
         {
           languageCode: LanguageCode.en,
-          value: 'Only Allow per order',
+          value: 'Multiple of per order',
         },
       ],
       description: [

--- a/packages/vendure-plugin-limit-variant-per-order/src/types.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/types.ts
@@ -1,0 +1,8 @@
+import { CustomProductVariantFields } from '@vendure/core/dist/entity/custom-entity-fields';
+
+declare module '@vendure/core' {
+  interface CustomProductVariantFields {
+    maxPerOrder: number;
+    onlyAllowPer: number;
+  }
+}

--- a/packages/vendure-plugin-limit-variant-per-order/test/dev-server.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/test/dev-server.ts
@@ -1,3 +1,4 @@
+import '../src/types';
 import { initialData } from '../../test/src/initial-data';
 import {
   createTestEnvironment,

--- a/packages/vendure-plugin-limit-variant-per-order/test/limit-variants-per-order.spec.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/test/limit-variants-per-order.spec.ts
@@ -140,7 +140,7 @@ describe('Limit variants per order plugin', function () {
     expect(order.lines[0].quantity).toBe(quantity);
   });
 
-  it('Should fail to  adjust orderLine to quantity(3) not multiple of onlyAllowPer', async () => {
+  it('Should fail to  adjust orderLine to quantity(3) which is not multiple of onlyAllowPer', async () => {
     const quantity = 3;
     const promise = shopClient.query(
       gql`
@@ -159,7 +159,7 @@ describe('Limit variants per order plugin', function () {
     await expect(promise).rejects.toThrow(errorMessage);
   });
 
-  it('Should fail to  adjust orderLine to quantity(7) greater than maxPerOrder', async () => {
+  it('Should fail to  adjust orderLine to quantity(7) which is greater than maxPerOrder', async () => {
     const quantity = 7;
     const promise = shopClient.query(
       gql`

--- a/packages/vendure-plugin-limit-variant-per-order/test/limit-variants-per-order.spec.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/test/limit-variants-per-order.spec.ts
@@ -18,6 +18,9 @@ describe('Limit variants per order plugin', function () {
   let shopClient: SimpleGraphQLClient;
   let serverStarted = false;
   let order: Order;
+  let onlyAllowPer = 2;
+  let maxPerOrder = 6;
+  let errorMessage = `You are only allowed to order max ${maxPerOrder} and a multiple of ${onlyAllowPer} of Laptop 13 inch 8GB`;
 
   beforeAll(async () => {
     registerInitializer('sqljs', new SqljsInitializer('__data__'));
@@ -49,67 +52,130 @@ describe('Limit variants per order plugin', function () {
     await adminClient.asSuperAdmin();
     const {
       updateProductVariants: [variant],
-    } = await adminClient.query(gql`
-      mutation {
-        updateProductVariants(
-          input: [{ id: "T_1", customFields: { maxPerOrder: 2 } }]
-        ) {
-          ... on ProductVariant {
-            customFields {
-              maxPerOrder
+    } = await adminClient.query(
+      gql`
+        mutation updateProductVariants($maxPerOrder: Int, $onlyAllowPer: Int) {
+          updateProductVariants(
+            input: [
+              {
+                id: "T_1"
+                customFields: {
+                  maxPerOrder: $maxPerOrder
+                  onlyAllowPer: $onlyAllowPer
+                }
+              }
+            ]
+          ) {
+            ... on ProductVariant {
+              customFields {
+                maxPerOrder
+                onlyAllowPer
+              }
             }
           }
         }
-      }
-    `);
-    expect(variant.customFields.maxPerOrder).toBe(2);
+      `,
+      { maxPerOrder, onlyAllowPer }
+    );
+    expect(variant.customFields.maxPerOrder).toBe(maxPerOrder);
+    expect(variant.customFields.onlyAllowPer).toBe(onlyAllowPer);
   });
 
-  it('Exposes MaxPerOrder in shop api', async () => {
+  it('Exposes MaxPerOrder and OnlyAllowPer in shop api', async () => {
     const { product } = await shopClient.query(gql`
       {
         product(id: 1) {
           variants {
             customFields {
               maxPerOrder
+              onlyAllowPer
             }
           }
         }
       }
     `);
     expect(
-      product.variants.find((v: any) => v.customFields.maxPerOrder === 2)
+      product.variants.find(
+        (v: any) => v.customFields.maxPerOrder === maxPerOrder
+      )
+    ).toBeDefined();
+    expect(
+      product.variants.find(
+        (v: any) => v.customFields.onlyAllowPer === onlyAllowPer
+      )
     ).toBeDefined();
   });
 
-  it('Can add 1 to cart', async () => {
-    const order = await addItem(shopClient, 'T_1', 1);
-    expect(order.lines[0].quantity).toBe(1);
-  });
-
-  it('Fails to add 2 more to cart', async () => {
-    const promise = addItem(shopClient, 'T_1', 2);
-    await expect(promise).rejects.toThrow(
-      'You are only allowed to order max 2 of Laptop 13 inch 8GB'
-    );
-  });
-
-  it('Can add 1 more to cart', async () => {
-    const order = await addItem(shopClient, 'T_1', 1);
+  it('Should add 2 to cart', async () => {
+    const order = await addItem(shopClient, 'T_1', 2);
     expect(order.lines[0].quantity).toBe(2);
   });
 
-  it('Fails for adjust orderLine', async () => {
-    const promise = shopClient.query(gql`
-      mutation {
-        adjustOrderLine(orderLineId: 1, quantity: 4) {
-          __typename
+  it("Can't add 1 more to cart, which would make the total quantity 3", async () => {
+    const promise = addItem(shopClient, 'T_1', 1);
+    await expect(promise).rejects.toThrow(errorMessage);
+  });
+
+  it('Can add 2 more to cart, which would make the total quantity 4', async () => {
+    const order = await addItem(shopClient, 'T_1', 2);
+    expect(order.lines[0].quantity).toBe(4);
+  });
+
+  it('Should adjust orderLine', async () => {
+    const quantity = 2;
+    const { adjustOrderLine: order } = await shopClient.query(
+      gql`
+        mutation adjustOrderLine($quantity: Int!) {
+          adjustOrderLine(orderLineId: 1, quantity: $quantity) {
+            ... on Order {
+              lines {
+                quantity
+              }
+            }
+          }
         }
-      }
-    `);
-    await expect(promise).rejects.toThrow(
-      'You are only allowed to order max 2 of Laptop 13 inch 8GB'
+      `,
+      { quantity }
     );
+    expect(order.lines[0].quantity).toBe(quantity);
+  });
+
+  it('Should fail to  adjust orderLine to quantity(3) not multiple of onlyAllowPer', async () => {
+    const quantity = 3;
+    const promise = shopClient.query(
+      gql`
+        mutation adjustOrderLine($quantity: Int!) {
+          adjustOrderLine(orderLineId: 1, quantity: $quantity) {
+            ... on Order {
+              lines {
+                quantity
+              }
+            }
+          }
+        }
+      `,
+      { quantity }
+    );
+    await expect(promise).rejects.toThrow(errorMessage);
+  });
+
+  it('Should fail to  adjust orderLine to quantity(7) greater than maxPerOrder', async () => {
+    const quantity = 7;
+    const promise = shopClient.query(
+      gql`
+        mutation adjustOrderLine($quantity: Int!) {
+          adjustOrderLine(orderLineId: 1, quantity: $quantity) {
+            ... on Order {
+              lines {
+                quantity
+              }
+            }
+          }
+        }
+      `,
+      { quantity }
+    );
+    await expect(promise).rejects.toThrow(errorMessage);
   });
 
   afterAll(() => {


### PR DESCRIPTION
# Description

The changes in this PR make the following adjustments to `vendure-plugin-limit-variant-per-order`
1. Add a custom field onlyAllowPer to `ProductVariant`s, so we can check if an order contains a multiple of `onlyAllowPer` of the parent `ProductVariant` per `Order`.
2. Make that field readable in the shop api.
# Breaking changes

Does this PR include any breaking changes we should be aware of? **NO**

# Screenshots

<img width="1470" alt="Screenshot 2024-03-08 at 11 11 41 AM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/62d63bf7-3eb9-4361-b057-c7e29f4241d9">
<img width="1470" alt="Screenshot 2024-03-08 at 1 40 16 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/2bd0ebf2-987b-4771-82c6-342ba157a5f8">
<img width="1470" alt="Screenshot 2024-03-08 at 1 56 05 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/825063e5-1d20-47e6-b980-29d05505601c">
<img width="1470" alt="Screenshot 2024-03-08 at 1 56 22 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/fe531a6d-d875-465f-bad2-85b5d0a46ccf">
<img width="1470" alt="Screenshot 2024-03-08 at 1 56 31 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/08e22f28-a0f1-4857-a46b-8c1980eab33f">




# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases for important functionality
- [X] I have updated the README if needed

📦 For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced quantity restriction per order by introducing a new constraint `onlyAllowPer` for product variants, allowing more precise control over the number of items a customer can order.
	- Added support for adding a multiple of `onlyAllowPer` of a `ProductVariant` per `Order`.
- **Bug Fixes**
	- Improved error messaging in the ordering process to reflect both `maxPerOrder` and `onlyAllowPer` constraints when exceeded.
- **Tests**
	- Updated test cases to cover the new `onlyAllowPer` constraint and adjusted assertions to match updated error messages and quantity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->