### PR TITLE
feat(accept-blue): Removed `endDate` and made `startDate` optional

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0 (2025-05-13)
+
+- BREAKING: `AcceptBlueSubscription.recurring.endDate` is removed.
+- BREAKING: `AcceptBlueSubscription.recurring.startDate` is now optional.
+- The fields `createdAt`, `nextRunDate`, `previousRunDate` and `numLeft` have been added to `AcceptBlueSubscription.recurring`.
+
 # 2.6.1 (2025-04-28)
 
 - Prevent throwing an error when no enabled Accept Blue payment method is found when fetching other eligible Payment Methods.

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "2.6.3",
+  "version": "3.0.0",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-service.ts
@@ -878,7 +878,16 @@ export class AcceptBlueService implements OnApplicationBootstrap {
         amount: subscription.amount,
         interval,
         intervalCount,
-        startDate: subscription.created_at,
+        createdAt: subscription.created_at
+          ? new Date(subscription.created_at)
+          : undefined,
+        nextRunDate: subscription.next_run_date
+          ? new Date(subscription.next_run_date)
+          : undefined,
+        previousRunDate: subscription.prev_run_date
+          ? new Date(subscription.prev_run_date)
+          : undefined,
+        numLeft: subscription.num_left,
       },
       transactions,
     };

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -30,8 +30,11 @@ const commonApiExtensions = gql`
     amount: Int!
     interval: AcceptBlueSubscriptionInterval!
     intervalCount: Int!
-    startDate: DateTime!
-    endDate: DateTime
+    createdAt: DateTime
+    startDate: DateTime
+    nextRunDate: DateTime
+    previousRunDate: DateTime
+    numLeft: Int
   }
 
   type AcceptBlueCardPaymentMethod {

--- a/packages/vendure-plugin-accept-blue/test/dev-server.ts
+++ b/packages/vendure-plugin-accept-blue/test/dev-server.ts
@@ -116,6 +116,7 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
           { name: 'allowECheck', value: 'true' },
           { name: 'allowGooglePay', value: 'true' },
           { name: 'allowApplePay', value: 'true' },
+          { name: 'allowVisa', value: 'true' },
           {
             name: 'tokenizationSourceKey',
             value: process.env.ACCEPT_BLUE_TOKENIZATION_SOURCE_KEY ?? null,
@@ -178,29 +179,29 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
       '{"signature":"MEUCIFZG/zqpZQohvMILpMEPRC/HzlYsUvJVTlcjuh6ddNZhAiEAyRldHj7sC9xbnCa00u8dUzwRYMOoENTQqm6tyldRcDU\\u003d","intermediateSigningKey":{"signedKey":"{\\"keyValue\\":\\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEscxfstKIwGYw8f2aybtHUYjaEKXpXh4c4uEN3NC0kZnawXUpGew8DWdS+vYOVZ5O639ZkRL32L5FeKcb0Wvdlg\\\\u003d\\\\u003d\\",\\"keyExpiration\\":\\"1743759806251\\"}","signatures":["MEYCIQCWPi+p9C/kgQMIuIUeNKRPxPWMORGO7xlm9NrMa6tfbAIhAPyJkxEIPP/ECk3U766OyHvhP5jfAk3/F2giIlNVUHIV"]},"protocolVersion":"ECv2","signedMessage":"{\\"encryptedMessage\\":\\"rXjz4P5ugdTumQ0s3B+kj7PcRDAkxJghyP/flpbxqTz40g4zaYAA9QrG+nX/bJg86I7j6NQU+cJLGTirN196p0bVCqOotx46DeOHXqDG5W2QFabxKa3igcxZ0bbQ3+OQxPN52Vz9jR1lNZkA+ZF4sckK4rtPJJltxxswVCgZm+YNUtTNb7hBh7eoJcu0WJCUv0obNcufJEz8+KoQJiaPu4TwmaIT9RanqKqlHzarXQdOhmHQJiOXfGiP8GeMaROuL9E2h8PowEyjbHEKrx0KjtRW2Jlk2wEQW4GIhietVOvO/9JpesepWX8vfn/HuVsOmXsj9BwBtKEX3Z5r9XlnMWzd8q8U8/1WUPZZgn8Q0B5vdOdzn7srmo4lFKrRBZTeyLjMZGdyINHh5ZSajWZmI9NeucEk3ZvIxAW0bV/mD5OOFmQOetclyldcEMxwsXO7E0TSp65GMAobGwNHkOd0wCN2DMyBxT4Vh4hN0dfZD4lDU2qUWjEc+/GPl/++g+s3rUR1KjyPSH06wv3yqmSG+u/0Gof/mfPoZyf1TRm6UzcFTY8HmoPeR3Oo\\",\\"ephemeralPublicKey\\":\\"BKgk4yeCEVqfZTHIAegqcnABhcc9x4v8IRQZbO7QZMEWAKBeJ9Q/fVKZgs/Tt9WyAKkH7FBfbBTbjEdh+j+3sFc\\\\u003d\\",\\"tag\\":\\"xslhQIESD/gFKNAb/SlRwD9gg8oVMiNQaSOIHFxA5Yo\\\\u003d\\"}"}',
   };
 
-  // try {
-  //   const { addPaymentToOrder } = await shopClient.query(ADD_PAYMENT_TO_ORDER, {
-  //     input: {
-  //       method: 'accept-blue',
-  //       metadata,
-  //       // metadata: { paymentMethodId: 14556 }, // Use a saved payment method
-  //     },
-  //   });
-  //   console.log(JSON.stringify);
-  //   console.log(
-  //     `Successfully transitioned order to ${addPaymentToOrder.state}`
-  //   );
+  try {
+    const { addPaymentToOrder } = await shopClient.query(ADD_PAYMENT_TO_ORDER, {
+      input: {
+        method: 'accept-blue',
+        // metadata,
+        metadata: { paymentMethodId: 14556 }, // Use a saved payment method
+      },
+    });
+    console.log(JSON.stringify);
+    console.log(
+      `Successfully transitioned order to ${addPaymentToOrder.state}`
+    );
 
-  //   // Attempt a refund
-  //   // const { refundAcceptBlueTransaction } = await shopClient.query(
-  //   //   REFUND_TRANSACTION,
-  //   //   {
-  //   //     transactionId: 354653,
-  //   //   }
-  //   // );
-  //   // console.log(`Refunded transaction: ${refundAcceptBlueTransaction}`);
-  // } catch (e) {
-  //   // Catch to prevent server from terminating
-  //   console.error(e);
-  // }
+    //   // Attempt a refund
+    //   // const { refundAcceptBlueTransaction } = await shopClient.query(
+    //   //   REFUND_TRANSACTION,
+    //   //   {
+    //   //     transactionId: 354653,
+    //   //   }
+    //   // );
+    //   // console.log(`Refunded transaction: ${refundAcceptBlueTransaction}`);
+  } catch (e) {
+    // Catch to prevent server from terminating
+    console.error(e);
+  }
 })();

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -141,6 +141,7 @@ export const GET_ORDER_BY_CODE = gql`
             amount
             interval
             intervalCount
