### PR TITLE
feat(facet-suggestions): admin ui fix

### DIFF
--- a/packages/vendure-plugin-facet-suggestions/CHANGELOG.md
+++ b/packages/vendure-plugin-facet-suggestions/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.2 (2024-12-20)
+
+- Fix to correctly save assets with Vendure V3.1
+
 # 1.1.1 (2024-08-04)
 
 - Update compatibility range (#480)

--- a/packages/vendure-plugin-facet-suggestions/package.json
+++ b/packages/vendure-plugin-facet-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-facet-suggestions",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A vendure plugin that allows you to define suggested facets for all products, or suggested facets based on other facets.",
   "author": "Surafel Tariku <surafelmelese09@gmail.com>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-facet-suggestions/src/ui/suggested-facets-component/suggested-facets.component.ts
+++ b/packages/vendure-plugin-facet-suggestions/src/ui/suggested-facets-component/suggested-facets.component.ts
@@ -90,18 +90,19 @@ export class SuggestedFacetsComponent implements CustomDetailComponent, OnInit {
       facetValueIds: unique([...currentFacetValueIds, facetValue.id]),
     });
     productGroup.markAsDirty();
+    productGroup.controls.facetValueIds.markAsDirty();
   }
 
   removeFacetValue(facetValue: FacetValue) {
     const productGroup = this.getProductFormGroup();
     const currentFacetValueIds: string[] = productGroup.value.facetValueIds;
-    console.log('productGroup', facetValue);
     productGroup.patchValue({
       facetValueIds: unique([
         ...currentFacetValueIds.filter((id) => id !== facetValue.id),
       ]),
     });
     productGroup.markAsDirty();
+    productGroup.controls.facetValueIds.markAsDirty();
   }
 
   private getProductFormGroup(): FormGroup {


### PR DESCRIPTION
# Description

In Vendure 3.1.1 we also need `productGroup.controls.facetValueIds.markAsDirty();` next to the already existing `productGroup.markAsDirty();`

Fixes #552 

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
