### PR TITLE
fix(metrics): variant IDs are not being passed to the backend query after initial load

### DIFF
--- a/packages/vendure-plugin-metrics/CHANGELOG.md
+++ b/packages/vendure-plugin-metrics/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.1 (2025-05-02)
+
+- Fixed a bug where variant IDs were not being passed correctly to the metrics query.
+
 # 1.7.0 (2024-12-19)
 
 - Update Vendure to 3.1.1

--- a/packages/vendure-plugin-metrics/package.json
+++ b/packages/vendure-plugin-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-metrics",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Vendure plugin measuring and visualizing e-commerce metrics",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-metrics/src/ui/metrics-ui.service.ts
+++ b/packages/vendure-plugin-metrics/src/ui/metrics-ui.service.ts
@@ -18,6 +18,8 @@ export interface AdvancedChartEntry {
 export class MetricsUiService {
   currencyCode$: Observable<any>;
   uiState$: Observable<any>;
+  selectedVariantIds$ = new BehaviorSubject<string[]>([]);
+
   constructor(private dataService: DataService) {
     this.currencyCode$ = this.dataService.settings
       .getActiveChannel()
@@ -28,13 +30,19 @@ export class MetricsUiService {
       .mapStream((data) => data.uiState);
   }
 
-  queryData(selectedVariantIds?: string[]) {
-    return combineLatest(this.currencyCode$, this.uiState$).pipe(
-      switchMap(([currencyCode, uiState]) =>
+  queryData() {
+    return combineLatest([
+      this.currencyCode$,
+      this.uiState$,
+      this.selectedVariantIds$,
+    ]).pipe(
+      switchMap(([currencyCode, uiState, selectedVariantIds]) =>
         this.dataService
           .query(GET_METRICS, {
             input: {
-              ...(selectedVariantIds ? { variantIds: selectedVariantIds } : []),
+              ...(selectedVariantIds.length
+                ? { variantIds: selectedVariantIds }
+                : []),
             },
           })
           .refetchOnChannelChange()

--- a/packages/vendure-plugin-metrics/src/ui/metrics-ui.service.ts
+++ b/packages/vendure-plugin-metrics/src/ui/metrics-ui.service.ts
@@ -16,19 +16,16 @@ export interface AdvancedChartEntry {
   providedIn: 'root',
 })
 export class MetricsUiService {
-  currencyCode$: Observable<any>;
-  uiState$: Observable<any>;
+  currencyCode$ = this.dataService.settings
+    .getActiveChannel()
+    .refetchOnChannelChange()
+    .mapStream((data) => data.activeChannel.defaultCurrencyCode || undefined);
+  uiState$ = this.dataService.client
+    .uiState()
+    .mapStream((data) => data.uiState);
   selectedVariantIds$ = new BehaviorSubject<string[]>([]);
 
-  constructor(private dataService: DataService) {
-    this.currencyCode$ = this.dataService.settings
-      .getActiveChannel()
-      .refetchOnChannelChange()
-      .mapStream((data) => data.activeChannel.defaultCurrencyCode || undefined);
-    this.uiState$ = this.dataService.client
-      .uiState()
-      .mapStream((data) => data.uiState);
-  }
+  constructor(private dataService: DataService) {}
 
   queryData() {
     return combineLatest([

--- a/packages/vendure-plugin-metrics/src/ui/metrics-widget.ts
+++ b/packages/vendure-plugin-metrics/src/ui/metrics-widget.ts
@@ -145,26 +145,23 @@ export class MetricsWidgetComponent implements OnInit {
           this.selectedVariantNames = selection.map(
             (s) => s.productVariantName
           );
-          (this.selectedVariantIds = selection.map((s) => s.productVariantId)),
-            this.changeDetectorRef.detectChanges();
-          this.loadChartData();
+          this.selectedVariantIds = selection.map((s) => s.productVariantId);
+          this.metricsService.selectedVariantIds$.next(this.selectedVariantIds);
+          this.changeDetectorRef.detectChanges();
         }
       });
   }
 
   clearProductVariantSelection() {
     this.selectedVariantIds = [];
+    this.metricsService.selectedVariantIds$.next(this.selectedVariantIds);
     this.selectedVariantNames = [];
     this.changeDetectorRef.detectChanges();
-    this.loadChartData();
   }
 
   loadChartData() {
     this.loading = true;
-    this.metrics$ = this.metricsService.queryData(
-      // this.selection$,
-      this.selectedVariantIds
-    );
+    this.metrics$ = this.metricsService.queryData();
     this.changeDetectorRef.detectChanges();
     this.metrics$?.subscribe(async (metrics) => {
       this.loading = false;

--- a/packages/vendure-plugin-metrics/src/ui/metrics-widget.ts
+++ b/packages/vendure-plugin-metrics/src/ui/metrics-widget.ts
@@ -108,7 +108,6 @@ import { MetricsUiService } from './metrics-ui.service';
 export class MetricsWidgetComponent implements OnInit {
   metrics$: Observable<ChartEntry[]> | undefined;
   selectedMetric: ChartEntry | undefined;
-  variantName: string;
   dropDownName = 'Select Variant';
   nrOfOrdersChart?: any;
   selectedVariantIds: string[] = [];
@@ -123,11 +122,6 @@ export class MetricsWidgetComponent implements OnInit {
 
   async ngOnInit() {
     this.loadChartData();
-  }
-
-  onDropdownItemClick(variantId: string, variantName: string) {
-    this.loadChartData();
-    this.dropDownName = variantName;
   }
 
   openProductSelectionDialog() {

--- a/packages/vendure-plugin-metrics/src/ui/metrics-widget.ts
+++ b/packages/vendure-plugin-metrics/src/ui/metrics-widget.ts
@@ -155,7 +155,7 @@ export class MetricsWidgetComponent implements OnInit {
 
   loadChartData() {
     this.loading = true;
-    this.metrics$ = this.metricsService.queryData();
+    this.metrics$ = this.metricsService.queryData$;
     this.changeDetectorRef.detectChanges();
     this.metrics$?.subscribe(async (metrics) => {
       this.loading = false;


### PR DESCRIPTION
# Description

Fixed a bug where variant IDs were not being passed correctly to the metrics query.

Also cleans up some unused variables and improves types from `any` by assigning values at declaration.

# To do before merge

- N/A

# Breaking changes

None

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
