### PR TITLE
fix(accept-blue): divide recurring amounts by 100

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.9.1 (2024-12-04)
+
+- Recurring amounts divided by 100
+
 # 1.9.0 (2024-11-21)
 
 - Round up `nrOfBillingCyclesLeft`, to prevent unwanted never-ending subscriptions. See #532

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
@@ -187,6 +187,7 @@ export class AcceptBlueClient {
       `customers/${customerId}/recurring-schedules`,
       {
         ...input,
+        amount: input.amount / 100,
         // Accept Blue requires dates to be in 'yyyy-mm-dd' format
         next_run_date: input.next_run_date
           ? this.toDateString(input.next_run_date)


### PR DESCRIPTION
# Description

Accept Blue expects amounts in fractions. The plugin sends amounts in cents for subscription amounts leading to multiplication by 100 of recurring values

# Checklist

📌 Always:
- [ x] Set a clear title
- [ x] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ x] Increased the version number in `package.json`
- [ x] Added changes to the `CHANGELOG.md`
