### PR TITLE
Fix: Goedgepickt stock sync - ignore deleted variants

### DIFF
--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.2 (2024-04-30)
+
+- Fix related to stock not updating when a variant with the same SKU has been deleted before.
+
 # 1.1.1 (2024-01-16)
 
 - Correctly transition to Delivered from Shipped

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "icon": "truck",

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -5,7 +5,6 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import {
-  Channel,
   ChannelService,
   ConfigService,
   EntityHydrator,
@@ -14,7 +13,6 @@ import {
   ID,
   JobQueue,
   JobQueueService,
-  Json,
   ListQueryBuilder,
   Logger,
   Order,
@@ -31,11 +29,14 @@ import {
   Translated,
   translateDeep,
 } from '@vendure/core';
-import {
-  CreateProductVariantInput,
-  UpdateProductVariantInput,
-} from '@vendure/common/lib/generated-types';
+import { IsNull } from 'typeorm';
+import util from 'util';
+import { transitionToDelivered } from '../../../util/src';
+import { loggerCtx, PLUGIN_INIT_OPTIONS } from '../constants';
+import { PickupPointCustomFields } from './custom-fields';
+import { GoedgepicktConfigEntity } from './goedgepickt-config.entity';
 import { GoedgepicktClient } from './goedgepickt.client';
+import { goedgepicktHandler } from './goedgepickt.handler';
 import {
   GoedgepicktEvent,
   GoedgepicktPluginConfig,
@@ -45,13 +46,6 @@ import {
   OrderStatus,
   ProductInput,
 } from './goedgepickt.types';
-import { loggerCtx, PLUGIN_INIT_OPTIONS } from '../constants';
-import { GoedgepicktConfigEntity } from './goedgepickt-config.entity';
-import { transitionToDelivered } from '../../../util/src';
-import { goedgepicktHandler } from './goedgepickt.handler';
-import { PickupPointCustomFields } from './custom-fields';
-import { IsNull } from 'typeorm';
-import util from 'util';
 
 interface StockInput {
   variantId: string;

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -496,7 +496,7 @@ export class GoedgepicktService
       this.getVariants(ctx),
     ]);
     Logger.info(
-      `Pusing ${variants.length} Vendure variants for channel ${channelToken} to GoedGepickt and fetching stock levels for those variants from GoedGepickt`,
+      `Pushing ${variants.length} Vendure variants for channel ${channelToken} to GoedGepickt and fetching stock levels for those variants from GoedGepickt`,
       loggerCtx
     );
     // Create update stocklevel jobs

--- a/packages/vendure-plugin-goedgepickt/src/goedgepickt.plugin.ts
+++ b/packages/vendure-plugin-goedgepickt/src/goedgepickt.plugin.ts
@@ -37,6 +37,7 @@ import { customFields } from './api/custom-fields';
     config.shippingOptions.fulfillmentHandlers.push(goedgepicktHandler);
     config.authOptions.customPermissions.push(goedgepicktPermission);
     config.customFields.Order.push(...customFields.Order!);
+
     return config;
   },
   compatibility: '^2.0.0',

--- a/packages/vendure-plugin-goedgepickt/test/dev-server.ts
+++ b/packages/vendure-plugin-goedgepickt/test/dev-server.ts
@@ -43,11 +43,11 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
       AdminUiPlugin.init({
         port: 3002,
         route: 'admin',
-        app: compileUiExtensions({
-          outputPath: path.join(__dirname, '__admin-ui'),
-          extensions: [GoedgepicktPlugin.ui],
-          devMode: true,
-        }),
+        // app: compileUiExtensions({
+        //   outputPath: path.join(__dirname, '__admin-ui'),
+        //   extensions: [GoedgepicktPlugin.ui],
+        //   devMode: true,
+        // }),
       }),
     ],
   });
@@ -80,5 +80,5 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
     fulfillmentHandler: goedgepicktHandler.code,
     translations: [],
   });
-  await createSettledOrder(shopClient, 1);
+  // await createSettledOrder(shopClient, 1);
 })();


### PR DESCRIPTION
# Description

Sometimes the stock level of a variant isn't updated, because the ID of a deleted variant was fetched from the DB. This could be the case when a variant was recreated with the same SKU.

Closes #408 - This is not the approach described in the issue, but a smaller, less intrusive fix, that should still be enough for the issue at hand.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
