### PR TITLE
Fix/invoice list performance

### DIFF
--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.1 (2024-07-09)
+
+- Important performance improvement for projects with larger amounts (> 60000) of invoices
+
 # 3.1.0 (2024-07-05)
 
 - Improved default HTML template

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendure-hub/pinelab-invoice-plugin",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vendure plugin for PDF invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-invoices/src/entities/invoice.entity.ts
+++ b/packages/vendure-plugin-invoices/src/entities/invoice.entity.ts
@@ -1,6 +1,6 @@
 import { OrderTaxSummary } from '@vendure/common/lib/generated-types';
 import { DeepPartial, VendureEntity } from '@vendure/core';
-import { Column, Entity, Unique } from 'typeorm';
+import { Column, Entity, Unique, Index } from 'typeorm';
 
 /**
  * The order totals that were used to generate the invoice.
@@ -19,9 +19,11 @@ export class InvoiceEntity extends VendureEntity {
     super(input);
   }
 
+  @Index()
   @Column()
   channelId!: string; // Channel id is needed here to ensure uniqueness of invoiceNumber
 
+  @Index()
   @Column({ nullable: false })
   orderId!: string;
 

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -221,10 +221,9 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
         qb.orWhere(condition.clause, parameters);
       }
     }
-    // qb.innerJoin('order.customer', 'customer');
-    // qb.addSelect(['customer.id', 'customer.emailAddress']);
     const [invoices, totalItems] = await qb.getManyAndCount();
-    // We now fetch the orders + customers for the results in a separate query. We do this because we cant
+    // We now fetch the orders + customers for the results in a separate query.
+    // We do this because we wan't to avoid getRawMany and the performance hit it brings
     const orderIds = invoices.map((i) => i.orderId);
     const orders = await this.orderService.findAll(
       ctx,

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -23,6 +23,7 @@ import {
   TransactionalConnection,
   UserInputError,
   EntityRelationPaths,
+  idsAreEqual,
 } from '@vendure/core';
 import {
   Invoice,
@@ -198,6 +199,7 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
       },
       entityAlias: 'invoice',
     });
+    // Order join needed for order code filtering
     qb.innerJoin(Order, 'order', 'order.id = invoice.orderId');
     qb.addSelect(['order.id', 'order.code']);
     if (options?.filter?.orderCode) {
@@ -219,37 +221,46 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
         qb.orWhere(condition.clause, parameters);
       }
     }
-    qb.innerJoin('order.customer', 'customer');
-    qb.addSelect(['customer.id', 'customer.emailAddress']);
-    const totalItems = await qb.getCount();
-    const result = await qb.getRawMany();
+    // qb.innerJoin('order.customer', 'customer');
+    // qb.addSelect(['customer.id', 'customer.emailAddress']);
+    const [invoices, totalItems] = await qb.getManyAndCount();
+    // We now fetch the orders + customers for the results in a separate query. We do this because we cant
+    const orderIds = invoices.map((i) => i.orderId);
+    const orders = await this.orderService.findAll(
+      ctx,
+      { filter: { id: { in: orderIds } } },
+      ['customer']
+    );
     const items: Invoice[] = [];
-    for (let invoiceEntity of result) {
-      if (!invoiceEntity.order_id) {
-        throw new UserInputError(
-          `No order with id ${invoiceEntity.orderId} found for invoice ${invoiceEntity.invoiceNumber}`
+    for (let invoice of invoices) {
+      const order = orders.items.find((o) =>
+        idsAreEqual(o.id, invoice.orderId)
+      );
+      if (!order) {
+        Logger.error(
+          `No order with id '${invoice.orderId}' found for invoice '${invoice.invoiceNumber}'. Omitting this invoice from the results`,
+          loggerCtx
         );
+        continue;
       }
-      if (!invoiceEntity.customer_id) {
-        throw new UserInputError(
-          `Order "${invoiceEntity.order_code}" has no customer. A customer is needed to get the download URL for an invoice`
+      if (!order.customer?.emailAddress) {
+        Logger.error(
+          `Order '${order.id}' for invoice '${invoice.invoiceNumber}' has no customer. Omitting this invoice from the results`,
+          loggerCtx
         );
+        continue;
       }
-      const orderTotals = JSON.parse(
-        invoiceEntity.invoice_orderTotals
-      ) as InvoiceOrderTotals;
+
       items.push({
-        createdAt: new Date(invoiceEntity.invoice_createdAt),
-        id: invoiceEntity.invoice_id,
-        invoiceNumber: invoiceEntity.invoice_invoiceNumber,
-        orderId: invoiceEntity.order_id,
-        orderCode: invoiceEntity.order_code,
-        isCreditInvoice: orderTotals.total < 0,
+        ...invoice,
+        orderCode: order.code,
+        orderId: order.id,
+        isCreditInvoice: invoice.isCreditInvoice,
         downloadUrl: this.getDownloadUrl(
           ctx,
-          invoiceEntity.invoice_invoiceNumber,
-          invoiceEntity.order_code,
-          invoiceEntity.customer_emailAddress
+          invoice.invoiceNumber,
+          order.code,
+          order.customer.emailAddress
         ),
       });
     }

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -199,10 +199,10 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
       },
       entityAlias: 'invoice',
     });
-    // Order join needed for order code filtering
-    qb.innerJoin(Order, 'order', 'order.id = invoice.orderId');
-    qb.addSelect(['order.id', 'order.code']);
     if (options?.filter?.orderCode) {
+      // Order join needed for order code filtering
+      qb.innerJoin(Order, 'order', 'order.id = invoice.orderId');
+      qb.addSelect(['order.id', 'order.code']);
       const filter = parseFilterParams(
         qb.connection,
         Order,


### PR DESCRIPTION
# Description

Getting the list of invoices was taking ~30 seconds in the HPS project (~60000 invoices). I researched the problem and found that typeORM's `getRawMany` was being 50 times slower than `getManyAndCount`. However, we do need the connected order's customer email, which is not a relation in the entity, so we do:
1. Get all invoices
2. If the filter contains orderCode, we also join the order relation
3. For the fetched invoices (so only 10, 25, 50 or 100 for pagination) we fetch the order+customer in a new query and get the order's customer email in code, in our function. I suspect this was the problem, because we were joining the order+customer relation for all 60 000 invoices, while we only need it for the actual entities we return.

The above was tested in the HPS project and improved the speed for getting paginated invoice list from ~30s to 300ms. And the same improvement for fetching pages with 100 invoices

* Also added indices on the channelId column and orderId column for even better performance


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
