### PR TITLE
feat(picqer): hydrate variant.product relation when pushing to picqer

### DIFF
--- a/packages/vendure-plugin-picqer/CHANGELOG.md
+++ b/packages/vendure-plugin-picqer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.7.0 (2025-04-23)
+
+- Hydrate `ProductVariant.Product` when pushing products to Picqer, so that consumers can use Product to populate Picqer custom fields.
+
 # 3.6.0 (2025-01-08)
 
 - Allow configuring the plugin to not cancel Vendure orders when a Picqer order is cancelled

--- a/packages/vendure-plugin-picqer/package.json
+++ b/packages/vendure-plugin-picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-picqer",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Vendure plugin syncing to orders and stock with Picqer",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-picqer/src/api/picqer.service.ts
+++ b/packages/vendure-plugin-picqer/src/api/picqer.service.ts
@@ -722,6 +722,7 @@ export class PicqerService implements OnApplicationBootstrap {
       'lines.productVariant',
       'lines.productVariant.translations',
       'lines.productVariant.taxCategory',
+      'lines.productVariant.product',
       'customer',
       'customer.addresses',
       'shippingLines',
@@ -887,6 +888,9 @@ export class PicqerService implements OnApplicationBootstrap {
           return;
         }
         try {
+          await this.entityHydrator.hydrate(ctx, variant, {
+            relations: ['product'],
+          });
           const productInput = this.mapToProductInput(
             ctx,
             variant,


### PR DESCRIPTION
# 3.7.0 (2025-04-23)

- Hydrate `ProductVariant.Product` when pushing products to Picqer, so that consumers can use Product to populate Picqer custom fields.
-
# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
