### PR TITLE
feat(picqer): no more order process override

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0 (2024-05-15)
+
+- The Picqer plugin now requires manual installation of the default order process with `checkFulfillment: false` to prevent overriding other custom order processes in the consuming projects.
+
 # 2.4.4 (2024-04-09)
 
 - Don't fall back to shipping address when passing billing address to Picqer

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -18,7 +18,8 @@ The plugin follows these principles:
 Add the plugin to your `vendure-config.ts`
 
 ```ts
-import {PicqerPlugin} from '@pinelab/vendure-plugin-picqer'
+import { PicqerPlugin } from '@pinelab/vendure-plugin-picqer';
+import { configureDefaultOrderProcess } from '@vendure/core';
 
 ...
 // Make sure Picqer can transition to 'Delivered' without the need of fulfillment

--- a/packages/vendure-plugin-picqer/README.md
+++ b/packages/vendure-plugin-picqer/README.md
@@ -21,7 +21,14 @@ Add the plugin to your `vendure-config.ts`
 import {PicqerPlugin} from '@pinelab/vendure-plugin-picqer'
 
 ...
+// Make sure Picqer can transition to 'Delivered' without the need of fulfillment
+orderOptions: {
+  process: [
+    configureDefaultOrderProcess({ checkFulfillmentStates: false })
+  ]
+},
 plugins: [
+  // Add Picqer as plugin
   PicqerPlugin.init({
           enabled: true,
           vendureHost: 'https://example-vendure.io',
@@ -77,7 +84,7 @@ curl -H "Authorization: Bearer abcde-your-apikey" `http://localhost:3000/picqer/
 
 ### Order process override
 
-This plugin installs the default order process with `checkFulfillmentStates: false` configured, so that orders can be transitioned to Shipped and Delivered without the need of fulfillment. Fulfillment is the responsibility of Picqer, so we won't handle that in Vendure when using this plugin.
+This plugin requires the default order process to be configured with `checkFulfillmentStates: false`, so that orders can be transitioned to Shipped and Delivered without the need of fulfillment. Fulfillment is the responsibility of Picqer, so we won't handle that in Vendure when using this plugin.
 
 ![!image](https://www.plantuml.com/plantuml/png/VOv1IyD048Nl-HNl1rH9Uog1I8iNRnQYtfVCn0nkPkFk1F7VIvgjfb2yBM_VVEyx97FHfi4NZrvO3NSFU6EbANA58n4iO0Sn7jBy394u5hbmrUrTmhP4ij1-87JBoIteoNt3AI6ncUT_Y4VlG-kCB_lL0d_M9wTKRyiDN6vGlLiJJj9-SgpGiDB2XuMSuaki3vEXctmdVc2r8l-ijvjv2TD8ytuNcSz1lR_7wvA9NifmwKfil_OgRy5VejCa9a7_x9fUnf5fy-lNHdOc-fv5pwQfECoCmVy0)
 

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "2.4.4",
+  "version": "3.0.0",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -365,7 +365,7 @@ export class PicqerService implements OnApplicationBootstrap {
         Logger.error(
           `Failed to cancel order ${order.code}: ${
             (result as ErrorResult).message
-          }. Did you configure the order process with "checkFulfillmentStates: false"?`,
+          }. Ensure the order process is configured with "checkFulfillmentStates: false"`,
           loggerCtx,
           util.inspect(result)
         );

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -365,7 +365,7 @@ export class PicqerService implements OnApplicationBootstrap {
         Logger.error(
           `Failed to cancel order ${order.code}: ${
             (result as ErrorResult).message
-          }`,
+          }. Did you configure the order process with "checkFulfillmentStates: false"?`,
           loggerCtx,
           util.inspect(result)
         );

--- a/packages/vendure-plugin-picqer/src/picqer.plugin.ts
+++ b/packages/vendure-plugin-picqer/src/picqer.plugin.ts
@@ -78,9 +78,6 @@ export interface PicqerOptions {
     });
     config.authOptions.customPermissions.push(picqerPermission);
     config.shippingOptions.fulfillmentHandlers.push(picqerHandler);
-    config.orderOptions.process = [
-      configureDefaultOrderProcess({ checkFulfillmentStates: false }),
-    ];
     return config;
   },
   compatibility: '^2.0.0',

--- a/packages/vendure-plugin-picqer/test/dev-server.ts
+++ b/packages/vendure-plugin-picqer/test/dev-server.ts
@@ -1,6 +1,7 @@
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { AssetServerPlugin } from '@vendure/asset-server-plugin';
 import {
+  configureDefaultOrderProcess,
   DefaultLogger,
   DefaultSearchPlugin,
   LogLevel,
@@ -31,6 +32,11 @@ import { picqerHandler } from '../dist/vendure-plugin-picqer/src/api/picqer.hand
     apiOptions: {
       adminApiPlayground: {},
       shopApiPlayground: {},
+    },
+    orderOptions: {
+      process: [
+        configureDefaultOrderProcess({ checkFulfillmentStates: false }),
+      ],
     },
     paymentOptions: {
       paymentMethodHandlers: [testPaymentMethod],

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -1,4 +1,10 @@
-import { DefaultLogger, LogLevel, mergeConfig, Order } from '@vendure/core';
+import {
+  configureDefaultOrderProcess,
+  DefaultLogger,
+  LogLevel,
+  mergeConfig,
+  Order,
+} from '@vendure/core';
 import {
   createTestEnvironment,
   E2E_DEFAULT_CHANNEL_TOKEN,
@@ -60,6 +66,11 @@ beforeAll(async () => {
         }),
       }),
     ],
+    orderOptions: {
+      process: [
+        configureDefaultOrderProcess({ checkFulfillmentStates: false }),
+      ],
+    },
     paymentOptions: {
       paymentMethodHandlers: [testPaymentMethod],
     },


### PR DESCRIPTION
# Description

The Picqer plugin now requires manual installation of the default order process with `checkFulfillment: false` to prevent overriding other custom order processes in the consuming projects.

# Breaking changes

Yes, the consumer must now configure the order process in vendure-config.ts

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
