### PR TITLE
feat(accept-blue): add ctx for event, log order history entry

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1 (2025-01-09)
+
+- Add ctx to AcceptBlueTransactionEvent
+
 # 2.0.0 (2024-12-19)
 
 - Update Vendure to 3.1.1

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
@@ -11,7 +11,6 @@ import {
   ID,
   Logger,
   Order,
-  OrderHistoryEntryData,
   OrderLine,
   PaymentMethod,
   PaymentMethodEvent,
@@ -30,7 +29,6 @@ import { SubscriptionHelper } from '../';
 import { AcceptBluePluginOptions } from '../accept-blue-plugin';
 import { PLUGIN_INIT_OPTIONS, loggerCtx } from '../constants';
 import {
-  ACCEPT_BLUE_TRANSACTION_UPDATE,
   AcceptBlueChargeTransaction,
   AcceptBlueEvent,
   AcceptBluePaymentMethod,
@@ -529,14 +527,6 @@ export class AcceptBlueService implements OnApplicationBootstrap {
           event.data.transaction?.id
         )
       );
-      await this.logHistoryEntry(
-        ctx,
-        orderLine.order.id,
-        event.data.transaction?.id ? `${event.data.transaction?.id}` : '',
-        event.data,
-        orderLine,
-        event.data.error_message
-      );
       Logger.debug(
         `Published AcceptBlueTransactionEvent (${event.id}) for orderLine ${orderLine.id}`,
         loggerCtx
@@ -567,33 +557,6 @@ export class AcceptBlueService implements OnApplicationBootstrap {
     // With LIKE, we can get false positives, so we check again if the parsed result contains the exact scheduleId
     return result.find((orderLine) =>
       orderLine.customFields.acceptBlueSubscriptionIds.includes(scheduleId)
-    );
-  }
-
-  async logHistoryEntry(
-    ctx: RequestContext,
-    orderId: ID,
-    transactionId: string,
-    rawData: AcceptBlueChargeTransaction,
-    orderLine?: OrderLine,
-    error?: unknown
-  ): Promise<void> {
-    const prettifiedError =
-      typeof error === 'string' ? error : (error as Error)?.message;
-    await this.historyService.createHistoryEntryForOrder(
-      {
-        ctx,
-        orderId,
-        type: ACCEPT_BLUE_TRANSACTION_UPDATE,
-        data: {
-          type: rawData.status,
-          transactionId,
-          rawData: JSON.stringify(rawData),
-          orderLineId: orderLine?.id ? `${orderLine.id}` : undefined,
-          error: prettifiedError,
-        },
-      },
-      false
     );
   }
 

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
@@ -7,7 +7,6 @@ import {
   EntityHydrator,
   EventBus,
   ForbiddenError,
-  HistoryService,
   ID,
   Logger,
   Order,
@@ -63,7 +62,6 @@ export class AcceptBlueService implements OnApplicationBootstrap {
     private readonly customerService: CustomerService,
     private readonly entityHydrator: EntityHydrator,
     private connection: TransactionalConnection,
-    private historyService: HistoryService,
     private eventBus: EventBus,
     moduleRef: ModuleRef,
     @Inject(PLUGIN_INIT_OPTIONS)

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-transaction-event.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-transaction-event.ts
@@ -1,4 +1,4 @@
-import { OrderLine, VendureEvent } from '@vendure/core';
+import { OrderLine, RequestContext, VendureEvent } from '@vendure/core';
 import { AcceptBlueEvent } from '../types';
 
 /**
@@ -6,6 +6,7 @@ import { AcceptBlueEvent } from '../types';
  */
 export class AcceptBlueTransactionEvent extends VendureEvent {
   constructor(
+    ctx: RequestContext,
     public status: 'succeeded' | 'updated' | 'declined' | 'error' | 'status',
     /**
      * The entire data object received from Accept Blue webhook

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -118,6 +118,10 @@ export const commonApiExtensions = gql`
     savedAcceptBluePaymentMethods: [AcceptBluePaymentMethod!]!
   }
 
+  extend enum HistoryEntryType {
+    ACCEPT_BLUE_TRANSACTION_UPDATE
+  }
+
   extend type Query {
     previewAcceptBlueSubscriptions(
       productVariantId: ID!

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -118,10 +118,6 @@ export const commonApiExtensions = gql`
     savedAcceptBluePaymentMethods: [AcceptBluePaymentMethod!]!
   }
 
-  extend enum HistoryEntryType {
-    ACCEPT_BLUE_TRANSACTION_UPDATE
-  }
-
   extend type Query {
     previewAcceptBlueSubscriptions(
       productVariantId: ID!

--- a/packages/vendure-plugin-accept-blue/src/types.ts
+++ b/packages/vendure-plugin-accept-blue/src/types.ts
@@ -1,20 +1,6 @@
 import { RequestContext } from '@vendure/core';
 import type { Request } from 'express';
 
-export const ACCEPT_BLUE_TRANSACTION_UPDATE = 'ACCEPT_BLUE_TRANSACTION_UPDATE';
-
-declare module '@vendure/core' {
-  interface OrderHistoryEntryData {
-    [ACCEPT_BLUE_TRANSACTION_UPDATE]: {
-      type: 'Approved' | 'Partially Approved' | 'Declined' | 'Error' | 'Update';
-      transactionId: string;
-      rawData: string;
-      orderLineId?: string;
-      error?: string;
-    };
-  }
-}
-
 export interface CustomFields {
   custom1?: string;
 }

--- a/packages/vendure-plugin-accept-blue/src/types.ts
+++ b/packages/vendure-plugin-accept-blue/src/types.ts
@@ -1,4 +1,20 @@
+import { RequestContext } from '@vendure/core';
 import type { Request } from 'express';
+
+export const ACCEPT_BLUE_TRANSACTION_UPDATE = 'ACCEPT_BLUE_TRANSACTION_UPDATE';
+
+declare module '@vendure/core' {
+  interface OrderHistoryEntryData {
+    [ACCEPT_BLUE_TRANSACTION_UPDATE]: {
+      type: 'Approved' | 'Partially Approved' | 'Declined' | 'Error' | 'Update';
+      transactionId: string;
+      rawData: string;
+      orderLineId?: string;
+      error?: string;
+    };
+  }
+}
+
 export interface CustomFields {
   custom1?: string;
 }
@@ -348,6 +364,7 @@ export interface AcceptBlueChargeTransaction extends AcceptBlueTransaction {
 }
 
 export interface AcceptBlueEvent {
+  ctx: RequestContext;
   type: 'succeeded' | 'updated' | 'declined' | 'error' | 'status';
   subType: string;
   event: 'transaction' | 'batch';


### PR DESCRIPTION
# Description

We want to better understand what happened if a payment doesn't go through for some reason and be able to view the history of this. Therefore, I added a logHistoryEntry for accept blue
Also, I added ctx to the event. This would allow us to capture the event and affect channel specific processing.

# To do before merge

I didn't write tests for this (yet). Please have a look and see if you think we can proceed with this change and I can write a test

No update has been done yet to README or version

# Breaking changes


# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ x] Set a clear title
- [x ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
