### PR TITLE
feat(accept-blue): return created subscription id

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.1 (2024-06-06)
+
+- Return subscription id in Graphql type for created Accept Blue subscriptions
+
 # 1.3.0 (2024-05-21)
 
 - Allow refunding a transaction via `refundAcceptBlueTransaction` mutation.

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "icon": "credit-card-refresh",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
@@ -369,6 +369,7 @@ export class AcceptBlueService {
       subscription.frequency
     );
     return {
+      id: subscription.id,
       amountDueNow: 0,
       name: subscription.title,
       priceIncludesTax: true,

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -14,6 +14,10 @@ export const commonApiExtensions = gql`
   }
 
   type AcceptBlueSubscription {
+    """
+    This ID might not be available yet when an order hasn't been placed yet
+    """
+    id: ID
     name: String!
     variantId: ID!
     amountDueNow: Int!


### PR DESCRIPTION
# Description

Return `orderLine.acceptBlueSubscription.id` for subscriptions that have been created in Accept Blue

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
