### PR TITLE
fix(accept-blue): convert biannually to mean every 6 months

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.2 (2024-07-08)
+
+- Convert `biannually` to every 6 months instead of once every 2 years
+
 # 1.4.0 (2024-06-21)
 
 - Update Version to 2.2.6

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/util.ts
+++ b/packages/vendure-plugin-accept-blue/src/util.ts
@@ -80,7 +80,7 @@ export function toAcceptBlueFrequency(subscription: Subscription): Frequency {
   if (interval === 'year' && intervalCount === 1) {
     return 'annually';
   }
-  if (interval === 'year' && intervalCount === 2) {
+  if (interval === 'month' && intervalCount === 6) {
     return 'biannually';
   }
   throw new Error(


### PR DESCRIPTION
# Description

biannually means twice a year. This means an intervalCount of 6 and an interval of 'month'. The current version treats biannually as once every 2 years.

# Breaking changes

biannually is now treated differently for subscriptions

# Screenshots


# Checklist

📌 Always:
- [ x] I have set a clear title
- [ x] My PR is small and contains a single feature
- [x ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ x] I have updated the README if needed

📦 For publishable packages:
- [ x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
