### PR TITLE
feat(picqer): Use first translations name if no name is set

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.3 (2024-04-03)
+
+- Correctly set product name in Picqer based on Vendure variant name. Falls back to first translation available before falling back to using SKU as name.
+
 # 2.4.2 (2024-03-13)
 
 - Don't update stock of products in Vendure that have `unlimitedstock=true` in Picqer

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-picqer/src/api/picqer.client.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.client.ts
@@ -275,7 +275,7 @@ export class PicqerClient {
     }
     const productId = product.idproduct;
     Logger.debug(
-      `Existing product '${productId}' found, updating product ${productId} in Picqer`,
+      `Existing product '${productId}' found for sku '${sku}', updating product in Picqer`,
       loggerCtx
     );
     return this.updateProduct(productId, input);

--- a/packages/vendure-plugin-picqer/test/dev-server.ts
+++ b/packages/vendure-plugin-picqer/test/dev-server.ts
@@ -90,14 +90,14 @@ import { picqerHandler } from '../dist/vendure-plugin-picqer/src/api/picqer.hand
       supportEmail: 'support@mystore.io',
     },
   });
-  await adminClient.query(FULL_SYNC);
+  // await adminClient.query(FULL_SYNC);
   // const variants = await updateVariants(adminClient, [
   //   { id: 'T_1', trackInventory: GlobalFlag.True },
   //   { id: 'T_2', trackInventory: GlobalFlag.True },
   //   { id: 'T_3', trackInventory: GlobalFlag.True },
   //   { id: 'T_4', trackInventory: GlobalFlag.True },
   // ]);
-  // const order = await createSettledOrder(shopClient, 3, true, [
-  //   { id: 'T_1', quantity: 3 },
-  // ]);
+  const order = await createSettledOrder(shopClient, 3, true, [
+    { id: 'T_1', quantity: 3 },
+  ]);
 })();


### PR DESCRIPTION
# Description

* Minor cleanup of unused code
* Fetch `variant.translations` relation on order placement
* Fallback to `variant.translations[0].name` before falling back to SKU. Suspicion is that the HPS project's NL language is causing product variant names to be overridden with the SKU on order placement.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the product update process in the Picqer integration by focusing on variant IDs instead of product IDs, enhancing error handling and logging.
- **Tests**
	- Adjusted test server setup to better support order creation and testing variant updates.
- **Bug Fixes**
	- Correctly set the product name in Picqer based on the Vendure variant name, with appropriate fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->