### PR TITLE
Channel aware onlyAllowPer custom field per ProductVariant

### DIFF
--- a/packages/vendure-plugin-limit-variant-per-order/CHANGELOG.md
+++ b/packages/vendure-plugin-limit-variant-per-order/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0 (2024-04-10)
+
+- Added support for chanel aware `onlyAllowPer` value per ProductVariant
+
 # 1.2.0 (2024-03-08)
 
 - Added support for adding a multiple of `onlyAllowPer` of a `ProductVariant` per `Order`

--- a/packages/vendure-plugin-limit-variant-per-order/package.json
+++ b/packages/vendure-plugin-limit-variant-per-order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-limit-variant-per-order",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Vendure plugin to limit the amount of a specific product that can be ordered per order.",
   "icon": "shield-lock",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-limit-variant-per-order/src/add-item-override.resolver.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/add-item-override.resolver.ts
@@ -7,6 +7,8 @@ import {
   RequestContext,
   Logger,
   Transaction,
+  ID,
+  idsAreEqual,
 } from '@vendure/core';
 import { ErrorResultUnion } from '@vendure/core/dist/common/error/error-result';
 import { Order } from '@vendure/core/dist/entity/order/order.entity';
@@ -16,6 +18,7 @@ import {
   MutationAdjustOrderLineArgs,
 } from '@vendure/common/lib/generated-shop-types';
 import { GraphQLError } from 'graphql';
+import { ChannelAwareIntValue } from './types';
 const loggerCtx = 'LimitVariantPerOrderPlugin';
 const maxItemsErrorCode = 'MAX_ITEMS_PER_ORDER_ERROR';
 
@@ -36,7 +39,7 @@ export class AddItemOverrideResolver extends ShopOrderResolver {
       return result;
     }
     const order = result as Order;
-    this.validate(order, args.productVariantId);
+    this.validate(order, args.productVariantId, ctx.channelId);
     return result;
   }
 
@@ -54,7 +57,7 @@ export class AddItemOverrideResolver extends ShopOrderResolver {
     const order = result as Order;
     const orderLine = order.lines.find((line) => line.id == args.orderLineId);
     if (orderLine) {
-      this.validate(order, orderLine.productVariant.id);
+      this.validate(order, orderLine.productVariant.id, ctx.channelId);
     }
     return result;
   }
