### PR TITLE
Feat/modify order active false (DO NOT MERGE)

### DIFF
--- a/packages/vendure-plugin-modify-customer-orders/CHANGELOG.md
+++ b/packages/vendure-plugin-modify-customer-orders/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2-beta (2024-11-12)
+
+- Ensure orders that transition from AddingItems to Draft also get de-activated
+
 # 1.3.1 (2024-08-04)
 
 - Update compatibility range (#480)

--- a/packages/vendure-plugin-modify-customer-orders/package.json
+++ b/packages/vendure-plugin-modify-customer-orders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-modify-customer-orders",
-  "version": "1.3.1",
+  "version": "1.3.2-beta",
   "description": "Vendure plugin for converting Active orders to Draft",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-modify-customer-orders/src/api/order-transition-listener.service.ts
+++ b/packages/vendure-plugin-modify-customer-orders/src/api/order-transition-listener.service.ts
@@ -54,6 +54,27 @@ export class OrderTransitionListenerService implements OnApplicationBootstrap {
           })
         );
     }
+
+    if (this.processContext.isServer) {
+      Logger.info(
+        'Listening for convert to Draft transition, to set orders active to false',
+        loggerCtx
+      );
+      this.eventBus
+        .ofType(OrderStateTransitionEvent)
+        .pipe(
+          filter((event) => event.toState === 'Draft' && event.order.active)
+        )
+        .subscribe(({ ctx, order: draftOrder }) =>
+          this.deactivateOrder(ctx, draftOrder).catch((e: any) => {
+            Logger.error(
+              `Error setting draft order ${draftOrder.code} to active`,
+              loggerCtx,
+              e?.stack
+            );
+          })
+        );
+    }
   }
 
   async assignOrderToCustomer(

--- a/packages/vendure-plugin-modify-customer-orders/test/modify-customer-orders.spec.ts
+++ b/packages/vendure-plugin-modify-customer-orders/test/modify-customer-orders.spec.ts
@@ -7,6 +7,7 @@ import {
   testConfig,
 } from '@vendure/testing';
 import { addItem, createSettledOrder } from '../../test/src/shop-utils';
+import { getOrder } from '../../test/src/admin-utils';
 import { TestServer } from '@vendure/testing/lib/test-server';
 import { initialData } from '../../test/src/initial-data';
 import { testPaymentMethod } from '../../test/src/test-payment-method';
@@ -94,6 +95,21 @@ describe('Customer managed groups', function () {
         'Only active orders can be changed to a draft order'
       );
     }
+  });
+
+  it('Should de-activate transitioned Draft order', async () => {
+    await shopClient.asUserWithCredentials(
+      'hayden.zieme12@hotmail.com',
+      'test'
+    );
+    const testActiveOrder = await addItem(shopClient, 'T_1', 1);
+    await adminClient.query(convertToDraftMutation, {
+      id: testActiveOrder.id,
+    });
+    const updatedOrder = await getOrder(adminClient, `${testActiveOrder.id}`);
+    expect(updatedOrder).not.toBeFalsy();
+    expect(updatedOrder!.state).toBe('Draft');
+    expect(updatedOrder!.active).toBe(false);
   });
 
   if (process.env.TEST_ADMIN_UI) {


### PR DESCRIPTION
# Description

This change is trying to force the active state to false. However, I added a test and it is failing. There is event driven change that happens after the order is set to `active: false` that sets it back to `active: true` wasn't able to figure out why.

# Deploy

This needs to happen to deploy this feature, for example:

- [ ] Ensure active gets set to false
- [ ] Make test pass
- [ ] Merge PR

# Breaking changes

No. 

# Checklist

📌 Always:
- [ x] I have set a clear title
- [ x] My PR is small and contains a single feature
- [ x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [x ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
