### PR TITLE
feat(accept-blue): prevent error throwing on disabled Accept Blue method

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 2.6.1 (2025-04-28)
+
+- Prevent throwing an error when no enabled Accept Blue payment method is found when fetching other eligible Payment Methods.
+
 # 2.6.2 (2025-04-22)
 
-- Dont expose Accept Blue config on non Accept Blue Payment Method Quotes
+- Don't expose Accept Blue config on non Accept Blue Payment Method Quotes
 
 # 2.6.1 (2025-04-18)
 

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -74,7 +74,6 @@ export class AcceptBlueCommonResolver {
     @Parent() quote: PaymentMethodQuote,
     @Ctx() ctx: RequestContext
   ): Promise<string | null | undefined> {
-    console.log(quote);
     return (await this.acceptBlueService.getStorefrontKeys(ctx, quote.id))
       ?.acceptBlueHostedTokenizationKey;
   }

--- a/packages/vendure-plugin-order-pdfs/README.md
+++ b/packages/vendure-plugin-order-pdfs/README.md
@@ -115,7 +115,6 @@ If you want to disable this behavior, you can supply `allowPublicDownload: false
 
 If you need custom data, or more relations in your template, you can supply a custom data loading function. All data returned from this function is passed into your Handlebars HTML template.
 
-
 ```ts
 import { LoadDataFn } from '@pinelab/vendure-plugin-order-pdfs';
 import { Injector, Order, RequestContext} from '@vendure/core';


### PR DESCRIPTION
# 2.6.1 (2025-04-28)

- Prevent throwing an error when no enabled Accept Blue payment method is found when fetching other eligible Payment Methods.

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
