### PR TITLE
feat(picqer): allow disabling cancellation of Vendure orders

### DIFF
--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -373,7 +373,11 @@ export class PicqerService implements OnApplicationBootstrap {
       );
       return;
     }
-    if (data.status === 'cancelled' && order.state !== 'Cancelled') {
+    if (
+      data.status === 'cancelled' &&
+      order.state !== 'Cancelled' &&
+      this.options.cancelOrdersOnPicqerCancellation
+    ) {
       const result = await this.orderService.cancelOrder(ctx, {
         orderId: order.id,
         reason: 'Cancelled in Picqer',

--- a/packages/vendure-plugin-picqer/src/picqer.plugin.ts
+++ b/packages/vendure-plugin-picqer/src/picqer.plugin.ts
@@ -76,6 +76,13 @@ export interface PicqerOptions {
    * Default is `true`
    */
   fallBackToProductFeaturedAsset?: boolean;
+  /**
+   * Define wether to cancel orders in Vendure when they are cancelled in Picqer.
+   * Default is `true`
+   *
+   * When, for example, orders in Picqer are cancelled solely because they need to be edited, you might want to disable this feature.
+   */
+  cancelOrdersOnPicqerCancellation?: boolean;
 }
 
 @VendurePlugin({
@@ -111,6 +118,7 @@ export class PicqerPlugin {
   static init(options: PicqerOptions) {
     this.options = {
       fallBackToProductFeaturedAsset: true,
+      cancelOrdersOnPicqerCancellation: true,
       ...options,
     };
     return PicqerPlugin;


### PR DESCRIPTION
# Description

# 3.6.0 (2025-01-08)

- Allow configuring the plugin to not cancel Vendure orders when a Picqer order is cancelled

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
