### PR TITLE
fix(stripe-subscription): fix payment method handler crash on enabled…

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.1 (2024-07-23)
+
+- Fix Vendure crash on payment method with "just" enabled: true/false update
+
 # 2.5.0 (2024-06-21)
 
 - Updated Vendure to 2.2.6

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.service.ts
@@ -181,7 +181,7 @@ export class StripeSubscriptionService {
     this.eventBus.ofType(PaymentMethodEvent).subscribe(async (event) => {
       if (event.type === 'created' || event.type === 'updated') {
         const paymentMethod = event.entity;
-        if (paymentMethod.handler.code === stripeSubscriptionHandler.code) {
+        if (paymentMethod.handler?.code === stripeSubscriptionHandler.code) {
           await this.registerWebhooks(event.ctx, paymentMethod).catch((e) => {
             Logger.error(
               `Failed to register webhooks for channel ${event.ctx.channel.token}: ${e}`,


### PR DESCRIPTION
# Description

When you update a payment method handler and just set enabled : true or false, the stripe plugin event handler will trigger but will not receive the handler and throw an error and crash Vendure

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ x] I have set a clear title
- [ x] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
