### PR TITLE
GoedGepickt: Skip fulfilment and retry stock updates via the Job queue

### DIFF
--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,6 +1,10 @@
 # 2.0.3 (2025-04-03)
 
 - Check for undefined or null, to prevent stock updates with 0 being ignored
+  
+# 2.0.3 (2025-04-03)
+
+- Check for undefined or null, to prevent stock updates with 0 being ignored
 
 # 2.0.2 (2025-03-20)
 

--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 2.0.3 (2025-04-03)
+# 2.0.4 (2025-04-15)
 
-- Check for undefined or null, to prevent stock updates with 0 being ignored
-  
+- Process stock updates via the job queue, so that it is retried when GoedGepickt returns a `Too Many Attempts` error
+- Don't use GoedGepickt as fulfilment handler anymore, instead directly move to `Shipped` or `Delivered` on incoming status change.
+
 # 2.0.3 (2025-04-03)
 
 - Check for undefined or null, to prevent stock updates with 0 being ignored

--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Process stock updates via the job queue, so that it is retried when GoedGepickt returns a `Too Many Attempts` error
 - Don't use GoedGepickt as fulfilment handler anymore, instead directly move to `Shipped` or `Delivered` on incoming status change.
+- Update image when the image on GoedGepickt is a placeholder
 
 # 2.0.3 (2025-04-03)
 

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.handler.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.handler.ts
@@ -1,42 +1,17 @@
-import { FulfillmentHandler, LanguageCode, Logger } from '@vendure/core';
-import { GoedgepicktService } from './goedgepickt.service';
-import { loggerCtx } from '../constants';
+import { FulfillmentHandler, LanguageCode } from '@vendure/core';
 
-let service: GoedgepicktService;
 export const goedgepicktHandler = new FulfillmentHandler({
   code: 'goedgepickt',
   description: [
     {
       languageCode: LanguageCode.en,
-      value: 'Send order to Goedgepickt',
+      value: 'GoedGepickt fulfilment',
     },
   ],
-  args: {
-    goedGepicktOrderUUID: {
-      type: 'string',
-      required: false,
-    },
-    trackingCode: {
-      type: 'string',
-      required: false,
-    },
-    trackingUrls: {
-      type: 'string',
-      required: false,
-    },
-  },
-  init: (injector) => {
-    service = injector.get(GoedgepicktService);
-  },
-  createFulfillment: async (ctx, orders, orderItems, args) => {
-    const orderCodes = orders.map((o) => o.code);
-    Logger.info(`Fulfilled orders ${orderCodes.join(',')}`, loggerCtx);
-    return {
-      method: `GoedGepickt - ${args.trackingCode}`,
-      trackingCode: args.trackingCode,
-      customFields: {
-        trackingUrls: args.trackingUrls,
-      },
-    };
+  args: {},
+  createFulfillment: () => {
+    throw Error(
+      `Don't use fulfillment with GoedGepickt. Directly transition to Shipped or Delivered instead.`
+    );
   },
 });

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -608,8 +608,12 @@ export class GoedgepicktService
         this.setAbsoluteImage(ctx, variant)
       );
       const uuid = existing?.uuid;
