### PR TITLE
feat(accept-blue): implementing eligible methods and surcharges

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0 (2025-02-06)
+
+- Allow disabling certain payment methods, e.g. Disable 'visa' or 'check'
+- Expose surcharges used by Accept Blue
+
 # 2.2.0 (2025-01-14)
 
 - Update a customer's shipping and billing details in Accept Blue on subscription creation

--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.3.0 (2025-02-06)
 
-- Allow disabling certain payment methods, e.g. Disable 'visa' or 'check'
-- Expose surcharges used by Accept Blue
+- Allow disabling certain payment methods, e.g. 'visa' or 'check', via the Vendure Admin UI
+- Expose surcharges used by Accept Blue via GraphQL query
 
 # 2.2.0 (2025-01-14)
 

--- a/packages/vendure-plugin-accept-blue/README.md
+++ b/packages/vendure-plugin-accept-blue/README.md
@@ -33,6 +33,8 @@ Create recurring subscriptions with the Accept Blue platform.
 
 These are the different payment methods you can use to pay for an order. Keep in mind that these examples use sample input data.
 
+You can use the query `eligibleAcceptBluePaymentMethods` to check what payment methods and card types are enabled. This is configured in Vendure: your Accept Blue API Key should have all methods enabled for this to work.
+
 ### Pay with Saved Payment Method
 
 If a customer already has a payment method saved in Accept Blue, you can use that to pay for an order.
