### PR TITLE
Accept Blue v2.4.0 - Renamed to Amex and removed `sec_code` check

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.4.0 (2025-03-13)
+
+- Renamed internals to Amex as well
+- Not checking for `sec_code` input anymore, as it is an optional argument
+
 # 2.3.1 (2025-03-12)
 
 - Renamed payment method American Express to Amex

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.spec.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.spec.ts
@@ -9,7 +9,7 @@ it('should enable all payment methods when all are allowed', () => {
     allowECheck: true,
     allowVisa: true,
     allowMasterCard: true,
-    allowAmericanExpress: true,
+    allowAmex: true,
     allowDiscover: true,
   });
 
@@ -31,7 +31,7 @@ it('should only enable specified payment methods', () => {
     allowECheck: true,
     allowVisa: true,
     allowMasterCard: false,
-    allowAmericanExpress: false,
+    allowAmex: false,
     allowDiscover: false,
   });
   expect(client.enabledPaymentMethods).toEqual(['ECheck', 'Visa']);
@@ -43,7 +43,7 @@ it('should enable no payment methods when none are allowed', () => {
     allowECheck: false,
     allowVisa: false,
     allowMasterCard: false,
-    allowAmericanExpress: false,
+    allowAmex: false,
     allowDiscover: false,
   });
   expect(client.enabledPaymentMethods).toEqual([]);

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-client.ts
@@ -66,7 +66,7 @@ export class AcceptBlueClient {
     if (enabledPaymentMethodArgs.allowMasterCard) {
       enabledPaymentMethods.push('MasterCard');
     }
-    if (enabledPaymentMethodArgs.allowAmericanExpress) {
+    if (enabledPaymentMethodArgs.allowAmex) {
       enabledPaymentMethods.push('Amex');
     }
     if (enabledPaymentMethodArgs.allowDiscover) {

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-handler.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-handler.ts
@@ -61,7 +61,7 @@ export const acceptBluePaymentHandler = new PaymentMethodHandler({
       defaultValue: true,
       label: [{ languageCode: LanguageCode.en, value: 'Master Card' }],
     },
-    allowAmericanExpress: {
+    allowAmex: {
       type: 'boolean',
       required: false,
       defaultValue: true,

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
@@ -501,13 +501,12 @@ export class AcceptBlueService implements OnApplicationBootstrap {
         `No apiKey or pin found on configured Accept Blue payment method`
       );
     }
+    // Find the handler arguments and pass the enabled payment methods to the client
     const mapToBoolean = (value: string | undefined) =>
       value === 'true' ? true : false;
     const enabledPaymentMethodArgs: EnabledPaymentMethodsArgs = {
-      allowAmericanExpress: mapToBoolean(
-        acceptBlueMethod.handler.args.find(
-          (a) => a.name === 'allowAmericanExpress'
-        )?.value
+      allowAmex: mapToBoolean(
+        acceptBlueMethod.handler.args.find((a) => a.name === 'allowAmex')?.value
       ),
       allowECheck: mapToBoolean(
         acceptBlueMethod.handler.args.find((a) => a.name === 'allowECheck')

--- a/packages/vendure-plugin-accept-blue/src/types.ts
+++ b/packages/vendure-plugin-accept-blue/src/types.ts
@@ -446,7 +446,7 @@ export interface RequestWithRawBody extends Request {
 export interface EnabledPaymentMethodsArgs {
   allowVisa?: boolean;
   allowMasterCard?: boolean;
-  allowAmericanExpress?: boolean;
+  allowAmex?: boolean;
   allowDiscover?: boolean;
   allowECheck?: boolean;
 }

--- a/packages/vendure-plugin-accept-blue/src/util.ts
+++ b/packages/vendure-plugin-accept-blue/src/util.ts
@@ -47,8 +47,7 @@ export function isSameCheck(input: CheckInput, check: ObfuscatedCheck) {
     input.name === check.name &&
     input.routing_number === check.routing_number &&
     input.account_number.endsWith(check.last4) &&
-    input.account_type === check.account_type &&
-    input.sec_code === check.sec_code
+    input.account_type === check.account_type
   );
 }
 /**
@@ -176,7 +175,6 @@ export function isCheckPaymentMethod(input: CheckPaymentMethodInput): boolean {
     input.account_number &&
     input.routing_number &&
     input.name &&
-    input.sec_code &&
     input.account_type
   );
 }


### PR DESCRIPTION
# Description

# 2.4.0 (2025-03-13)

- Renamed internals to Amex as well
- Not checking for `sec_code` input anymore, as it is an optional argument

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