+            createdAt
             startDate
             nextRunDate
             previousRunDate
@@ -253,6 +254,7 @@ export const UPDATE_SUBSCRIPTION = gql`
         amount
         interval
         intervalCount
+        createdAt
         startDate
         nextRunDate
         previousRunDate

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -142,7 +142,9 @@ export const GET_ORDER_BY_CODE = gql`
             interval
             intervalCount
             startDate
-            endDate
+            nextRunDate
+            previousRunDate
+            numLeft
           }
           transactions {
             id
@@ -252,7 +254,9 @@ export const UPDATE_SUBSCRIPTION = gql`
         interval
         intervalCount
         startDate
-        endDate
+        nextRunDate
+        previousRunDate
+        numLeft
       }
     }
   }

--- a/packages/vendure-plugin-shipping-extensions/src/config/shipping/shipping-util.ts
+++ b/packages/vendure-plugin-shipping-extensions/src/config/shipping/shipping-util.ts
@@ -1,6 +1,5 @@
 import {
   assertFound,
-  EntityHydrator,
   Injector,
   Order,
   OrderService,


### PR DESCRIPTION
# 3.0.0 (2025-05-13)

- BREAKING: `AcceptBlueSubscription.recurring.endDate` is removed.
- BREAKING: `AcceptBlueSubscription.recurring.startDate` is now optional.
- The fields `createdAt`, `nextRunDate`, `previousRunDate` and `numLeft` have been added to `AcceptBlueSubscription.recurring`.

# Breaking changes

Yes, see above

![image](https://github.com/user-attachments/assets/25af675c-192f-41ad-98a8-a321aebea8fe)

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
