### PR TITLE
Private collections should not be set as primary collections

### DIFF
--- a/packages/vendure-plugin-primary-collection/CHANGELOG.md
+++ b/packages/vendure-plugin-primary-collection/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.4.1 (2023-10-24)
+# 1.4.2 (2023-10-24)
 
 - Primary collection filter should hide Private collections (#395)
 

--- a/packages/vendure-plugin-primary-collection/CHANGELOG.md
+++ b/packages/vendure-plugin-primary-collection/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.4.1 (2023-10-24)
 
+- Primary collection filter should hide Private collections (#395)
+
+# 1.4.1 (2023-10-24)
+
 - Fixed issue when creating a new product in Vendure (#367)
 
 # 1.4.0 (2023-10-24)

--- a/packages/vendure-plugin-primary-collection/package.json
+++ b/packages/vendure-plugin-primary-collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-primary-collection",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Adds a primary collection to all Products by extending Vendure's graphql api",
   "author": "Surafel Melese Tariku <surafelmelese09@gmail.com>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
+++ b/packages/vendure-plugin-primary-collection/src/api/primary-collections-helper.service.ts
@@ -15,6 +15,7 @@ export class PrimaryCollectionHelperService {
       .createQueryBuilder('product')
       .leftJoinAndSelect('product.variants', 'variant')
       .leftJoinAndSelect('variant.collections', 'collection')
+      .where('not collection.isPrivate')
       .getMany();
     const updatedProducts: Partial<Product>[] = [];
     for (let product of allProducts) {

--- a/packages/vendure-plugin-primary-collection/src/ui/select-primary-collection.component.ts
+++ b/packages/vendure-plugin-primary-collection/src/ui/select-primary-collection.component.ts
@@ -74,7 +74,9 @@ export class SelectPrimaryCollectionComponent
           { id: this.id }
         )
         .single$.subscribe((d: any) => {
-          this.productsCollections = d?.product?.collections;
+          this.productsCollections = d?.product?.collections.filter(
+            (c) => !c.isPrivate
+          );
           this.productsCollectionsAreLoading = false;
           this.cdr.markForCheck();
         });

--- a/packages/vendure-plugin-primary-collection/test/initial-test-data.ts
+++ b/packages/vendure-plugin-primary-collection/test/initial-test-data.ts
@@ -41,6 +41,7 @@ export const initialTestData: InitialData = {
           args: { facetValueNames: ['electronics'], containsAny: false },
         },
       ],
+      private: true,
     },
     {
       name: 'Others',

--- a/packages/vendure-plugin-primary-collection/test/primary-collection.spec.ts
+++ b/packages/vendure-plugin-primary-collection/test/primary-collection.spec.ts
@@ -1,10 +1,4 @@
-import {
-  ChannelService,
-  DefaultLogger,
-  LogLevel,
-  RequestContext,
-  mergeConfig,
-} from '@vendure/core';
+import { DefaultLogger, LogLevel, mergeConfig } from '@vendure/core';
 import {
   createTestEnvironment,
   registerInitializer,
@@ -154,8 +148,12 @@ describe('Product Primary Collection', function () {
         productId: 'T_3',
       }
     );
-    expect(t1Product.primaryCollection.name).toBe('Electronics');
-    expect(t2Product.primaryCollection).not.toBeNull();
+    //Although Product(1),Laptop, belongs to the Collection Electronics, since Electronics is a private collection, we dont expect it to be it's Primary Collection
+    expect(t1Product.primaryCollection.name).not.toBe('Electronics');
+    expect(t1Product.primaryCollection.name).toBe('Computers');
+    //The Product(2), Cars, only belongs to the private Collection Electronics
+    expect(t2Product.primaryCollection).toBeNull();
+    //The Product(3), Motors, belongs to the  non-private Collection Others
     expect(t3Product.primaryCollection).not.toBeNull();
   });
 


### PR DESCRIPTION
# Description

The changes in this PR fix and close #395 
# Breaking changes

Does this PR include any breaking changes we should be aware of? **NO**

# Screenshots

<img width="1470" alt="Screenshot 2024-04-05 at 12 22 31 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/9620348e-5979-4a96-8c3d-672946153f1c">

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases for important functionality
- [X] I have updated the README if needed

📦 For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Primary collection filter now excludes Private collections, enhancing privacy and control over collection visibility.

- **Bug Fixes**
	- Resolved an issue with creating new products in Vendure, ensuring smoother product management.

- **Tests**
	- Updated tests to validate the correct handling of primary collections, especially concerning private collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->