### PR TITLE
fix: remove fallback shipping address for billing address

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.4 (2024-04-09)
+
+- Don't fallback to shipping address when passing billing address to Picqer
+
 # 2.4.3 (2024-04-03)
 
 - Correctly set product name in Picqer based on Vendure variant name. Falls back to first translation available before falling back to using SKU as name.

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.4.4 (2024-04-09)
 
-- Don't fallback to shipping address when passing billing address to Picqer
+Don't fall back to shipping address when passing billing address to Picqer
 
 # 2.4.3 (2024-04-03)
 

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.4.4 (2024-04-09)
 
-Don't fall back to shipping address when passing billing address to Picqer
+- Don't fall back to shipping address when passing billing address to Picqer
 
 # 2.4.3 (2024-04-03)
 

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1108,8 +1108,7 @@ export class PicqerService implements OnApplicationBootstrap {
       // use billing if available, otherwise fallback to shipping address
       invoicename: invoicename ?? deliveryname ?? customerFullname,
       invoicecontactname,
-      invoiceaddress:
-        this.getFullAddress(billingAddress),
+      invoiceaddress: this.getFullAddress(billingAddress),
       invoicezipcode: billingAddress?.postalCode,
       invoicecity: billingAddress?.city,
       invoicecountry: order.billingAddress?.countryCode?.toUpperCase(),

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1109,8 +1109,7 @@ export class PicqerService implements OnApplicationBootstrap {
       invoicename: invoicename ?? deliveryname ?? customerFullname,
       invoicecontactname,
       invoiceaddress:
-        this.getFullAddress(billingAddress) ??
-        this.getFullAddress(shippingAddress),
+        this.getFullAddress(billingAddress),
       invoicezipcode: billingAddress?.postalCode,
       invoicecity: billingAddress?.city,
       invoicecountry: order.billingAddress?.countryCode?.toUpperCase(),


### PR DESCRIPTION
We've changed the front-end check-out to make filling out the shipping address the default instead of making the billing address the default. It occurred to us that the shipping address is always filled in the billing address. Which doesn't make sense for us (anymore). From a Picqer API perspective the invoiceaddress is not required. So I think it's better to remove the fallback.

https://picqer.com/en/api/orders