-      if (uuid) {
+      console.log(existing);
+      if (!existing?.picture?.toLowerCase().includes('image_placeholder.png')) {
+        // The picture on GG is not a placeholder, so don't update it again.
         product.picture = undefined; // Don't update picture on existing product
+      }
+      if (uuid) {
         await client.updateProduct(uuid, product);
         Logger.debug(`Updated variant ${product.sku}`, loggerCtx);
       } else {

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -412,7 +412,7 @@ export class GoedgepicktService
       return;
     }
     const newStatus = ggOrder.status;
-    let vendureOrder = await this.orderService.findOneByCode(ctx, orderCode);
+    const vendureOrder = await this.orderService.findOneByCode(ctx, orderCode);
     if (!vendureOrder) {
       Logger.warn(
         `Order with code ${orderCode} doesn't exists. Not updating status to ${newStatus} for this order in channel ${ctx.channel.token}`,

--- a/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
+++ b/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
@@ -320,6 +320,11 @@ describe('Goedgepickt plugin', function () {
     const updatedVariant = await findVariantBySku('L2201308');
     expect(res.ok).toBe(true);
     expect(updatedVariant).toBeDefined();
+    // Wait for async job processing to have processed stock
+    await waitFor(async () => {
+      const stock = await getAvailableStock(updatedVariant?.id!);
+      return stock?.stockOnHand === 123;
+    });
     const stock = await getAvailableStock(updatedVariant?.id!);
     expect(stock.stockOnHand).toBe(123);
     expect(stock.stockAllocated).toBe(0);

--- a/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
+++ b/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
@@ -3,12 +3,14 @@ import {
   AvailableStock,
   configureDefaultOrderProcess,
   DefaultLogger,
+  EventBus,
   ID,
   LanguageCode,
   LogLevel,
   mergeConfig,
   Order,
   OrderService,
+  OrderStateTransitionEvent,
   ProductService,
   ProductVariant,
   ProductVariantService,
@@ -330,6 +332,7 @@ describe('Goedgepickt plugin', function () {
     expect(stock.stockAllocated).toBe(0);
   });
 
+  let orderTransitionEvents: OrderStateTransitionEvent[] = [];
   it('Completes order via webhook', async () => {
     // Catch order fetching
     nock(apiUrl)
@@ -344,6 +347,13 @@ describe('Goedgepickt plugin', function () {
             trackTraceUrl: 'pinelab.studio/xyz',
           },
         ],
+      });
+    // Listen for order state events
+    server.app
+      .get(EventBus)
+      .ofType(OrderStateTransitionEvent)
+      .subscribe((event) => {
+        orderTransitionEvents.push(event);
       });
     const body: IncomingOrderStatusEvent = {
       newStatus: 'completed',
@@ -370,15 +380,22 @@ describe('Goedgepickt plugin', function () {
     expect(res.ok).toBe(true);
     expect(adminOrder.state).toBe('Delivered');
     const stock = await getAvailableStock(1);
-    expect(stock.stockOnHand).toBe(121); // Deducted 2 because of allocation
-    expect(stock.stockAllocated).toBe(-2);
+    expect(stock.stockOnHand).toBe(123); // No deduction, because we dont do allocation
+    expect(stock.stockAllocated).toBe(0);
   });
 
-  it('Has fulfillment after completion', async () => {
-    const adminOrder = await getOrder(adminClient, order.id as string);
-    const fulfillment = adminOrder?.fulfillments?.[0];
-    expect(fulfillment?.method).toBe('GoedGepickt - XYZ');
-    expect(fulfillment?.trackingCode).toBe('XYZ');
+  it('Transition to Shipped, and then to Delivered', async () => {
+    const shippedEvent = orderTransitionEvents[0];
+    expect(shippedEvent).toBeDefined();
+    expect(shippedEvent?.fromState).toBe('PaymentSettled');
+    expect(shippedEvent?.toState).toBe('Shipped');
+    expect(shippedEvent?.order.code).toBe(order.code);
+    // Delivered should be the immediate next event
+    const deliveredEvent = orderTransitionEvents[1];
+    expect(deliveredEvent).toBeDefined();
+    expect(deliveredEvent?.fromState).toBe('Shipped');
+    expect(deliveredEvent?.toState).toBe('Delivered');
+    expect(deliveredEvent?.order.code).toBe(order.code);
   });
 
   it('Pushes product on product creation', async () => {


### PR DESCRIPTION
# Description

# 2.0.4 (2025-04-15)

- Process stock updates via the job queue, so that it is retried when GoedGepickt returns a `Too Many Attempts` error
- Don't use GoedGepickt as fulfilment handler anymore, instead directly move to `Shipped` or `Delivered` on incoming status change.

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
