### PR TITLE
feat(klaviyo): Multiple order placed events and exclude items from Ordered Product events

### DIFF
--- a/packages/vendure-plugin-klaviyo/CHANGELOG.md
+++ b/packages/vendure-plugin-klaviyo/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0 (2024-08-14)
+
+- Allow setting multiple Klaviyo handlers for Vendure's OrderPlacedEvent
+- Allow order items to be excluded from 'Ordered Product' events
+
 # 1.1.1 (2024-08-04)
 
 - Update compatibility range (#480)

--- a/packages/vendure-plugin-klaviyo/README.md
+++ b/packages/vendure-plugin-klaviyo/README.md
@@ -23,7 +23,7 @@ plugins: [
 ];
 ```
 
-All placed orders will now be synced
+All placed orders will now be synced.
 
 ## Custom event handlers
 
@@ -33,7 +33,10 @@ If you want to send more events to Klaviyo, you can implement your own handlers.
 
    ```ts
    import { AccountVerifiedEvent } from '@vendure/core';
-   import { KlaviyoEventHandler } from '@pinelab/vendure-plugin-klaviyo';
+   import {
+     KlaviyoEventHandler,
+     KlaviyoGenericEvent,
+   } from '@pinelab/vendure-plugin-klaviyo';
 
    /**
     * Event handler to send Vendure's AccountVerifiedEvent to Klaviyo
@@ -43,7 +46,7 @@ If you want to send more events to Klaviyo, you can implement your own handlers.
        vendureEvent: AccountVerifiedEvent,
        mapToKlaviyoEvent: async (event, injector) => {
          const { customer } = event;
-         return {
+         return <KlaviyoGenericEvent>{
            // Unique ID per event to make the event idempotent
            uniqueId: `account-verified-${customer.id}-${Date.now()}`,
            eventName: 'Account Verified',
@@ -77,3 +80,17 @@ If you want to send more events to Klaviyo, you can implement your own handlers.
      }),
    ];
    ```
+
+## Custom data in Klaviyo's default Order Placed event
+
+If you'd like to send custom data in the Klaviyo native Order Placed event, you can also create a custom handler, but make sure to return a `KlaviyoOrderPlacedEvent` instead of a `KlaviyoGenericEvent`. The plugin will recognize your return type and handle it as an Order Placed event.
+
+Don't forget to exclude the default order placed handler if you do!
+
+```ts
+     KlaviyoPlugin.init({
+       apiKey: 'some_private_api_key',
+       // No defaultOrderPlacedHandler here!
+       eventHandlers: [customOrderPlacedHandler],
+     }),
+```

--- a/packages/vendure-plugin-klaviyo/package.json
+++ b/packages/vendure-plugin-klaviyo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-klaviyo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "An extensible plugin for sending placed orders to the Klaviyo marketing platform.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-klaviyo/src/event-handler/klaviyo-event-handler.ts
+++ b/packages/vendure-plugin-klaviyo/src/event-handler/klaviyo-event-handler.ts
@@ -22,6 +22,10 @@ export interface KlaviyoOrderItem {
   Categories?: string[];
   Brand?: string;
   customProperties?: CustomProperties;
+  /**
+   * Setting this to true will exclude this item from being sent as Ordered Product event to Klaviyo.
+   */
+  excludeFromOrderedProductEvent?: boolean;
 }
 
 type CustomProperties = Record<string, string | string[] | number | boolean>;

--- a/packages/vendure-plugin-klaviyo/src/klaviyo.service.ts
+++ b/packages/vendure-plugin-klaviyo/src/klaviyo.service.ts
@@ -25,18 +25,10 @@ import {
   mapToOrderedProductEvent,
 } from './util/map-to-klaviyo-input';
 
-interface EventJobData {
+type JobData = {
   ctx: SerializedRequestContext;
   event: KlaviyoGenericEvent;
-}
-
-interface OrderEventJobData {
-  action: 'handle-order-event';
-  ctx: SerializedRequestContext;
-  event: KlaviyoOrderPlacedEvent;
-}
-
-type JobData = EventJobData | OrderEventJobData;
+};
 
 export class KlaviyoService implements OnApplicationBootstrap {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Weird TS error, but our JobData is JSON compatible
@@ -116,7 +108,7 @@ export class KlaviyoService implements OnApplicationBootstrap {
       new Injector(this.moduleRef)
     );
     if (event) {
-      const jobData: EventJobData = {
+      const jobData: JobData = {
         ctx: vendureEvent.ctx.serialize(),
         event,
       };
@@ -206,4 +198,4 @@ export class KlaviyoService implements OnApplicationBootstrap {
       }
     }
   }
-}
+};

