### PR TITLE
feat(stripe-subscription): move default stripePaymentMethods from service to resolver

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.8.1(2025-04-26)
+
+- moved default `['card']` paymentMethods and `setup_future_usage: 'off_session'` from `StripeSubscriptionService.createIntentByOrder` and move it into the `createStripeSubscriptionIntent` resolver
+- **BREAKING CHANGE**: `StripeSubscriptionService.createIntentByOrder`, `StripeSubscriptionService.createIntent`, and `StripeSubscriptionService.createIntentForDraftOrder` now requires a `paymentMethods: string[]` and `setupFutureUsage` argument; update all calls to pass your desired default (e.g. `['card']`)
+
 # 2.8.0 (2025-04-17)
 
 - Don't validate webhook secret, but call Stripe API directly to get valid data.

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.resolver.ts
+++ b/packages/vendure-plugin-stripe-subscription/src/api/stripe-subscription.resolver.ts
@@ -123,7 +123,13 @@ export class StripeSubscriptionShopApiResolver {
   async createStripeSubscriptionIntent(
     @Ctx() ctx: RequestContext
   ): Promise<GraphqlShopMutation['createStripeSubscriptionIntent']> {
-    const res = await this.stripeSubscriptionService.createIntent(ctx);
+    const stripePaymentMethods = ['card']; // TODO make configurable per channel
+    const setupFutureUsage = 'off_session'; // TODO make configurable per channel
+    const res = await this.stripeSubscriptionService.createIntent(
+      ctx,
+      stripePaymentMethods,
+      setupFutureUsage
+    );
     return res;
   }
 }
@@ -138,9 +144,13 @@ export class StripeSubscriptionAdminApiResolver {
     @Ctx() ctx: RequestContext,
     @Args() args: MutationCreateStripeSubscriptionIntentArgs
   ): Promise<GraphqlAdminMutation['createStripeSubscriptionIntent']> {
+    const stripePaymentMethods = ['card']; // TODO make configurable per channel
+    const setupFutureUsage = 'off_session'; // TODO make configurable per channel
     const res = await this.stripeSubscriptionService.createIntentForDraftOrder(
       ctx,
-      args.orderId
+      args.orderId,
+      stripePaymentMethods,
+      setupFutureUsage
     );
     return res;
   }


### PR DESCRIPTION
# Description
- Removes the hard-coded array of paymentMethods and setup_future_usage: 'off_session'  from the createIntentByOrder service.
- Shifts the responsibility for defining paymentMethods and setup_future_usage: 'off_session' into the resolver.
- Allows caller (e.g. resolver, controller ) to pass an array of payment methods (e.g. ['card'], ['affirm', 'card']) and setupFurtureUsage based on order or channel to the service.

# Breaking changes
- `StripeSubscriptionService.createIntentByOrder`, `StripeSubscriptionService.createIntent`, and `StripeSubscriptionService.createIntentForDraftOrder` now requires a `paymentMethods: string[]` and  `setupFurtureUsage` argument;

# Reason
- Previously, the `StripeSubscriptionService.createIntentByOrder` method had a hardcoded `const paymentMethods = ['card']`, making the service inflexible and preventing it from being reused with different payment methods.
- We need to dynamically select payment methods (e.g. use Affirm for certain SKUs). The createIntent service must accept an argument, allowing us to use this service and logically change the payment method based on the order.


# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