@@ -201,6 +203,10 @@ mutation {
 ```
 
 This wil emit an `AcceptBlueSubscriptionEvent` of type `updated`.
+
+## Accept Blue Surcharges
+
+You can use the query `acceptBlueSurcharge` to see what surcharges your account has configured.
 
 ## CORS
 

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.spec.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.spec.ts
@@ -1,0 +1,78 @@
+import { it, expect } from 'vitest';
+import { AcceptBlueClient } from './accept-blue-client';
+import { AcceptBluePaymentMethodType } from './generated/graphql';
+
+const API_KEY = 'test-api-key';
+const PIN = 'test-pin';
+it('should enable all payment methods when all are allowed', () => {
+  const client = new AcceptBlueClient(API_KEY, PIN, {
+    allowECheck: true,
+    allowVisa: true,
+    allowMasterCard: true,
+    allowAmericanExpress: true,
+    allowDiscover: true,
+  });
+
+  const expected: AcceptBluePaymentMethodType[] = [
+    'ECheck',
+    'Visa',
+    'MasterCard',
+    'Amex',
+    'Discover',
+  ];
+  expect(client.enabledPaymentMethods).toEqual(
+    expect.arrayContaining(expected)
+  );
+  expect(client.enabledPaymentMethods.length).toBe(5);
+});
+
+it('should only enable specified payment methods', () => {
+  const client = new AcceptBlueClient(API_KEY, PIN, {
+    allowECheck: true,
+    allowVisa: true,
+    allowMasterCard: false,
+    allowAmericanExpress: false,
+    allowDiscover: false,
+  });
+
+  expect(client.enabledPaymentMethods).toEqual(['ECheck', 'Visa']);
+  expect(client.enabledPaymentMethods.length).toBe(2);
+});
+
+it('should enable no payment methods when none are allowed', () => {
+  const client = new AcceptBlueClient(API_KEY, PIN, {
+    allowECheck: false,
+    allowVisa: false,
+    allowMasterCard: false,
+    allowAmericanExpress: false,
+    allowDiscover: false,
+  });
+
+  expect(client.enabledPaymentMethods).toEqual([]);
+});
+
+it('should use test endpoint when testMode is true', () => {
+  const client = new AcceptBlueClient(
+    API_KEY,
+    PIN,
+    {
+      allowECheck: true,
+    },
+    true
+  );
+
+  expect(client.endpoint).toBe('https://api.develop.accept.blue/api/v2/');
+});
+
+it('should use production endpoint when testMode is false', () => {
+  const client = new AcceptBlueClient(
+    API_KEY,
+    PIN,
+    {
+      allowECheck: true,
+    },
+    false
+  );
+
+  expect(client.endpoint).toBe('https://api.accept.blue/api/v2/');
+});

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.spec.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.spec.ts
@@ -34,7 +34,6 @@ it('should only enable specified payment methods', () => {
     allowAmericanExpress: false,
     allowDiscover: false,
   });
-
   expect(client.enabledPaymentMethods).toEqual(['ECheck', 'Visa']);
   expect(client.enabledPaymentMethods.length).toBe(2);
 });
@@ -47,7 +46,6 @@ it('should enable no payment methods when none are allowed', () => {
     allowAmericanExpress: false,
     allowDiscover: false,
   });
-
   expect(client.enabledPaymentMethods).toEqual([]);
 });
 
@@ -60,7 +58,6 @@ it('should use test endpoint when testMode is true', () => {
     },
     true
   );
-
   expect(client.endpoint).toBe('https://api.develop.accept.blue/api/v2/');
 });
 
@@ -73,6 +70,5 @@ it('should use production endpoint when testMode is false', () => {
     },
     false
   );
-
   expect(client.endpoint).toBe('https://api.accept.blue/api/v2/');
 });

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
@@ -21,7 +21,10 @@ import {
   NoncePaymentMethodInput,
 } from '../types';
 import { isSameCard, isSameCheck } from '../util';
-import { AcceptBluePaymentMethodType } from './generated/graphql';
+import {
+  AcceptBluePaymentMethodType,
+  AcceptBlueSurcharges,
+} from './generated/graphql';
 
 export class AcceptBlueClient {
   readonly endpoint: string;
@@ -387,6 +390,14 @@ export class AcceptBlueClient {
       );
     }
     return result;
+  }
+
+  /**
+   * Get Surcharge settings from Accept Blue for all payment methods
+   */
+  async getSurcharges(): Promise<AcceptBlueSurcharges> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return await this.request('get', `surcharge`);
   }
 
   async createWebhook(

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance } from 'axios';
 import util from 'util';
 import { loggerCtx } from '../constants';
 import {
+  AcceptBlueCardPaymentMethod,
   AcceptBlueChargeTransaction,
   AcceptBlueCustomer,
   AcceptBlueCustomerInput,
@@ -16,17 +17,21 @@ import {
   AcceptBlueWebhookInput,
   CheckPaymentMethodInput,
   CustomFields,
+  EnabledPaymentMethodsArgs,
   NoncePaymentMethodInput,
 } from '../types';
 import { isSameCard, isSameCheck } from '../util';
+import { AcceptBluePaymentMethodType } from './generated/graphql';
 
 export class AcceptBlueClient {
   readonly endpoint: string;
   readonly instance: AxiosInstance;
+  public readonly enabledPaymentMethods: AcceptBluePaymentMethodType[];
 
   constructor(
     public readonly apiKey: string,
     public readonly pin: string = '',
+    enabledPaymentMethodArgs: EnabledPaymentMethodsArgs,
     public readonly testMode?: boolean
   ) {
     if (this.testMode) {
@@ -47,6 +52,38 @@ export class AcceptBlueClient {
       },
       validateStatus: () => true,
     });
+    // Determine enabled methods
+    const enabledPaymentMethods: AcceptBluePaymentMethodType[] = [];
+    if (enabledPaymentMethodArgs.allowECheck) {
+      enabledPaymentMethods.push('ECheck');
+    }
+    if (enabledPaymentMethodArgs.allowVisa) {
+      enabledPaymentMethods.push('Visa');
+    }
+    if (enabledPaymentMethodArgs.allowMasterCard) {
+      enabledPaymentMethods.push('MasterCard');
+    }
+    if (enabledPaymentMethodArgs.allowAmericanExpress) {
+      enabledPaymentMethods.push('Amex');
+    }
+    if (enabledPaymentMethodArgs.allowDiscover) {
+      enabledPaymentMethods.push('Discover');
+    }
+    this.enabledPaymentMethods = enabledPaymentMethods;
+  }
+
+  isPaymentMethodAllowed(pm: AcceptBluePaymentMethod): boolean {
+    if (
+      pm.payment_method_type === 'check' &&
+      this.enabledPaymentMethods.includes('ECheck')
+    ) {
+      return true;
+    }
+    const cardType = (pm as AcceptBlueCardPaymentMethod).card_type;
+    if (this.enabledPaymentMethods.includes(cardType)) {
+      return true;
+    }
+    return false;
   }
 
   async getTransaction(id: number): Promise<AcceptBlueChargeTransaction> {
@@ -129,6 +166,10 @@ export class AcceptBlueClient {
     return result;
   }
 
+  /**
+   * Checks if a payment method with the same details already exists.
+   * Or, create new if doesn't exist yet.
+   */
   async getOrCreatePaymentMethod(
     acceptBlueCustomerId: number,
     input: NoncePaymentMethodInput | CheckPaymentMethodInput
@@ -209,6 +250,21 @@ export class AcceptBlueClient {
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return result;
+  }
+
+  async getPaymentMethod(
+    acceptBlueCustomerId: number,
+    paymentMethodId: number
+  ): Promise<AcceptBluePaymentMethod | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const result = await this.request(
+      'get',
+      `payment-methods/${paymentMethodId}`
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (result.customer_id == acceptBlueCustomerId) {
+      return result as AcceptBluePaymentMethod;
+    }
   }
 
   async createPaymentMethod(

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -15,6 +15,7 @@ import { AcceptBlueService } from './accept-blue-service';
 import {
   AcceptBluePaymentMethodQuote,
   AcceptBlueSubscription,
+  AcceptBlueSurcharges,
   Query as GraphqlQuery,
   QueryPreviewAcceptBlueSubscriptionsArgs,
   QueryPreviewAcceptBlueSubscriptionsForProductArgs,
@@ -114,5 +115,12 @@ export class AcceptBlueCommonResolver {
     @Ctx() ctx: RequestContext
   ): Promise<AcceptBluePaymentMethodQuote[]> {
     return this.acceptBlueService.getEligiblePaymentMethods(ctx);
+  }
+
+  @Query()
+  async acceptBlueSurcharges(
+    @Ctx() ctx: RequestContext
+  ): Promise<AcceptBlueSurcharges> {
+    return await this.acceptBlueService.getSurcharges(ctx);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -13,6 +13,7 @@ import {
 } from '../types';
 import { AcceptBlueService } from './accept-blue-service';
 import {
+  AcceptBluePaymentMethodQuote,
   AcceptBlueSubscription,
   Query as GraphqlQuery,
   QueryPreviewAcceptBlueSubscriptionsArgs,
@@ -106,5 +107,12 @@ export class AcceptBlueCommonResolver {
     return value.payment_method_type === 'card'
       ? 'AcceptBlueCardPaymentMethod'
       : 'AcceptBlueCheckPaymentMethod';
+  }
+
+  @Query()
+  async eligibleAcceptBluePaymentMethods(
+    @Ctx() ctx: RequestContext
+  ): Promise<AcceptBluePaymentMethodQuote[]> {
+    return this.acceptBlueService.getEligiblePaymentMethods(ctx);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-handler.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-handler.ts
@@ -43,18 +43,48 @@ export const acceptBluePaymentHandler = new PaymentMethodHandler({
       label: [{ languageCode: LanguageCode.en, value: 'API key' }],
       ui: { component: 'password-form-input' },
     },
+    pin: {
+      type: 'string',
+      required: false,
+      label: [{ languageCode: LanguageCode.en, value: 'PIN' }],
+      ui: { component: 'password-form-input' },
+    },
+    allowVisa: {
+      type: 'boolean',
+      required: false,
+      defaultValue: true,
+      label: [{ languageCode: LanguageCode.en, value: 'Visa' }],
+    },
+    allowMasterCard: {
+      type: 'boolean',
+      required: false,
+      defaultValue: true,
+      label: [{ languageCode: LanguageCode.en, value: 'Master Card' }],
+    },
+    allowAmericanExpress: {
+      type: 'boolean',
+      required: false,
+      defaultValue: true,
+      label: [{ languageCode: LanguageCode.en, value: 'American Express' }],
+    },
+    allowDiscover: {
+      type: 'boolean',
+      required: false,
+      defaultValue: true,
+      label: [{ languageCode: LanguageCode.en, value: 'Discover' }],
+    },
+    allowECheck: {
+      type: 'boolean',
+      required: false,
+      defaultValue: true,
+      label: [{ languageCode: LanguageCode.en, value: 'E-check' }],
+    },
     tokenizationSourceKey: {
       type: 'string',
       required: false,
       label: [
         { languageCode: LanguageCode.en, value: 'Hosted tokenization key' },
       ],
-    },
-    pin: {
-      type: 'string',
-      required: false,
-      label: [{ languageCode: LanguageCode.en, value: 'PIN' }],
-      ui: { component: 'password-form-input' },
     },
     webhookSecret: {
       type: 'string',
@@ -106,7 +136,12 @@ export const acceptBluePaymentHandler = new PaymentMethodHandler({
       | CheckPaymentMethodInput
       | NoncePaymentMethodInput
       | SavedPaymentMethodInput;
-    const client = new AcceptBlueClient(args.apiKey, args.pin, args.testMode);
+    const client = new AcceptBlueClient(
+      args.apiKey,
+      args.pin,
+      args,
+      args.testMode
+    );
     try {
       const result = await service.handlePaymentForOrder(
         ctx,

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
@@ -57,6 +57,7 @@ import {
   AcceptBluePaymentMethodQuote,
   AcceptBlueRefundResult,
   AcceptBlueSubscription,
+  AcceptBlueSurcharges,
   AcceptBlueTransaction,
   UpdateAcceptBlueSubscriptionInput,
 } from './generated/graphql';
@@ -199,11 +200,13 @@ export class AcceptBlueService implements OnApplicationBootstrap {
         input as NoncePaymentMethodInput | CheckPaymentMethodInput
       );
     }
-    if (client.isPaymentMethodAllowed(paymentMethod)) {
+    if (!client.isPaymentMethodAllowed(paymentMethod)) {
       throw new UserInputError(
         `Payment method ${paymentMethod.payment_method_type} ${
           (paymentMethod as AcceptBlueCardPaymentMethod).card_type ?? ''
-        } is not allowed`
+        } is not allowed. Allowed methods: ${client.enabledPaymentMethods.join(
+          ', '
+        )}`
       );
     }
     const recurringSchedules = await this.createRecurringSchedule(
@@ -470,6 +473,11 @@ export class AcceptBlueService implements OnApplicationBootstrap {
       errorMessage: refundResult.error_message,
       errorDetails,
     };
+  }
+
+  async getSurcharges(ctx: RequestContext): Promise<AcceptBlueSurcharges> {
+    const client = await this.getClientForChannel(ctx);
+    return await client.getSurcharges();
   }
 
   async getClientForChannel(ctx: RequestContext): Promise<AcceptBlueClient> {

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -149,6 +149,26 @@ const commonApiExtensions = gql`
     receiptEmail: String
   }
 
+  enum AcceptBluePaymentMethodType {
+    Visa
+    MasterCard
+    Discover
+    Amex
+    ECheck
+  }
+
+  type AcceptBlueSurcharge {
+    type: String!
+    value: Float!
+  }
+
+  """
+  Used to display eligible payment methods
+  """
+  type AcceptBluePaymentMethodQuote {
+    name: AcceptBluePaymentMethodType!
+  }
+
   extend type Query {
     previewAcceptBlueSubscriptions(
       productVariantId: ID!
@@ -158,6 +178,8 @@ const commonApiExtensions = gql`
       productId: ID!
       customInputs: JSON
     ): [AcceptBlueSubscription!]!
