### PR TITLE
feat(picqer): allow not falling back to product image

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.4.2 (2024-11-13)
 
-- Making falling back to parent product featured asset configurable, so that only images of variants are synced to Picqer.
+- Make falling back to parent product featured asset configurable, so that only images of variants are synced to Picqer.
 
 # 3.4.1 (2024-10-08)
 

--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.2 (2024-11-13)
+
+- Making falling back to parent product featured asset configurable, so that only images of variants are synced to Picqer.
+
 # 3.4.1 (2024-10-08)
 
 - Removed unused order line index in `pushPicqerOrderLineFields` strategy

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -1006,7 +1006,7 @@ export class PicqerService implements OnApplicationBootstrap {
     variant: ProductVariant
   ): Promise<string | undefined> {
     let asset = await this.assetService.getFeaturedAsset(ctx, variant);
-    if (!asset?.preview) {
+    if (!asset?.preview && this.options.fallBackToProductFeaturedAsset) {
       // No featured asset on variant, try the parent product
       await this.entityHydrator.hydrate(ctx, variant, {
         relations: ['product'],

--- a/packages/vendure-plugin-picqer/src/picqer.plugin.ts
+++ b/packages/vendure-plugin-picqer/src/picqer.plugin.ts
@@ -67,7 +67,15 @@ export interface PicqerOptions {
     order: Order
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => any;
+  /**
+   * Define wether to trigger a sync when one of these custom fields is updated on a ProductVariant
+   */
   shouldSyncOnProductVariantCustomFields?: string[];
+  /**
+   * Define wether to fall back to a variant's product, when the variant does not have a featured asset.
+   * Default is `true`
+   */
+  fallBackToProductFeaturedAsset?: boolean;
 }
 
 @VendurePlugin({
@@ -101,11 +109,10 @@ export class PicqerPlugin {
   static options: PicqerOptions;
 
   static init(options: PicqerOptions) {
-    if (options.enabled !== false) {
-      // Only disable if explicitly set to false
-      options.enabled = true;
-    }
-    this.options = options;
+    this.options = {
+      fallBackToProductFeaturedAsset: true,
+      ...options,
+    };
     return PicqerPlugin;
   }
 


### PR DESCRIPTION
# Description

- make falling back to parent product featured asset configurable, so that only images of variants are synced to Picqer.

# Deploy

This needs to happen to deploy this feature, for example:

- [ ] Merge PR
- [ ] Wait until version is published
- [ ] Install 3.4.2 in consumer project

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [x] I have updated the README if needed

📦 For publishable packages:
- [x] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [x] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
