### PR TITLE
feat(google-storage-assets): admin assetserver support for vendure v3

### DIFF
--- a/packages/vendure-plugin-google-storage-assets/CHANGELOG.md
+++ b/packages/vendure-plugin-google-storage-assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.2 (2024-10-31)
+
+- Use asset server for admin with Vendure V3 support
+
 # 1.2.1 (2024-08-04)
 
 - Update compatibility range (#480)

--- a/packages/vendure-plugin-google-storage-assets/package.json
+++ b/packages/vendure-plugin-google-storage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-storage-assets",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Vendure plugin for uploading assets to Google storage",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-google-storage-assets/src/google-storage-strategy.ts
+++ b/packages/vendure-plugin-google-storage-assets/src/google-storage-strategy.ts
@@ -29,10 +29,11 @@ export class GoogleStorageStrategy implements AssetStorageStrategy {
   }
 
   toAbsoluteUrl(request: Request | undefined, identifier: string): string {
-    if (
-      this.useAssetServerForAdminUi &&
-      (request as any)?.vendureRequestContext?._apiType === 'admin'
-    ) {
+    // Vendure v3 has an extra 'default' property before we can access the apiType
+    const apiType =
+      (request as any)?.vendureRequestContext?.default?._apiType ||
+      (request as any)?.vendureRequestContext?._apiType;
+    if (this.useAssetServerForAdminUi && apiType === 'admin') {
       // go via assetServer if admin
       return `${request!.protocol}://${request!.get(
         'host'
@@ -82,6 +83,7 @@ export class GoogleStorageStrategy implements AssetStorageStrategy {
       destination: fileName,
     });
     if (fileName.startsWith('preview/')) {
+      // For each preview, we also generate a thumbnail version
       await this.writeThumbnail(fileName, tmpFile.name);
     }
     return fileName;


### PR DESCRIPTION
# Description

The Google Storage strategy checks for apiType `admin` in the request context to decide if it should serve directly from CDN or via asset server. In Vendure v3 the structure of the request context changed a bit. This PR solves that, thus making the plugin v3 compatible

# Breaking changes

Nope, both V2 and V3 are supported now.


# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
