### PR TITLE
Invoices 4.1.1 Don't allow accounting export when the order totals changed + Xero fixes

### DIFF
--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 4.0.4 (2024-08-29)
+# 4.1.0 (2024-08-29)
 
-- Don't allow exporting to accounting when the order changed.
+- Exporting credit invoices now have their own accounting export interface
+- Don't allow accounting export when the order totals changed, to prevent mismatch between accounting export and invoice
 
 # 4.0.3 (2024-08-27)
 

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.4 (2024-08-29)
+
+- Don't allow exporting to accounting when the order changed.
+
 # 4.0.3 (2024-08-27)
 
 - Try to find Xero contact by name first, then by email address

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.1.0 (2024-08-29)
+# 4.1.0 (2024-08-30)
 
 - Exporting credit invoices via accounting strategies now have their own interface method
 - Don't allow accounting export when the order totals changed, to prevent mismatch between accounting export and invoice

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 4.1.0 (2024-08-29)
 
-- Exporting credit invoices now have their own accounting export interface
+- Exporting credit invoices via accounting strategies now have their own interface method
 - Don't allow accounting export when the order totals changed, to prevent mismatch between accounting export and invoice
+- Added Due Date to Xero exports, which is needed for invoice approval
 
 # 4.0.3 (2024-08-27)
 

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.1.0 (2024-08-30)
 