@@ -62,12 +65,22 @@ export class AddItemOverrideResolver extends ShopOrderResolver {
   /**
    * Throw an error if quantity is over maxPerOrder
    */
-  private validate(order: Order, variantId: string | number): void {
+  private validate(
+    order: Order,
+    variantId: string | number,
+    channelId: ID
+  ): void {
     const orderLine = order.lines.find(
       (line) => line.productVariant.id == variantId
     )!;
     const maxPerOrder = orderLine.productVariant.customFields.maxPerOrder;
-    const onlyAllowPer = orderLine.productVariant.customFields.onlyAllowPer;
+    const onlyAllowPersList =
+      orderLine.productVariant.customFields.onlyAllowPer;
+    const onlyAllowPer =
+      onlyAllowPersList
+        .map((v) => JSON.parse(v) as ChannelAwareIntValue)
+        .find((channelValue) => idsAreEqual(channelValue.channelId, channelId))
+        ?.value ?? 0;
     if (
       (maxPerOrder && orderLine.quantity > maxPerOrder) ||
       (onlyAllowPer && orderLine.quantity % onlyAllowPer !== 0)

--- a/packages/vendure-plugin-limit-variant-per-order/src/limit-variant-per-order.plugin.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/limit-variant-per-order.plugin.ts
@@ -5,6 +5,8 @@ import {
   VendurePlugin,
 } from '@vendure/core';
 import { AddItemOverrideResolver } from './add-item-override.resolver';
+import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
+import path from 'path';
 
 @VendurePlugin({
   imports: [PluginCommonModule],
@@ -34,9 +36,11 @@ import { AddItemOverrideResolver } from './add-item-override.resolver';
     });
     config.customFields.ProductVariant.push({
       name: 'onlyAllowPer',
-      type: 'int',
+      type: 'text',
       public: true,
-      nullable: true,
+      list: true,
+      defaultValue: [],
+      ui: { component: 'channel-aware-int-form-input' },
       label: [
         {
           languageCode: LanguageCode.en,
@@ -55,4 +59,9 @@ import { AddItemOverrideResolver } from './add-item-override.resolver';
   },
   compatibility: '^2.0.0',
 })
-export class LimitVariantPerOrderPlugin {}
+export class LimitVariantPerOrderPlugin {
+  public static uiExtensions: AdminUiExtension = {
+    extensionPath: path.join(__dirname, 'ui'),
+    providers: ['providers.ts'],
+  };
+}

--- a/packages/vendure-plugin-limit-variant-per-order/src/types.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/types.ts
@@ -1,8 +1,14 @@
+import { ID } from '@vendure/core';
 import { CustomProductVariantFields } from '@vendure/core/dist/entity/custom-entity-fields';
 
 declare module '@vendure/core' {
   interface CustomProductVariantFields {
     maxPerOrder: number;
-    onlyAllowPer: number;
+    onlyAllowPer: string[];
   }
 }
+
+export type ChannelAwareIntValue = {
+  channelId: ID;
+  value: number;
+};

--- a/packages/vendure-plugin-limit-variant-per-order/src/ui/channel-aware-int-custom-field/channel-aware-int-custom-field.component.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/ui/channel-aware-int-custom-field/channel-aware-int-custom-field.component.ts
@@ -1,0 +1,95 @@
+import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import {
+  IntCustomFieldConfig,
+  SharedModule,
+  FormInputComponent,
+  Channel,
+  DataService,
+} from '@vendure/admin-ui/core';
+import { Observable } from 'rxjs';
+import { GET_ACTIVE_CHANNEL } from './channel-aware-int-custom-field.graphql';
+import { ID } from '@vendure/common/lib/shared-types';
+import { ActivatedRoute } from '@angular/router';
+
+type ChannelAwareIntValue = {
+  channelId: ID;
+  value: number;
+};
+@Component({
+  template: `
+    <input type="number" min="0" step="1" [formControl]="valueFormControl" />
+  `,
+  standalone: true,
+  imports: [SharedModule],
+})
+export class ChannelAwareIntCustomFieldComponent
+  implements FormInputComponent<IntCustomFieldConfig>, OnInit
+{
+  isListInput?: boolean | undefined = true;
+  readonly: boolean;
+  activeChannel$: Observable<Pick<Channel, 'id' | 'defaultCurrencyCode'>>;
+  config: IntCustomFieldConfig;
+  formControl: FormControl;
+  values: ChannelAwareIntValue[];
+  valueFormControl: FormControl<number | null>;
+  activeChannelId: ID;
+  constructor(
+    private dataService: DataService,
+    private cdr: ChangeDetectorRef,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    this.route.params.subscribe((s: any) => {
+      setTimeout(() => this.parseFormControlValue(), 10);
+    });
+  }
+
+  parseFormControlValue() {
+    if (this.formControl.value?.length) {
+      this.values = this.formControl.value.map(
+        (v) => JSON.parse(v) as ChannelAwareIntValue
+      );
+    } else {
+      this.values = [];
+    }
+
+    this.activeChannel$ =
+      this.dataService.query<any>(GET_ACTIVE_CHANNEL).stream$;
+    this.activeChannel$.subscribe((data: any) => {
+      this.activeChannelId = data.activeChannel.id;
+      const channelValue = this.values.find((v) =>
+        this.idsAreEqual(v.channelId, this.activeChannelId)
+      )?.value;
+      this.valueFormControl = new FormControl<number | null>(channelValue ?? 0);
+      this.valueFormControl.valueChanges.subscribe((value) => {
+        if (!value) {
+          //remove entry of this channel
+          this.values = this.values.filter(
+            (v) => !this.idsAreEqual(v.channelId, this.activeChannelId)
+          );
+          return;
+        }
+        const channelData = this.values.find((v) =>
+          this.idsAreEqual(v.channelId, this.activeChannelId)
+        );
+        if (channelData) {
+          channelData.value = value;
+        } else {
+          this.values.push({ channelId: this.activeChannelId, value });
+        }
+        this.formControl.setValue(this.values.map((v) => JSON.stringify(v)));
+        this.formControl.markAsDirty();
+      });
+      this.cdr.detectChanges();
+    });
+  }
+
+  idsAreEqual(id1?: ID, id2?: ID): boolean {
+    if (id1 === undefined || id2 === undefined || !id2 || !id1) {
+      return false;
+    }
+    return id1.toString() === id2.toString();
+  }
+}

--- a/packages/vendure-plugin-limit-variant-per-order/src/ui/channel-aware-int-custom-field/channel-aware-int-custom-field.graphql.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/ui/channel-aware-int-custom-field/channel-aware-int-custom-field.graphql.ts
@@ -1,0 +1,9 @@
+import { gql } from 'graphql-tag';
+
+export const GET_ACTIVE_CHANNEL = gql`
+  query GetActiveChannel {
+    activeChannel {
+      id
+    }
+  }
+`;

--- a/packages/vendure-plugin-limit-variant-per-order/src/ui/providers.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/src/ui/providers.ts
@@ -1,0 +1,9 @@
+import { registerFormInputComponent } from '@vendure/admin-ui/core';
+import { ChannelAwareIntCustomFieldComponent } from './channel-aware-int-custom-field/channel-aware-int-custom-field.component';
+
+export default [
+  registerFormInputComponent(
+    'channel-aware-int-form-input',
+    ChannelAwareIntCustomFieldComponent
+  ),
+];

--- a/packages/vendure-plugin-limit-variant-per-order/test/dev-server.ts
+++ b/packages/vendure-plugin-limit-variant-per-order/test/dev-server.ts
@@ -7,6 +7,7 @@ import {
   testConfig,
 } from '@vendure/testing';
 import {
+  AutoIncrementIdStrategy,
   ChannelService,
   DefaultLogger,
   DefaultSearchPlugin,
@@ -16,6 +17,8 @@ import {
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
 import { LimitVariantPerOrderPlugin } from '../src/limit-variant-per-order.plugin';
+import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
+import path from 'path';
 
 require('dotenv').config();
 
@@ -29,6 +32,11 @@ require('dotenv').config();
       AdminUiPlugin.init({
         port: 3002,
         route: 'admin',
+        app: compileUiExtensions({
+          outputPath: path.join(__dirname, './__admin-ui'),
+          extensions: [LimitVariantPerOrderPlugin.uiExtensions],
+          devMode: true,
+        }),
       }),
     ],
     apiOptions: {
@@ -36,6 +44,9 @@ require('dotenv').config();
     },
     paymentOptions: {
       paymentMethodHandlers: [testPaymentMethod],
+    },
+    entityOptions: {
+      entityIdStrategy: new AutoIncrementIdStrategy(),
     },
   });
   const { server, adminClient, shopClient } = createTestEnvironment(devConfig);


### PR DESCRIPTION
# Description

The changes in this PR implement and close #398 

# Breaking changes

`ProductVariant.customFields.onlyAllowPer` will return `[String!]` and not `Int`

# Screenshots

<img width="1470" alt="Screenshot 2024-04-10 at 2 41 39 PM" src="https://github.com/Pinelab-studio/pinelab-vendure-plugins/assets/39517388/19d953bb-a966-4d6b-b3fb-f4812c1f4bd3">

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [X] I have added or updated test cases for important functionality
- [] I have updated the README if needed

📦 For publishable packages:
- [X] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [X] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
