### PR TITLE
Accept Blue: Creating and deleting payment methods

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.0 (2025-06-06)
+
+- Enable creating and deleting payment methods via the Shop API for logged in customers
+- Enable creating and deleting payment methods via the Admin API for all customers
+- Allow connecting payment methods to existing subscriptions
+
 # 3.1.0 (2025-06-05)
 
 - Upgraded to Vendure 3.3.2

--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Enable creating and deleting payment methods via the Shop API for logged in customers
 - Enable creating and deleting payment methods via the Admin API for all customers
-- Allow connecting payment methods to existing subscriptions
 
 # 3.1.0 (2025-06-05)
 

--- a/packages/vendure-plugin-accept-blue/README.md
+++ b/packages/vendure-plugin-accept-blue/README.md
@@ -184,6 +184,18 @@ mutation {
 }
 ```
 
+For creating a a card payment method, you need to use Hosted Tokenization (see `Pay with Nonce/Tokenized card` above). After getting a nonce token, you can use the following mutation to create a card payment method. For the Shop API, you need to be logged in. For the Admin API, you need to pass an Accept Blue customer ID into the mutation.
+
+```graphql
+mutation {
+  createAcceptBlueCardPaymentMethod(
+    input: { nonce: "nonce-z5frsiogt4kce2paljeb" }
+  ) {
+    id
+  }
+}
+```
+
 ## Fetching Transactions and Subscriptions for placed orders
 
 After an order is placed, the `order.lines.acceptBlueSubscriptions` is populated with the actual subscription values from the Accept Blue platform, so it will not call your strategy anymore. This is to better reflect the subscription that was actually created at the time of ordering.

--- a/packages/vendure-plugin-accept-blue/README.md
+++ b/packages/vendure-plugin-accept-blue/README.md
@@ -196,6 +196,8 @@ mutation {
 }
 ```
 
+To create a check payment method, you can use the `createAcceptBlueCheckPaymentMethod` mutation.
+
 ## Fetching Transactions and Subscriptions for placed orders
 
 After an order is placed, the `order.lines.acceptBlueSubscriptions` is populated with the actual subscription values from the Accept Blue platform, so it will not call your strategy anymore. This is to better reflect the subscription that was actually created at the time of ordering.

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "3.0.1",
+  "version": "3.2.0",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -34,8 +34,8 @@ import {
   MutationUpdateAcceptBlueCheckPaymentMethodArgs,
   MutationDeleteAcceptBluePaymentMethodArgs,
   MutationCreateAcceptBlueCardPaymentMethodArgs,
+  MutationCreateAcceptBlueCheckPaymentMethodArgs,
 } from './generated/graphql';
