### PR TITLE
fix(accept-blue): export AcceptBlueTransactionEvent from package

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.2 (2024-10-29)
+
+- Export `AcceptBlueTransactionEvent` from package
+
 # 1.7.1 (2024-09-18)
 
 - Don't throw error while resolving `PaymentMethodQuote.acceptBlueHostedTokenizationKey` if there is no `AcceptBlue` method (#452)

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/index.ts
+++ b/packages/vendure-plugin-accept-blue/src/index.ts
@@ -4,5 +4,6 @@ export * from '../../util/src/subscription/subscription-helper';
 export * from './accept-blue-plugin';
 export * from './api/accept-blue-service';
 export * from './api/accept-blue-client';
+export * from './api/accept-blue-transaction-event';
 export * from './api/accept-blue-handler';
 export * from './api/accept-blue-common-resolvers';


### PR DESCRIPTION
# Description

Fixes https://github.com/Pinelab-studio/pinelab-vendure-plugins/issues/522
AcceptBlueTransactionEvent now exported from package

# Breaking changes

None

# Checklist

📌 Always:
- [x] I have set a clear title
- [x ] My PR is small and contains a single feature
- [x ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [x ] I have updated the README if needed

📦 For publishable packages:
- [ x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