-- Exporting credit invoices via accounting strategies now have their own interface method
+- Exporting credit invoices via accounting strategies now have their own method interface
 - Don't allow accounting export when the order totals changed, to prevent mismatch between accounting export and invoice
 - Added Due Date to Xero exports, which is needed for invoice approval
 

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendure-hub/pinelab-invoice-plugin",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Vendure plugin for PDF invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -33,6 +33,6 @@
   },
   "gitHead": "476f36da3aafea41fbf21c70774a30306f1d238f",
   "devDependencies": {
-    "xero-node": "^9.0.0"
+    "xero-node": "9.2.0"
   }
 }

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendure-hub/pinelab-invoice-plugin",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Vendure plugin for PDF invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-invoices/src/services/accounting.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/accounting.service.ts
@@ -55,7 +55,7 @@ export class AccountingService implements OnModuleInit {
           job.data.orderCode
         ).catch((error: Error) => {
           Logger.warn(
-            `Failed to export invoice to accounting platform for '${job.data.orderCode}': ${error?.message}`,
+            `Failed to export invoice '${job.data.invoiceNumber}' to accounting platform for '${job.data.orderCode}': ${error?.message}`,
             loggerCtx
           );
           throw error;

--- a/packages/vendure-plugin-invoices/src/services/accounting.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/accounting.service.ts
@@ -121,7 +121,6 @@ export class AccountingService implements OnModuleInit {
         !this.orderMatchesInvoice(order, invoice) &&
         !invoice.isCreditInvoice
       ) {
-        // console.log('============= NO MATCH', invoice.invoiceNumber, order.total, order.totalWithTax, order.taxSummary, invoice.orderTotals)
         // Throw an error when order totals don't match to prevent re-exporting wrong data.
         // Credit invoices are allowed, because they use the reversed invoice.orderTotals instead of the order data itself
         throw Error(

--- a/packages/vendure-plugin-invoices/src/services/accounting.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/accounting.service.ts
@@ -187,13 +187,13 @@ export class AccountingService implements OnModuleInit {
    * Checks if the total and tax rates of the order still match the ones from the invoice.
    * When they differ, it means the order changed compared to the invoice.
    *
-   * Invoice totals are made absolute (Math.abs), because it could be about a credit invoice,
-   * which has the same amount but negative
+   * This should not be used with credit invoices, as their totals will mostly differ from the order,
+   * because a new invoice is created immediately
    */
   private orderMatchesInvoice(order: Order, invoice: InvoiceEntity): boolean {
     if (
-      order.total !== Math.abs(invoice.orderTotals.total) ||
-      order.totalWithTax !== Math.abs(invoice.orderTotals.totalWithTax)
+      order.total !== invoice.orderTotals.total ||
+      order.totalWithTax !== invoice.orderTotals.totalWithTax
     ) {
       // Totals don't match anymore
       return false;
@@ -203,7 +203,7 @@ export class AccountingService implements OnModuleInit {
       const matchingInvoiceSummary = invoice.orderTotals.taxSummaries.find(
         (invoiceSummary) =>
           invoiceSummary.taxRate === orderSummary.taxRate &&
-          Math.abs(invoiceSummary.taxBase) === orderSummary.taxBase
+          invoiceSummary.taxBase === orderSummary.taxBase
       );
       // If no matching tax summary is found, the order doesn't match the invoice
       return !!matchingInvoiceSummary;

--- a/packages/vendure-plugin-invoices/src/strategies/accounting/accounting-export-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/strategies/accounting/accounting-export-strategy.ts
@@ -32,10 +32,23 @@ export interface AccountingExportStrategy {
   exportInvoice(
     ctx: RequestContext,
     invoice: InvoiceEntity,
-    order: Order,
+    order: Order
+  ): Promise<ExternalReference> | ExternalReference;
+
+  /**
+   * Export the given Credit Invoice to the external accounting system.
+   * You should use invoice.orderTotals for the credit invoice and NOT the data from the order, because that will have the new data.
+   * You can still use order.code and address details ion your credit invoice.
+   *
+   * This function will be executed asynchronously in via the JobQueue.
+   */
+  exportCreditInvoice(
+    ctx: RequestContext,
+    invoice: InvoiceEntity,
     /**
-     * If the invoice is a credit invoice, this will be the original invoice that the credit invoice is for.
+     * The original invoice that the credit invoice is for.
      */
-    isCreditInvoiceFor?: InvoiceEntity
+    isCreditInvoiceFor: InvoiceEntity,
+    order: Order
   ): Promise<ExternalReference> | ExternalReference;
 }

--- a/packages/vendure-plugin-invoices/src/strategies/accounting/accounting-export-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/strategies/accounting/accounting-export-strategy.ts
@@ -37,8 +37,10 @@ export interface AccountingExportStrategy {
 
   /**
    * Export the given Credit Invoice to the external accounting system.
-   * You should use invoice.orderTotals for the credit invoice and NOT the data from the order, because that will have the new data.
-   * You can still use order.code and address details ion your credit invoice.
+   * You should use invoice.orderTotals for the credit invoice and NOT the data from the order, because that
+   * will be the current (modified) order object, not the credit invoice.
+   *
+   * You can still use order.code and address details from the order object, just not the prices.
    *
    * This function will be executed asynchronously in via the JobQueue.
    */

--- a/packages/vendure-plugin-invoices/src/strategies/accounting/xero-uk-export-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/strategies/accounting/xero-uk-export-strategy.ts
@@ -162,7 +162,9 @@ export class XeroUKExportStrategy implements AccountingExportStrategy {
         status: 'DRAFT' as any,
         url: this.config.getVendureUrl?.(order, invoice),
       };
-      const idempotencyKey = `${ctx.channel.token}-${order.code}-${invoice.invoiceNumber}`;
+      const idempotencyKey = `${ctx.channel.token}-${
+        invoice.invoiceNumber
+      }-${order.updatedAt.toISOString()}`;
       const response = await this.xero.accountingApi.createInvoices(
         this.tenantId,
         { invoices: [xeroInvoice] },
@@ -230,7 +232,9 @@ export class XeroUKExportStrategy implements AccountingExportStrategy {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         status: 'DRAFT' as any,
       };
-      const idempotencyKey = `${ctx.channel.token}-${order.code}-${invoice.invoiceNumber}`;
+      const idempotencyKey = `${ctx.channel.token}-${
+        invoice.invoiceNumber
+      }-${order.updatedAt.toISOString()}`;
       const response = await this.xero.accountingApi.createCreditNotes(
         this.tenantId,
         { creditNotes: [creditNote] },

--- a/packages/vendure-plugin-invoices/src/strategies/accounting/xero-uk-export-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/strategies/accounting/xero-uk-export-strategy.ts
@@ -36,7 +36,7 @@ interface Config {
   /**
    * See https://central.xero.com/s/article/Add-edit-or-delete-custom-invoice-quote-templates
    */
-  invoiceBrandingThemeId: string;
+  invoiceBrandingThemeId?: string;
   /**
    * Construct a reference based on the given order object
    */
@@ -127,7 +127,6 @@ export class XeroUKExportStrategy implements AccountingExportStrategy {
         'lines.productVariant',
         'lines.productVariant.translations',
         'shippingLines.shippingMethod',
-        'payments',
       ],
     });
     if (!order.customer) {
@@ -373,27 +372,20 @@ export class XeroUKExportStrategy implements AccountingExportStrategy {
       }
     );
     // Map shipping lines
-    // lineItems.push(
-    //   ...order.shippingLines.map((shippingLine) => {
-    //     return {
-    //       description: translateDeep(
-    //         shippingLine.shippingMethod,
-    //         ctx.channel.defaultLanguageCode
-    //       ).name,
-    //       quantity: 1,
-    //       unitAmount: this.toMoney(shippingLine.discountedPrice),
-    //       accountCode: this.config.shippingAccountCode,
-    //       taxType: this.getTaxType(shippingLine.taxRate, order.code),
-    //     };
-    //   })
-    // );
-    // FIXME TEST
-    lineItems.push({
-      description: 'TEST',
-      quantity: 1,
-      unitAmount: this.toMoney(200),
-      accountCode: '0103',
-    });
+    lineItems.push(
+      ...order.shippingLines.map((shippingLine) => {
+        return {
+          description: translateDeep(
+            shippingLine.shippingMethod,
+            ctx.channel.defaultLanguageCode
+          ).name,
+          quantity: 1,
+          unitAmount: this.toMoney(shippingLine.discountedPrice),
+          accountCode: this.config.shippingAccountCode,
+          taxType: this.getTaxType(shippingLine.taxRate, order.code),
+        };
+      })
+    );
     // Map surcharges
     lineItems.push(
       ...order.surcharges.map((surcharge) => {

--- a/packages/vendure-plugin-invoices/src/ui/invoices-detail-view/invoices-detail-view.ts
+++ b/packages/vendure-plugin-invoices/src/ui/invoices-detail-view/invoices-detail-view.ts
@@ -7,6 +7,11 @@ export const invoiceFragment = gql`
     invoiceNumber
     isCreditInvoice
     downloadUrl
+    accountingReference {
+      reference
+      link
+      errorMessage
+    }
   }
 `;
 

--- a/packages/vendure-plugin-invoices/test/dev-server.ts
+++ b/packages/vendure-plugin-invoices/test/dev-server.ts
@@ -45,10 +45,21 @@ require('dotenv').config();
             clientSecret: process.env.XERO_CLIENT_SECRET!,
             shippingAccountCode: '0103',
             salesAccountCode: '0102',
+            invoiceBrandingThemeId: '62f2bce1-32c4-4e8d-a9b1-87060fb7c791',
             getReference: () =>
               'THIS IS A TEST INVOICE, DONT APPROVE THIS PLEASE.',
             getVendureUrl: (order) =>
               `https://pinelab.studio/order/${order.code}`,
+            getDueDate: (ctx, order, invoice) => {
+              const payment = order.payments.find((p) => p.state === 'Settled');
+              if (payment?.method === 'purchase-order') {
+                const date = new Date();
+                date.setDate(date.getDate() + 30); //30 days later
+                return date;
+              } else {
+                return new Date();
+              }
+            },
           }),
         ],
       }),

--- a/packages/vendure-plugin-invoices/test/dev-server.ts
+++ b/packages/vendure-plugin-invoices/test/dev-server.ts
@@ -45,16 +45,8 @@ require('dotenv').config();
             clientSecret: process.env.XERO_CLIENT_SECRET!,
             shippingAccountCode: '0103',
             salesAccountCode: '0102',
-            getReference: (order, invoice, isCreditInvoiceFor) => {
-              if (isCreditInvoiceFor) {
-                return `Credit note for ${isCreditInvoiceFor}`;
-              } else {
-                return `${order.code} | PO NUMBER | ${order.payments
-                  .filter((p) => p.state === 'Settled')
-                  .map((p) => p.transactionId)
-                  .join(',')}`;
-              }
-            },
+            getReference: () =>
+              'THIS IS A TEST INVOICE, DONT APPROVE THIS PLEASE.',
             getVendureUrl: (order) =>
               `https://pinelab.studio/order/${order.code}`,
           }),
@@ -64,11 +56,11 @@ require('dotenv').config();
       AdminUiPlugin.init({
         port: 3002,
         route: 'admin',
-        app: compileUiExtensions({
-          outputPath: path.join(__dirname, '__admin-ui'),
-          extensions: [InvoicePlugin.ui],
-          devMode: true,
-        }),
+        // app: compileUiExtensions({
+        //   outputPath: path.join(__dirname, '__admin-ui'),
+        //   extensions: [InvoicePlugin.ui],
+        //   devMode: true,
+        // }),
       }),
     ],
     paymentOptions: {

--- a/packages/vendure-plugin-invoices/test/dev-server.ts
+++ b/packages/vendure-plugin-invoices/test/dev-server.ts
@@ -67,11 +67,11 @@ require('dotenv').config();
       AdminUiPlugin.init({
         port: 3002,
         route: 'admin',
-        // app: compileUiExtensions({
-        //   outputPath: path.join(__dirname, '__admin-ui'),
-        //   extensions: [InvoicePlugin.ui],
-        //   devMode: true,
-        // }),
+        app: compileUiExtensions({
+          outputPath: path.join(__dirname, '__admin-ui'),
+          extensions: [InvoicePlugin.ui],
+          devMode: true,
+        }),
       }),
     ],
     paymentOptions: {

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -66,6 +66,7 @@ const mockAccountingStrategy = new MockAccountingStrategy(
 const mockAccountingStrategySpy = {
   init: vi.spyOn(mockAccountingStrategy, 'init'),
   exportInvoice: vi.spyOn(mockAccountingStrategy, 'exportInvoice'),
+  exportCreditInvoice: vi.spyOn(mockAccountingStrategy, 'exportCreditInvoice'),
 };
 
 beforeAll(async () => {
@@ -270,8 +271,9 @@ describe('Generate with credit invoicing enabled', function () {
 
   it('Triggered accounting export strategy for credit invoice', async () => {
     await wait();
-    const [ctx, invoice, order, isCreditInvoiceFor] =
-      mockAccountingStrategySpy.exportInvoice.mock.calls[1];
+    console.log(mockAccountingStrategySpy.exportCreditInvoice.mock.calls);
+    const [ctx, invoice, isCreditInvoiceFor, order] =
+      mockAccountingStrategySpy.exportCreditInvoice.mock.calls[0];
     expect(ctx).toBeInstanceOf(RequestContext);
     expect(invoice).toBeInstanceOf(InvoiceEntity);
     expect(isCreditInvoiceFor?.invoiceNumber).toBe(10001);
@@ -279,12 +281,11 @@ describe('Generate with credit invoicing enabled', function () {
   });
 
   it('Triggered accounting export strategy for new invoice after credit invoice', async () => {
-    const [ctx, invoice, order, isCreditInvoiceFor] =
-      mockAccountingStrategySpy.exportInvoice.mock.calls[2];
+    const [ctx, invoice, order] =
+      mockAccountingStrategySpy.exportInvoice.mock.calls[1];
     expect(ctx).toBeInstanceOf(RequestContext);
     expect(invoice).toBeInstanceOf(InvoiceEntity);
     expect(order).toBeInstanceOf(Order);
-    expect(isCreditInvoiceFor).toBe(null);
   });
 
   it('Returns all invoices for order', async () => {
@@ -302,15 +303,15 @@ describe('Generate with credit invoicing enabled', function () {
     expect(invoices[0].invoiceNumber).toBe(10003);
   });
 
-  it('Exports invoice to accounting again via mutation', async () => {
+  it('Exports the credit invoice to accounting again via mutation', async () => {
     const { exportInvoiceToAccountingPlatform } = await adminClient.query(gql`
       mutation {
         exportInvoiceToAccountingPlatform(invoiceNumber: 10002)
       }
     `);
     await wait();
-    const [ctx, invoice, order, isCreditInvoiceFor] =
-      mockAccountingStrategySpy.exportInvoice.mock.calls[3];
+    const [ctx, invoice, isCreditInvoiceFor] =
+      mockAccountingStrategySpy.exportCreditInvoice.mock.calls[1];
     expect(exportInvoiceToAccountingPlatform).toBe(true);
     expect(invoice.invoiceNumber).toBe(10002);
     expect(isCreditInvoiceFor?.invoiceNumber).toBe(10001);

--- a/packages/vendure-plugin-invoices/test/mock-accounting-strategy.ts
+++ b/packages/vendure-plugin-invoices/test/mock-accounting-strategy.ts
@@ -15,12 +15,23 @@ export class MockAccountingStrategy implements AccountingExportStrategy {
   exportInvoice(
     ctx: RequestContext,
     invoice: InvoiceEntity,
-    order: Order,
-    isCreditInvoiceFor?: InvoiceEntity
+    order: Order
   ): ExternalReference {
     return {
       reference: 'mockReference',
       link: 'mockLink',
+    };
+  }
+
+  exportCreditInvoice(
+    ctx: RequestContext,
+    invoice: InvoiceEntity,
+    isCreditInvoiceFor: InvoiceEntity,
+    order: Order
+  ): ExternalReference {
+    return {
+      reference: 'mockCreditReference',
+      link: 'mockCreditLink',
     };
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18042,10 +18042,10 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-xero-node@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/xero-node/-/xero-node-9.0.0.tgz#1f10e9d1f25c7f636997375c6d74f3ff09064548"
-  integrity sha512-+e0lVD63F/O7D+UPfbPmK5NfYlxx7Ew5+4mECQYba0+5BzW1btFei8RFyHiVlGeYGpH/WaELQKKPJCTndHTCgg==
+xero-node@9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/xero-node/-/xero-node-9.2.0.tgz#6ea0979ac01c41019af1ac3451dec125d020ba5b"
+  integrity sha512-w5B/jntQ5SQmFdFrUuZyZPPF8opB/4I9LQjl3tic/KSgs+BjSTGh6rFFD6ce0feyHHbitZYtEIswkw4ZFp1v4w==
   dependencies:
     axios "^1.6.5"
     openid-client "5.6.5"


### PR DESCRIPTION
# Description

## 4.1.0 (2024-08-30)

- Exporting credit invoices via accounting strategies now have their own interface method
- Don't allow accounting export when the order totals changed, to prevent mismatch between accounting export and invoice
- Added Due Date to Xero exports, which is needed for invoice approval

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
