### PR TITLE
fix(metrics): font color fix for dark mode in metrics

### DIFF
--- a/packages/vendure-plugin-metrics/CHANGELOG.md
+++ b/packages/vendure-plugin-metrics/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.1 (2024-12-18)
+
+- Fixed chart text color to display correctly in dark mode.
+
 # 1.6.0 (2024-11-19)
 
 - Allow showing metrics of past X months instead of always past 12 months.

--- a/packages/vendure-plugin-metrics/package.json
+++ b/packages/vendure-plugin-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-metrics",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Vendure plugin measuring and visualizing e-commerce metrics",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-metrics/src/ui/chartist/chartist.component.scss
+++ b/packages/vendure-plugin-metrics/src/ui/chartist/chartist.component.scss
@@ -31,6 +31,10 @@
     transform-origin: 100% 0;
     transform: translate(-100%) rotate(-45deg);
     white-space: nowrap;
+    color: var(--clr-label-info-font-color);
+  }
+  .ct-label.ct-vertical.ct-start {
+    color: var(--clr-label-info-font-color);
   }
   .ct-series-a .ct-slice-pie,
   .ct-series-a .ct-area {


### PR DESCRIPTION
Description
- fixed the font color for metrics plugin when in dark mode

![Screenshot from 2024-12-12 14-39-56](https://github.com/user-attachments/assets/2d7c977c-f844-44d8-81fd-f65d561f3ad3)
