### PR TITLE
Make isCustomerManaged editable from admin-ui

### DIFF
--- a/packages/vendure-plugin-customer-managed-groups/CHANGELOG.md
+++ b/packages/vendure-plugin-customer-managed-groups/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0 (2024-03-29)
+
+- Make `isCustomerManagedGroup` editable from admin-ui
+
 # 1.2.0 (2024-03-06)
 
 - Made available customer group management functions on admin api

--- a/packages/vendure-plugin-customer-managed-groups/package.json
+++ b/packages/vendure-plugin-customer-managed-groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-customer-managed-groups",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "This plugin allows customer groups to have 'Group admins', that are allowed to fetch placed orders for everyone in the group.",
   "icon": "account-group",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-customer-managed-groups/src/api/custom-fields.ts
+++ b/packages/vendure-plugin-customer-managed-groups/src/api/custom-fields.ts
@@ -41,7 +41,6 @@ export const customFields: CustomFields = {
       type: 'boolean',
       public: false,
       nullable: true,
-      readonly: true,
       label: [
         {
           languageCode: LanguageCode.en,

--- a/packages/vendure-plugin-customer-managed-groups/src/customer-managed-groups.plugin.ts
+++ b/packages/vendure-plugin-customer-managed-groups/src/customer-managed-groups.plugin.ts
@@ -31,14 +31,14 @@ import {
   compatibility: '^2.0.0',
 })
 export class CustomerManagedGroupsPlugin {
-  static ui: AdminUiExtension = {
-    extensionPath: path.join(__dirname, 'ui'),
-    ngModules: [
-      {
-        type: 'shared',
-        ngModuleFileName: 'customer-group-extension.shared-module.ts',
-        ngModuleName: 'CustomerGroupExtensionSharedModule',
-      },
-    ],
-  };
+  // static ui: AdminUiExtension = {
+  //   extensionPath: path.join(__dirname, 'ui'),
+  //   ngModules: [
+  //     {
+  //       type: 'shared',
+  //       ngModuleFileName: 'customer-group-extension.shared-module.ts',
+  //       ngModuleName: 'CustomerGroupExtensionSharedModule',
+  //     },
+  //   ],
+  // };
 }

--- a/packages/vendure-plugin-customer-managed-groups/test/dev-server.ts
+++ b/packages/vendure-plugin-customer-managed-groups/test/dev-server.ts
@@ -38,7 +38,7 @@ require('dotenv').config();
         route: 'admin',
         app: compileUiExtensions({
           outputPath: path.join(__dirname, '__admin-ui'),
-          extensions: [CustomerManagedGroupsPlugin.ui],
+          extensions: [],
           devMode: true,
         }),
       }),


### PR DESCRIPTION
# Description

The changes in this implement and close #377 
# Breaking changes

`CustomerManagedGroupsPlugin.ui` has been removed since we no longer have any ui-extensions.

# Screenshots

<img width="1470" alt="Screenshot 2024-03-29 at 11 05 53 AM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/d8899a05-4143-4da9-b029-d7b50bdd421d">

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability for admins to edit the `isCustomerManagedGroup` status directly from the admin UI.
- **Refactor**
	- Updated field configuration to allow mutability.
	- Modified Admin UI extensions configuration and development server settings for improved plugin integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->