### PR TITLE
feat(picqer): added additional order line fields

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.0 (2024-10-08)
+
+- Allow specifying additional fields on order.products when pushing orders to Picqer
+
 # 3.3.1 (2024-09-26)
 
 - Find channel's default translation for products when sending to Picqer.

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -766,7 +766,7 @@ export class PicqerService implements OnApplicationBootstrap {
     const vatGroups = await picqerClient.getVatGroups();
     // Create or update each product of order
     const productInputs: OrderProductInput[] = [];
-    for (const line of order.lines) {
+    for (const [lineIndex, line] of order.lines.entries()) {
       const vatGroup = vatGroups.find(
         (vg) => vg.percentage === line.productVariant.taxRateApplied.value
       );
@@ -779,9 +779,15 @@ export class PicqerService implements OnApplicationBootstrap {
         line.productVariant.sku,
         this.mapToProductInput(ctx, line.productVariant, vatGroup.idvatgroup)
       );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const additionalOrderLineFields =
+        this.options.pushPicqerOrderLineFields?.(ctx, line, lineIndex, order) ||
+        {};
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       productInputs.push({
         idproduct: picqerProduct.idproduct,
         amount: line.quantity,
+        ...additionalOrderLineFields,
       });
     }
     let orderInput = this.mapToOrderInput(

--- a/packages/vendure-plugin-picqer/src/picqer.plugin.ts
+++ b/packages/vendure-plugin-picqer/src/picqer.plugin.ts
@@ -1,7 +1,9 @@
 import {
   Order,
+  OrderLine,
   PluginCommonModule,
   ProductVariant,
+  RequestContext,
   VendurePlugin,
 } from '@vendure/core';
 import { ProductData } from './api/types';
@@ -53,6 +55,19 @@ export interface PicqerOptions {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pushPicqerOrderFields?: (order: Order) => any;
+  /**
+   * Map any Vendure fields to Order.products fields in Picqer.
+   * See https://picqer.com/en/api/orders#attributes for available Picqer fields
+   * @example
+   * pushPicqerOrderLineFields: (orderLine) => {remarks: 'Please write "Happy birthday" on the box of this item'})
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pushPicqerOrderLineFields?: (
+    ctx: RequestContext,
+    orderLine: OrderLine,
+    lineIndex: number,
+    order: Order
+  ) => any;
   shouldSyncOnProductVariantCustomFields?: string[];
 }
 

--- a/packages/vendure-plugin-picqer/test/dev-server.ts
+++ b/packages/vendure-plugin-picqer/test/dev-server.ts
@@ -1,5 +1,4 @@
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
-import { AssetServerPlugin } from '@vendure/asset-server-plugin';
 import {
   configureDefaultOrderProcess,
   DefaultLogger,
@@ -9,20 +8,17 @@ import {
   OrderProcess,
 } from '@vendure/core';
 import {
-  SqljsInitializer,
   createTestEnvironment,
   registerInitializer,
+  SqljsInitializer,
 } from '@vendure/testing';
-import path from 'path';
-import { updateVariants, addShippingMethod } from '../../test/src/admin-utils';
-import { GlobalFlag } from '../../test/src/generated/admin-graphql';
+import { addShippingMethod } from '../../test/src/admin-utils';
 import { initialData } from '../../test/src/initial-data';
 import { createSettledOrder } from '../../test/src/shop-utils';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
-import { PicqerPlugin } from '../src';
-import { FULL_SYNC, UPSERT_CONFIG } from '../src/ui/queries';
-import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
 import { picqerHandler } from '../dist/vendure-plugin-picqer/src/api/picqer.handler';
+import { PicqerPlugin } from '../src';
+import { UPSERT_CONFIG } from '../src/ui/queries';
 
 (async () => {
   require('dotenv').config();
@@ -67,12 +63,17 @@ import { picqerHandler } from '../dist/vendure-plugin-picqer/src/api/picqer.hand
             id: '901892834',
           },
         }),
+        pushPicqerOrderLineFields: (ctx, orderLine, lineIndex, order) => ({
+          remarks: `Test note on line number ${lineIndex + 1} with id '${
+            orderLine.id
+          }' for order '${order.code}`,
+        }),
         shouldSyncOnProductVariantCustomFields: ['noLongerAvailable'],
       }),
-      AssetServerPlugin.init({
-        assetUploadDir: path.join(__dirname, '../__data__/assets'),
-        route: 'assets',
-      }),
+      // AssetServerPlugin.init({
+      //   assetUploadDir: path.join(__dirname, '../__data__/assets'),
+      //   route: 'assets',
+      // }),
       DefaultSearchPlugin,
       AdminUiPlugin.init({
         port: 3002,

--- a/packages/vendure-plugin-picqer/test/picqer.spec.ts
+++ b/packages/vendure-plugin-picqer/test/picqer.spec.ts
@@ -18,7 +18,15 @@ import {
 } from '@vendure/testing';
 import { TestServer } from '@vendure/testing/lib/test-server';
 import nock from 'nock';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
 import {
   addShippingMethod,
   getAllVariants,
@@ -69,6 +77,9 @@ beforeAll(async () => {
             carrier: 'dhl',
             id: '901892834',
           },
+        }),
+        pushPicqerOrderLineFields: (ctx, orderLine, lineIndex, order) => ({
+          remarks: `Test note on line number ${lineIndex} with id '${orderLine.id}' for order '${order.code}`,
         }),
         shouldSyncOnProductVariantCustomFields: ['height'],
       }),
@@ -268,6 +279,10 @@ describe('Order placement', function () {
       carrier: 'dhl',
       id: '901892834',
     });
+    expect(picqerOrderRequest.products[0].remarks).toContain(
+      'Test note on line number'
+    );
+    expect(picqerOrderRequest.products[0].remarks).not.toContain('undefined'); // Undefined in string means some argument was not passed
   });
 
   it('Should update to "Delivered" on incoming order status "completed"', async () => {


### PR DESCRIPTION
# Description

Allow specifying additional fiels on order.products in Picqer

# Screenshots

![image](https://github.com/user-attachments/assets/3f7d203f-381f-4ead-abdc-9c761e82fae1)


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