-import { s } from 'vitest/dist/reporters-MmQN-57K';
 
 @Resolver()
 export class AcceptBlueCommonResolver {
@@ -217,5 +217,24 @@ export class AcceptBlueCommonResolver {
     }
     // For Shop API, we use the ctx.activeUserId
     return await this.acceptBlueService.createCardPaymentMethod(ctx, input);
+  }
+
+  @Mutation()
+  @Allow(Permission.UpdateCustomer, Permission.Authenticated)
+  async createAcceptBlueCheckPaymentMethod(
+    @Ctx() ctx: RequestContext,
+    @Args()
+    { input, customerId }: MutationCreateAcceptBlueCheckPaymentMethodArgs
+  ): Promise<GraphqlMutation['createAcceptBlueCheckPaymentMethod']> {
+    if (ctx.apiType === 'admin') {
+      // CustomerId is only defined for admin API
+      return await this.acceptBlueService.createCheckPaymentMethod(
+        ctx,
+        input,
+        customerId
+      );
+    }
+    // For Shop API, we use the ctx.activeUserId
+    return await this.acceptBlueService.createCheckPaymentMethod(ctx, input);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -33,7 +33,9 @@ import {
   AcceptBlueCardPaymentMethod,
   MutationUpdateAcceptBlueCheckPaymentMethodArgs,
   MutationDeleteAcceptBluePaymentMethodArgs,
+  MutationCreateAcceptBlueCardPaymentMethodArgs,
 } from './generated/graphql';
+import { s } from 'vitest/dist/reporters-MmQN-57K';
 
 @Resolver()
 export class AcceptBlueCommonResolver {
@@ -197,5 +199,23 @@ export class AcceptBlueCommonResolver {
     @Args() { id }: MutationDeleteAcceptBluePaymentMethodArgs
   ): Promise<GraphqlMutation['deleteAcceptBluePaymentMethod']> {
     return await this.acceptBlueService.deletePaymentMethod(ctx, id);
+  }
+
+  @Mutation()
+  @Allow(Permission.UpdateCustomer, Permission.Authenticated)
+  async createAcceptBlueCardPaymentMethod(
+    @Ctx() ctx: RequestContext,
+    @Args() { input, customerId }: MutationCreateAcceptBlueCardPaymentMethodArgs
+  ): Promise<GraphqlMutation['createAcceptBlueCardPaymentMethod']> {
+    if (ctx.apiType === 'admin') {
+      // CustomerId is only defined for admin API
+      return await this.acceptBlueService.createCardPaymentMethod(
+        ctx,
+        input,
+        customerId
+      );
+    }
+    // For Shop API, we use the ctx.activeUserId
+    return await this.acceptBlueService.createCardPaymentMethod(ctx, input);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -32,6 +32,7 @@ import {
   QueryPreviewAcceptBlueSubscriptionsForProductArgs,
   AcceptBlueCardPaymentMethod,
   MutationUpdateAcceptBlueCheckPaymentMethodArgs,
+  MutationDeleteAcceptBluePaymentMethodArgs,
 } from './generated/graphql';
 
 @Resolver()
@@ -187,5 +188,14 @@ export class AcceptBlueCommonResolver {
     { input }: MutationUpdateAcceptBlueCheckPaymentMethodArgs
   ): Promise<GraphqlMutation['updateAcceptBlueCheckPaymentMethod']> {
     return await this.acceptBlueService.updateCheckPaymentMethod(ctx, input);
+  }
+
+  @Mutation()
+  @Allow(Permission.UpdateCustomer, Permission.Authenticated)
+  async deleteAcceptBluePaymentMethod(
+    @Ctx() ctx: RequestContext,
+    @Args() { id }: MutationDeleteAcceptBluePaymentMethodArgs
+  ): Promise<GraphqlMutation['deleteAcceptBluePaymentMethod']> {
+    return await this.acceptBlueService.deletePaymentMethod(ctx, id);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -214,6 +214,15 @@ const commonApiExtensions = gql`
     sec_code: String
   }
 
+  input CreateAcceptBlueCardPaymentMethodInput {
+    sourceToken: String!
+    expiry_month: Int!
+    expiry_year: Int!
+    avs_address: String
+    avs_zip: String
+    name: String
+  }
+
   extend type Mutation {
     updateAcceptBlueCardPaymentMethod(
       input: UpdateAcceptBlueCardPaymentMethodInput!
@@ -227,6 +236,16 @@ const commonApiExtensions = gql`
 
 export const shopApiExtensions = gql`
   ${commonApiExtensions}
+
+  extend type Mutation {
+    """
+    Creating a card payment method is only allowed with a nonce token.
+    See Hosted Tokenization in the Accept Blue docs for more information.
+    """
+    createAcceptBlueCardPaymentMethod(
+      input: CreateAcceptBlueCardPaymentMethodInput!
+    ): AcceptBlueCardPaymentMethod!
+  }
 `;
 
 export const adminApiExtensions = gql`
@@ -248,5 +267,14 @@ export const adminApiExtensions = gql`
     updateAcceptBlueSubscription(
       input: UpdateAcceptBlueSubscriptionInput!
     ): AcceptBlueSubscription!
+
+    """
+    Creating a card payment method is only allowed with a nonce token.
+    See Hosted Tokenization in the Accept Blue docs for more information.
+    """
+    createAcceptBlueCardPaymentMethod(
+      input: CreateAcceptBlueCardPaymentMethodInput!
+      customerId: Int!
+    ): AcceptBlueCardPaymentMethod!
   }
 `;

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -221,6 +221,7 @@ const commonApiExtensions = gql`
     updateAcceptBlueCheckPaymentMethod(
       input: UpdateAcceptBlueCheckPaymentMethodInput!
     ): AcceptBlueCheckPaymentMethod!
+    deleteAcceptBluePaymentMethod(id: Int!): Boolean!
   }
 `;
 

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -223,6 +223,14 @@ const commonApiExtensions = gql`
     name: String
   }
 
+  input CreateAcceptBlueCheckPaymentMethodInput {
+    name: String!
+    routing_number: String!
+    account_number: String!
+    account_type: String!
+    sec_code: String!
+  }
+
   extend type Mutation {
     updateAcceptBlueCardPaymentMethod(
       input: UpdateAcceptBlueCardPaymentMethodInput!
@@ -245,6 +253,9 @@ export const shopApiExtensions = gql`
     createAcceptBlueCardPaymentMethod(
       input: CreateAcceptBlueCardPaymentMethodInput!
     ): AcceptBlueCardPaymentMethod!
+    createAcceptBlueCheckPaymentMethod(
+      input: CreateAcceptBlueCheckPaymentMethodInput!
+    ): AcceptBlueCheckPaymentMethod!
   }
 `;
 
@@ -276,5 +287,9 @@ export const adminApiExtensions = gql`
       input: CreateAcceptBlueCardPaymentMethodInput!
       customerId: Int!
     ): AcceptBlueCardPaymentMethod!
+    createAcceptBlueCheckPaymentMethod(
+      input: CreateAcceptBlueCheckPaymentMethodInput!
+      customerId: Int!
+    ): AcceptBlueCheckPaymentMethod!
   }
 `;

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
@@ -1,6 +1,10 @@
 import { Logger, UserInputError } from '@vendure/core';
 import axios, { AxiosInstance } from 'axios';
 import util from 'util';
+import {
+  AcceptBluePaymentMethodType,
+  AcceptBlueSurcharges,
+} from '../api/generated/graphql';
 import { loggerCtx } from '../constants';
 import {
   AcceptBlueChargeTransaction,
@@ -15,20 +19,16 @@ import {
   AcceptBlueWebhook,
   AcceptBlueWebhookInput,
   AllowedPaymentMethodInput,
+  AppleOrGooglePayInput,
   CheckPaymentMethodInput,
   CustomFields,
   EnabledPaymentMethodsArgs,
   NoncePaymentMethodInput,
-  AppleOrGooglePayInput,
   SourcePaymentMethodInput,
   UpdateCardPaymentMethodInput,
   UpdateCheckPaymentMethodInput,
 } from '../types';
 import { isSameCard, isSameCheck } from '../util';
-import {
-  AcceptBluePaymentMethodType,
-  AcceptBlueSurcharges,
-} from '../api/generated/graphql';
 
 export class AcceptBlueClient {
   readonly endpoint: string;
@@ -326,6 +326,12 @@ export class AcceptBlueClient {
     return result;
   }
 
+  async deletePaymentMethod(paymentMethodId: number): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    await this.request('delete', `payment-methods/${paymentMethodId}`);
+    Logger.info(`Deleted payment method '${paymentMethodId}'`, loggerCtx);
+  }
+
   async createRecurringSchedule(
     customerId: number,
     input: AcceptBlueRecurringScheduleCreateInput
@@ -514,6 +520,13 @@ export class AcceptBlueClient {
         loggerCtx,
         util.inspect(result.data)
       );
+      if (String(result.headers['content-type']).includes('application/json')) {
+        // Errors with a JSON body indicate user input errors
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        throw new UserInputError(
+          result.data?.error_message ?? result.statusText
+        );
+      }
       throw Error(result.statusText);
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
@@ -522,8 +522,8 @@ export class AcceptBlueClient {
       );
       if (String(result.headers['content-type']).includes('application/json')) {
         // Errors with a JSON body indicate user input errors
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         throw new UserInputError(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
           result.data?.error_message ?? result.statusText
         );
       }

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-service.ts
@@ -46,6 +46,8 @@ import {
   SavedPaymentMethodInput,
   StorefrontKeys,
   AcceptBlueCardPaymentMethod,
+  SecCode,
+  AccountType,
 } from '../types';
 import {
   getNrOfBillingCyclesLeft,
@@ -65,6 +67,7 @@ import {
   AcceptBlueSurcharges,
   AcceptBlueTransaction,
   CreateAcceptBlueCardPaymentMethodInput,
+  CreateAcceptBlueCheckPaymentMethodInput,
   UpdateAcceptBlueCardPaymentMethodInput,
   UpdateAcceptBlueCheckPaymentMethodInput,
   UpdateAcceptBlueSubscriptionInput,
@@ -472,6 +475,24 @@ export class AcceptBlueService implements OnApplicationBootstrap {
       avs_address: input.avs_address ?? undefined,
       avs_zip: input.avs_zip ?? undefined,
     })) as AcceptBlueCardPaymentMethod;
+  }
+
+  async createCheckPaymentMethod(
+    ctx: RequestContext,
+    input: CreateAcceptBlueCheckPaymentMethodInput,
+    customerId?: number
+  ): Promise<AcceptBlueCheckPaymentMethod> {
+    const client = await this.getClientForChannel(ctx);
+    // Get customer ID from CTX if no customerId is given
+    const acceptBlueCustomerId =
+      customerId ?? (await this.getAcceptBlueCustomerId(ctx));
+    return (await client.createPaymentMethod(acceptBlueCustomerId, {
+      account_number: input.account_number,
+      account_type: input.account_type as AccountType,
+      routing_number: input.routing_number,
+      sec_code: input.sec_code as SecCode,
+      name: input.name,
+    })) as AcceptBlueCheckPaymentMethod;
   }
 
   async updateSubscription(

--- a/packages/vendure-plugin-accept-blue/src/types.ts
+++ b/packages/vendure-plugin-accept-blue/src/types.ts
@@ -198,7 +198,9 @@ export interface NoncePaymentMethodInput {
   source: string;
   expiry_month: number;
   expiry_year: number;
-  last4: string;
+  last4?: string;
+  avs_address?: string;
+  avs_zip?: string;
 }
 
 export interface SourcePaymentMethodInput {

--- a/packages/vendure-plugin-accept-blue/src/util.ts
+++ b/packages/vendure-plugin-accept-blue/src/util.ts
@@ -11,7 +11,7 @@ import {
 } from './types';
 
 interface MaskedCardInput {
-  last4: string;
+  last4?: string;
   expiry_month: number;
   expiry_year: number;
 }
@@ -36,6 +36,10 @@ export function isSameCard(
   card1: MaskedCardInput,
   card2: MaskedCardInput
 ): boolean {
+  if (!card1.last4 || !card2.last4) {
+    // if no last4 given, we always assume they are different
+    return false;
+  }
   return (
     card1.last4 === card2.last4 &&
     card1.expiry_month === card2.expiry_month &&

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -76,6 +76,41 @@ export const SHOP_CREATE_CARD_PAYMENT_METHOD = gql`
   }
 `;
 
+export const SHOP_CREATE_CHECK_PAYMENT_METHOD = gql`
+  mutation CreateCheckPaymentMethod(
+    $input: CreateAcceptBlueCheckPaymentMethodInput!
+  ) {
+    createAcceptBlueCheckPaymentMethod(input: $input) {
+      id
+      created_at
+      name
+      payment_method_type
+      account_type
+      routing_number
+      sec_code
+      last4
+    }
+  }
+`;
+
+export const ADMIN_CREATE_CHECK_PAYMENT_METHOD = gql`
+  mutation CreateCheckPaymentMethod(
+    $input: CreateAcceptBlueCheckPaymentMethodInput!
+    $customerId: Int!
+  ) {
+    createAcceptBlueCheckPaymentMethod(input: $input, customerId: $customerId) {
+      id
+      created_at
+      name
+      payment_method_type
+      account_type
+      routing_number
+      sec_code
+      last4
+    }
+  }
+`;
+
 export const ADD_ITEM_TO_ORDER = gql`
   mutation AddItemToOrder($productVariantId: ID!, $quantity: Int!) {
     addItemToOrder(productVariantId: $productVariantId, quantity: $quantity) {

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -329,3 +329,9 @@ export const UPDATE_CHECK_PAYMENT_METHOD = gql`
     }
   }
 `;
+
+export const DELETE_PAYMENT_METHOD = gql`
+  mutation DeletePaymentMethod($id: Int!) {
+    deleteAcceptBluePaymentMethod(id: $id)
+  }
+`;

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -37,6 +37,45 @@ export const CREATE_PAYMENT_METHOD = gql`
   }
 `;
 
+export const ADMIN_CREATE_CARD_PAYMENT_METHOD = gql`
+  mutation CreateCardPaymentMethod(
+    $input: CreateAcceptBlueCardPaymentMethodInput!
+    $customerId: Int!
+  ) {
+    createAcceptBlueCardPaymentMethod(input: $input, customerId: $customerId) {
+      id
+      created_at
+      avs_address
+      avs_zip
+      name
+      expiry_month
+      expiry_year
+      payment_method_type
+      card_type
+      last4
+    }
+  }
+`;
+
+export const SHOP_CREATE_CARD_PAYMENT_METHOD = gql`
+  mutation CreateCardPaymentMethod(
+    $input: CreateAcceptBlueCardPaymentMethodInput!
+  ) {
+    createAcceptBlueCardPaymentMethod(input: $input) {
+      id
+      created_at
+      avs_address
+      avs_zip
+      name
+      expiry_month
+      expiry_year
+      payment_method_type
+      card_type
+      last4
+    }
+  }
+`;
+
 export const ADD_ITEM_TO_ORDER = gql`
   mutation AddItemToOrder($productVariantId: ID!, $quantity: Int!) {
     addItemToOrder(productVariantId: $productVariantId, quantity: $quantity) {


### PR DESCRIPTION
# 3.2.0 (2025-06-06)

- Enable creating and deleting payment methods via the Shop API for logged in customers
- Enable creating and deleting payment methods via the Admin API for all customers

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
