### PR TITLE
Fix: Invoices and Shipmate - don't throw but log

### DIFF
--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2 (2024-06-13)
+
+- Don't throw errors when a cancelled invoice doesn't have a previous invoice, but log and return instead.
+
 # 2.3.1 (2024-06-05)
 
 - Sort invoices by created at

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-invoices",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Vendure plugin for invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-invoices/src/api/invoice-admin.resolver.ts
+++ b/packages/vendure-plugin-invoices/src/api/invoice-admin.resolver.ts
@@ -54,6 +54,11 @@ export class InvoiceAdminResolver {
       order.code,
       false
     );
+    if (!invoice) {
+      throw new UserInputError(
+        `Could not generate invoice for order. Please check the logs for more information.`
+      );
+    }
     return {
       ...invoice,
       isCreditInvoice: invoice.isCreditInvoice,

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -262,7 +262,7 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
     channelToken: string,
     orderCode: string,
     createCreditInvoiceOnly: boolean
-  ): Promise<InvoiceEntity> {
+  ): Promise<InvoiceEntity | undefined> {
     const ctx = await this.createCtx(channelToken);
     let [order, previousInvoiceForOrder, config] = await Promise.all([
       this.orderService.findOneByCode(ctx, orderCode),
@@ -270,25 +270,35 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
       this.getConfig(ctx),
     ]);
     if (!config) {
-      throw Error(
-        `Cannot generate invoice for ${orderCode}, because no config was found`
+      Logger.warn(
+        `Cannot generate invoice for ${orderCode}, because no config was found`,
+        loggerCtx
       );
-    } else if (!config.enabled) {
-      throw Error(
-        `Not generating invoice for ${orderCode} for channel ${channelToken}, because invoice generation is disabled in the config.`
+      return;
+    }
+    if (!config.enabled) {
+      Logger.info(
+        `Not generating invoice for ${orderCode} for channel ${channelToken}, because invoice generation is disabled in the config.`,
+        loggerCtx
       );
-    } else if (!order) {
-      throw Error(`No order found with code ${orderCode}`);
+      return;
+    }
+    if (!order) {
+      throw new UserInputError(`No order found with code ${orderCode}`);
     }
     if (createCreditInvoiceOnly && !config?.createCreditInvoices) {
-      throw new UserInputError(
-        `Cannot generate credit invoice only with "createCreditInvoiceOnly=true" for order ${orderCode}, because credit invoices are disabled in the config.`
+      Logger.info(
+        `Cannot generate credit invoice only with "createCreditInvoiceOnly=true" for order ${orderCode}, because credit invoices are disabled in the config.`,
+        loggerCtx
       );
+      return;
     }
     if (createCreditInvoiceOnly && !previousInvoiceForOrder) {
-      throw new UserInputError(
-        `"createCreditInvoiceOnly=true" was supplied, but no previous invoice exists for order ${orderCode}, so we can not generate a credit invoice.`
+      Logger.info(
+        `"createCreditInvoiceOnly=true" was supplied, but no previous invoice exists for order ${orderCode}, so we can not generate a credit invoice.`,
+        loggerCtx
       );
+      return;
     }
     if (createCreditInvoiceOnly) {
       Logger.info(

--- a/packages/vendure-plugin-shipmate/CHANGELOG.md
+++ b/packages/vendure-plugin-shipmate/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.5 (2024-06-13)
+
+- Don't throw errors when an order doesn't exist, but log and return. This can happen because shipments are also manually created in Shipmate.
+
 # 1.0.4 (2024-06-12)
 
 - Removed unused @Index(), because a unique constraint was already present

--- a/packages/vendure-plugin-shipmate/package.json
+++ b/packages/vendure-plugin-shipmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-shipmate",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Vendure plugin for integration with Shipmate",
   "icon": "truck",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",


### PR DESCRIPTION
# Description

- Invoices: Don't throw errors when a cancelled invoice doesn't have a previous invoice, but log and return instead.
- Shipmate: Don't throw errors when an order doesn't exist, but log and return. This can happen because shipments are also manually created in Shipmate.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