--- a/packages/vendure-plugin-klaviyo/src/klaviyo.service.ts
+++ b/packages/vendure-plugin-klaviyo/src/klaviyo.service.ts
@@ -6,10 +6,10 @@ import {
   JobQueue,
   JobQueueService,
   Logger,
-  OrderPlacedEvent,
   RequestContext,
   SerializedRequestContext,
 } from '@vendure/core';
+import { isAxiosError } from 'axios';
 import { ApiKeySession, EventCreateQueryV2, EventsApi } from 'klaviyo-api';
 import { PLUGIN_INIT_OPTIONS, loggerCtx } from './constants';
 import {
@@ -17,7 +17,6 @@ import {
   KlaviyoEventHandler,
   KlaviyoGenericEvent,
   KlaviyoOrderPlacedEvent,
-  KlaviyoOrderPlacedEventHandler,
 } from './event-handler/klaviyo-event-handler';
 import { KlaviyoPluginOptions } from './klaviyo.plugin';
 import {
@@ -25,10 +24,8 @@ import {
   mapToKlaviyoOrderPlacedInput,
   mapToOrderedProductEvent,
 } from './util/map-to-klaviyo-input';
-import { isAxiosError } from 'axios';
 
-interface GenericEventJobData {
-  action: 'handle-event';
+interface EventJobData {
   ctx: SerializedRequestContext;
   event: KlaviyoGenericEvent;
 }
@@ -39,7 +36,7 @@ interface OrderEventJobData {
   event: KlaviyoOrderPlacedEvent;
 }
 
-type JobData = GenericEventJobData | OrderEventJobData;
+type JobData = EventJobData | OrderEventJobData;
 
 export class KlaviyoService implements OnApplicationBootstrap {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Weird TS error, but our JobData is JSON compatible
@@ -60,15 +57,14 @@ export class KlaviyoService implements OnApplicationBootstrap {
         const data = _data as JobData;
         const ctx = RequestContext.deserialize(data.ctx);
         try {
-          if (data.action === 'handle-event') {
-            await this.handleGenericEvent(ctx, data.event);
-          } else if (data.action === 'handle-order-event') {
-            await this.handleOrderEvent(ctx, data.event);
-          }
-          Logger.info(`Successfully handled job '${data.action}'`, loggerCtx);
+          await this.handleEventJob(ctx, data.event);
+          Logger.info(
+            `Successfully handled job '${data.event.eventName}'`,
+            loggerCtx
+          );
         } catch (e) {
           Logger.warn(
-            `Failed to handle job '${data.action}': ${
+            `Failed to handle job '${data.event.eventName}': ${
               (e as Error).message
             }. Job data: ${JSON.stringify(data.event)}`,
             loggerCtx
@@ -84,31 +80,14 @@ export class KlaviyoService implements OnApplicationBootstrap {
       );
       return;
     }
-    // Listen for OrderPlacedEvent
-    this.eventBus.ofType(OrderPlacedEvent).subscribe((event) => {
-      Logger.info(`Creating job for '${event.constructor.name}'`, loggerCtx);
-      this.createOrderEventJob(event).catch((err) => {
-        Logger.error(
-          `Error creating order event job: ${err}`,
-          loggerCtx,
-          (err as Error)?.stack
-        );
-      });
-    });
     // Listen for configured event handlers
     this.options.eventHandlers.forEach((handler) => {
-      if (handler.vendureEvent === OrderPlacedEvent) {
-        // OrderPlacedEvent is handled separately below
-        return;
-      }
       this.eventBus.ofType(handler.vendureEvent).subscribe((event) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        Logger.info(`Creating job for '${event?.constructor.name}'`, loggerCtx);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this.createEventJob(event, handler).catch((err) => {
           Logger.error(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            `Error creating event job for '${event?.constructor.name}': ${err}`,
+            `Error creating job for '${event?.constructor.name}' event: ${err}`,
             loggerCtx,
             (err as Error)?.stack
           );
@@ -121,39 +100,6 @@ export class KlaviyoService implements OnApplicationBootstrap {
         .join(', ')}`,
       loggerCtx
     );
-  }
-
-  /**
-   * Create Jobs to sent Placed Order Events to Klaviyo.
-   * This calls the configured event handler and sends the result to the job queue
-   */
-  async createOrderEventJob(
-    orderPlacedEvent: OrderPlacedEvent,
-    retries = 10
-  ): Promise<void> {
-    const orderPlacedHandlers = this.options.eventHandlers.filter(
-      (handler) => handler.vendureEvent === OrderPlacedEvent
-    );
-    if (!orderPlacedHandlers.length) {
-      Logger.warn(
-        `No order placed event mapper configured for Klaviyo, not sending Placed Order and Ordered Product events`,
-        loggerCtx
-      );
-      return;
-    }
-    for (const handler of orderPlacedHandlers) {
-      const event = await (
-        handler as KlaviyoOrderPlacedEventHandler
-      ).mapToKlaviyoEvent(orderPlacedEvent, new Injector(this.moduleRef));
-      if (event) {
-        const jobData: OrderEventJobData = {
-          action: 'handle-order-event',
-          ctx: orderPlacedEvent.ctx.serialize(),
-          event,
-        };
-        await this.jobQueue.add(jobData, { retries });
-      }
-    }
   }
 
   /**
@@ -170,8 +116,7 @@ export class KlaviyoService implements OnApplicationBootstrap {
       new Injector(this.moduleRef)
     );
     if (event) {
-      const jobData: GenericEventJobData = {
-        action: 'handle-event',
+      const jobData: EventJobData = {
         ctx: vendureEvent.ctx.serialize(),
         event,
       };
@@ -180,44 +125,47 @@ export class KlaviyoService implements OnApplicationBootstrap {
   }
 
   /**
-   * Push an order to Klaviyo as 'Placed Order Event' and create 'Ordered Product Events for each order line
-   * https://developers.klaviyo.com/en/docs/guide_to_integrating_a_platform_without_a_pre_built_klaviyo_integration#ordered-product
+   * Send events to Klaviyo
    */
-  async handleOrderEvent(
+  async handleEventJob(
     ctx: RequestContext,
-    event: KlaviyoOrderPlacedEvent
+    event: KlaviyoGenericEvent | KlaviyoOrderPlacedEvent
   ): Promise<void> {
     const klaviyoApi = await this.getKlaviyoApi(ctx);
-    await this.createEvent(klaviyoApi, mapToKlaviyoOrderPlacedInput(event));
+    if (event.eventName !== 'Order Placed') {
+      // Anything other than Order Placed is handled as a generic Klaviyo event
+      await this.createEvent(klaviyoApi, mapToKlaviyoEventInput(event));
+      Logger.info(
+        `Sent '${event.eventName}' event with event ID '${event.uniqueId}' to Klaviyo.`,
+        loggerCtx
+      );
+      return;
+    }
+    // This means we are dealing with an Order Placed event, and they require special handling
+    // Push an order to Klaviyo as 'Placed Order Event' and create 'Ordered Product Events' for each order line
+    const orderPlacedEvent = event as KlaviyoOrderPlacedEvent;
+    await this.createEvent(
+      klaviyoApi,
+      mapToKlaviyoOrderPlacedInput(orderPlacedEvent)
+    );
     Logger.info(
-      `Sent' Placed Order' event to Klaviyo for order ${event.orderId}`,
+      `Sent 'Placed Order' event to Klaviyo for order ${orderPlacedEvent.orderId}`,
       loggerCtx
     );
-    for (const [index, orderItem] of event.orderItems.entries()) {
+    for (const [index, orderItem] of orderPlacedEvent.orderItems.entries()) {
+      if (orderItem.excludeFromOrderedProductEvent) {
+        // Exclude this item from the Ordered Product event
+        continue;
+      }
       const orderedProductEvent = mapToOrderedProductEvent(
         orderItem,
         index,
-        event
+        orderPlacedEvent
       );
       await this.createEvent(klaviyoApi, orderedProductEvent);
     }
     Logger.info(
-      `Sent 'Ordered Product' event to Klaviyo for order ${event.orderId} for ${event.orderItems.length} order lines`,
-      loggerCtx
-    );
-  }
-
-  /**
-   * Push an order to Klaviyo as 'Placed Order Event' and create 'Ordered Product Events for each order line
-   */
-  async handleGenericEvent(
-    ctx: RequestContext,
-    event: KlaviyoGenericEvent
-  ): Promise<void> {
-    const klaviyoApi = await this.getKlaviyoApi(ctx);
-    await this.createEvent(klaviyoApi, mapToKlaviyoEventInput(event));
-    Logger.info(
-      `Sent '${event.eventName}' event with event ID '${event.uniqueId}' to Klaviyo.`,
+      `Sent 'Ordered Product' event to Klaviyo for order ${orderPlacedEvent.orderId} for ${orderPlacedEvent.orderItems.length} order lines`,
       loggerCtx
     );
   }

--- a/packages/vendure-plugin-klaviyo/src/klaviyo.service.ts
+++ b/packages/vendure-plugin-klaviyo/src/klaviyo.service.ts
@@ -198,4 +198,4 @@ export class KlaviyoService implements OnApplicationBootstrap {
       }
     }
   }
-};
+}

--- a/packages/vendure-plugin-klaviyo/test/dev-server.ts
+++ b/packages/vendure-plugin-klaviyo/test/dev-server.ts
@@ -1,5 +1,4 @@
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
-import { AssetServerPlugin } from '@vendure/asset-server-plugin';
 import {
   DefaultLogger,
   DefaultSearchPlugin,
@@ -11,12 +10,11 @@ import {
   registerInitializer,
   SqljsInitializer,
 } from '@vendure/testing';
-import path from 'path';
-import { addShippingMethod } from '../../test/src/admin-utils';
 import { initialData } from '../../test/src/initial-data';
 import { createSettledOrder } from '../../test/src/shop-utils';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
-import { KlaviyoPlugin } from '../src';
+import { KlaviyoPlugin, defaultOrderPlacedEventHandler } from '../src';
+import { mockCustomEventHandler } from './mock-custom-event-handler';
 
 (async () => {
   require('dotenv').config();
@@ -34,10 +32,7 @@ import { KlaviyoPlugin } from '../src';
     plugins: [
       KlaviyoPlugin.init({
         apiKey: process.env.KLAVIYO_PRIVATE_API_KEY!,
-      }),
-      AssetServerPlugin.init({
-        assetUploadDir: path.join(__dirname, '../__data__/assets'),
-        route: 'assets',
+        eventHandlers: [defaultOrderPlacedEventHandler, mockCustomEventHandler],
       }),
       DefaultSearchPlugin,
       AdminUiPlugin.init({

--- a/packages/vendure-plugin-klaviyo/test/mock-custom-event-handler.ts
+++ b/packages/vendure-plugin-klaviyo/test/mock-custom-event-handler.ts
@@ -1,0 +1,29 @@
+import { OrderPlacedEvent } from '@vendure/core';
+import { KlaviyoEventHandler, KlaviyoGenericEvent } from '../src';
+
+/**
+ * Testing if a custom event can be sent to Klaviyo
+ */
+export const mockCustomEventHandler: KlaviyoEventHandler<OrderPlacedEvent> = {
+  vendureEvent: OrderPlacedEvent,
+  mapToKlaviyoEvent: async ({ order, ctx }, injector) => {
+    if (!order.customer) {
+      return false;
+    }
+    return <KlaviyoGenericEvent>{
+      eventName: 'Custom Testing Event',
+      uniqueId: order.code,
+      profile: {
+        emailAddress: order.customer.emailAddress,
+        externalId: order.customer.id.toString(),
+        firstName: order.customer.firstName,
+        lastName: order.customer.lastName,
+        phoneNumber: order.customer.phoneNumber,
+        address: {},
+      },
+      customProperties: {
+        customTestEventProp: 'some information',
+      },
+    };
+  },
+};

--- a/packages/vendure-plugin-klaviyo/test/mock-order-placed-handler.ts
+++ b/packages/vendure-plugin-klaviyo/test/mock-order-placed-handler.ts
@@ -1,5 +1,10 @@
 import { EntityHydrator, OrderPlacedEvent, translateDeep } from '@vendure/core';
-import { KlaviyoEventHandler, KlaviyoOrderItem, toKlaviyoMoney } from '../src';
+import {
+  KlaviyoEventHandler,
+  KlaviyoOrderItem,
+  KlaviyoOrderPlacedEvent,
+  toKlaviyoMoney,
+} from '../src';
 
 /**
  * Mock custom Klaviyo handler to test custom and additional properties
@@ -27,8 +32,8 @@ export const mockOrderPlacedHandler: KlaviyoEventHandler<OrderPlacedEvent> = {
     if (!order.customer) {
       return false;
     }
-    return {
-      eventName: 'Custom Order Placed',
+    return <KlaviyoOrderPlacedEvent>{
+      eventName: 'Order Placed',
       uniqueId: order.code,
       orderId: order.code,
       orderPlacedAt: order.orderPlacedAt ?? order.updatedAt,
@@ -41,7 +46,7 @@ export const mockOrderPlacedHandler: KlaviyoEventHandler<OrderPlacedEvent> = {
         phoneNumber: order.customer.phoneNumber,
         address: {},
       },
-      orderItems: <KlaviyoOrderItem[]>order.lines.map((line) => ({
+      orderItems: <KlaviyoOrderItem[]>order.lines.map((line, index) => ({
         Brand: 'Test Brand',
         ProductURL: 'https://pinelab.studio/product/some-product',
         Categories: ['Some mock category'],
@@ -55,6 +60,7 @@ export const mockOrderPlacedHandler: KlaviyoEventHandler<OrderPlacedEvent> = {
         ItemPrice: toKlaviyoMoney(line.proratedUnitPriceWithTax),
         RowTotal: toKlaviyoMoney(line.proratedLinePriceWithTax),
         ImageURL: 'custom-image-url.png',
+        excludeFromOrderedProductEvent: true,
       })),
       customProperties: {
         customOrderProp: 'my custom order value',


### PR DESCRIPTION
# Description

# 1.2.0 (2024-08-14)

- Allow setting multiple Klaviyo handlers for Vendure's OrderPlacedEvent
- Allow order items to be excluded from 'Ordered Product' events

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