+    eligibleAcceptBluePaymentMethods: [AcceptBluePaymentMethodQuote!]!
+    acceptBlueSurcharges: [AcceptBlueSurcharge!]!
   }
 `;
 

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -157,9 +157,14 @@ const commonApiExtensions = gql`
     ECheck
   }
 
-  type AcceptBlueSurcharge {
+  type AcceptBlueSurchargeValue {
     type: String!
     value: Float!
+  }
+
+  type AcceptBlueSurcharges {
+    check: AcceptBlueSurchargeValue!
+    card: AcceptBlueSurchargeValue!
   }
 
   """
@@ -179,7 +184,7 @@ const commonApiExtensions = gql`
       customInputs: JSON
     ): [AcceptBlueSubscription!]!
     eligibleAcceptBluePaymentMethods: [AcceptBluePaymentMethodQuote!]!
-    acceptBlueSurcharges: [AcceptBlueSurcharge!]!
+    acceptBlueSurcharges: AcceptBlueSurcharges!
   }
 `;
 

--- a/packages/vendure-plugin-accept-blue/src/types.ts
+++ b/packages/vendure-plugin-accept-blue/src/types.ts
@@ -137,8 +137,7 @@ export interface AcceptBlueCustomer {
 }
 
 /** +++++ Payment +++++ */
-
-type CardType = 'Visa' | 'MasterCard' | 'Discover' | 'Amex' | 'JCB' | 'Diners';
+type CardType = 'Visa' | 'MasterCard' | 'Discover' | 'Amex';
 export type AccountType = 'Checking' | 'Savings';
 export type SecCode = 'PPD' | 'CCD' | 'TEL' | 'WEB';
 
@@ -155,7 +154,7 @@ export interface AcceptBlueCardPaymentMethod {
   avs_zip: string;
   expiry_month: number;
   expiry_year: number;
-  card_type: string;
+  card_type: CardType;
 }
 
 export interface AcceptBlueCheckPaymentMethod {
@@ -442,4 +441,12 @@ export interface AcceptBlueWebhook {
 
 export interface RequestWithRawBody extends Request {
   rawBody: Buffer;
+}
+
+export interface EnabledPaymentMethodsArgs {
+  allowVisa?: boolean;
+  allowMasterCard?: boolean;
+  allowAmericanExpress?: boolean;
+  allowDiscover?: boolean;
+  allowECheck?: boolean;
 }

--- a/packages/vendure-plugin-accept-blue/test/accept-blue.spec.ts
+++ b/packages/vendure-plugin-accept-blue/test/accept-blue.spec.ts
@@ -43,6 +43,7 @@ import {
   GET_CUSTOMER_WITH_ID,
   GET_HISTORY_ENTRIES,
   GET_ORDER_BY_CODE,
+  GET_SURCHARGES,
   GET_USER_SAVED_PAYMENT_METHOD,
   PREVIEW_SUBSCRIPTIONS_FOR_PRODUCT,
   PREVIEW_SUBSCRIPTIONS_FOR_VARIANT,
@@ -182,6 +183,30 @@ describe('Shop API', () => {
     ]);
   });
 
+  it('Returns surcharge configuration', async () => {
+    nockInstance.get('/surcharge').reply(200, {
+      card: {
+        type: 'currency',
+        value: 0,
+      },
+      check: {
+        type: 'currency',
+        value: 0,
+      },
+    });
+    const { acceptBlueSurcharges } = await shopClient.query(GET_SURCHARGES);
+    expect(acceptBlueSurcharges).toEqual({
+      card: {
+        type: 'currency',
+        value: 0,
+      },
+      check: {
+        type: 'currency',
+        value: 0,
+      },
+    });
+  });
+
   it('Previews subscriptions for variant', async () => {
     const { previewAcceptBlueSubscriptions } = await shopClient.query(
       PREVIEW_SUBSCRIPTIONS_FOR_VARIANT,
@@ -306,7 +331,6 @@ describe('Payment with Saved Payment Method', () => {
     const testPaymentMethod =
       haydenSavedPaymentMethods[haydenSavedPaymentMethods.length - 1];
     nockInstance
-      .persist()
       .get(`/payment-methods/${testPaymentMethod.id}`)
       .reply(201, testPaymentMethod);
     await shopClient.query(SET_SHIPPING_METHOD, {

--- a/packages/vendure-plugin-accept-blue/test/dev-server.ts
+++ b/packages/vendure-plugin-accept-blue/test/dev-server.ts
@@ -110,6 +110,7 @@ import { SetShippingAddress } from '../../test/src/generated/shop-graphql';
           { name: 'apiKey', value: process.env.API_KEY },
           { name: 'pin', value: process.env.PIN },
           { name: 'testMode', value: 'true' },
+          { name: 'allowECheck', value: 'true' },
           {
             name: 'tokenizationSourceKey',
             value: process.env.ACCEPT_BLUE_TOKENIZATION_SOURCE_KEY ?? null,

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -256,3 +256,11 @@ export const UPDATE_SUBSCRIPTION = gql`
     }
   }
 `;
+
+export const ELIGIBLE_AC_PAYMENT_METHODS = gql`
+  query eligibleAcceptBluePaymentMethods {
+    eligibleAcceptBluePaymentMethods {
+      name
+    }
+  }
+`;

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -264,3 +264,18 @@ export const ELIGIBLE_AC_PAYMENT_METHODS = gql`
     }
   }
 `;
+
+export const GET_SURCHARGES = gql`
+  query {
+    acceptBlueSurcharges {
+      card {
+        type
+        value
+      }
+      check {
+        type
+        value
+      }
+    }
+  }
+`;

--- a/packages/vendure-plugin-accept-blue/test/helpers/mocks.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/mocks.ts
@@ -1,6 +1,7 @@
 export const haydenSavedPaymentMethods = [
   {
     id: 14556,
+    customer_id: 181937,
     created_at: '2024-01-11T10:44:14.000Z',
     name: 'Hayden Zieme',
     payment_method_type: 'card',
@@ -13,6 +14,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 14969,
+    customer_id: 181937,
     created_at: '2024-02-06T09:10:53.000Z',
     name: null,
     payment_method_type: 'card',
@@ -25,6 +27,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15012,
+    customer_id: 181937,
     created_at: '2024-02-06T22:14:07.000Z',
     name: 'Hayden Zieme',
     payment_method_type: 'check',
@@ -36,6 +39,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15019,
+    customer_id: 181937,
     created_at: '2024-02-07T07:48:20.000Z',
     name: 'Hayden Zieme',
     payment_method_type: 'check',
@@ -47,6 +51,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15020,
+    customer_id: 181937,
     created_at: '2024-02-07T08:00:23.000Z',
     name: 'Hayden Zieme',
     payment_method_type: 'check',
@@ -58,6 +63,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15021,
+    customer_id: 181937,
     created_at: '2024-02-07T08:01:32.000Z',
     name: 'Hiede',
     payment_method_type: 'check',
@@ -69,6 +75,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15022,
+    customer_id: 181937,
     created_at: '2024-02-07T08:03:25.000Z',
     name: 'Hayden',
     payment_method_type: 'check',
@@ -80,6 +87,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15023,
+    customer_id: 181937,
     created_at: '2024-02-07T08:04:22.000Z',
     name: 'Hayden',
     payment_method_type: 'check',
@@ -91,6 +99,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15024,
+    customer_id: 181937,
     created_at: '2024-02-07T08:05:06.000Z',
     name: 'Hayden',
     payment_method_type: 'check',
@@ -102,6 +111,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15035,
+    customer_id: 181937,
     created_at: '2024-02-07T10:50:37.000Z',
     name: 'Hayden Zieme',
     payment_method_type: 'check',
@@ -113,6 +123,7 @@ export const haydenSavedPaymentMethods = [
   },
   {
     id: 15036,
+    customer_id: 181937,
     created_at: '2024-02-07T22:14:07.000Z',
     name: 'Hayden Zieme',
     payment_method_type: 'check',


### PR DESCRIPTION
# Description

# 2.3.0 (2025-02-06)

- Allow disabling certain payment methods, e.g. 'visa' or 'check', via the Vendure Admin UI
- Expose surcharges used by Accept Blue via GraphQL query

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
