### PR TITLE
Accept Blue: Allow updating payment method by customers

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.0 (2025-06-10)
+
+- Enable updating payment method on a subscription via the Shop API for logged in customers
+
 # 3.2.0 (2025-06-06)
 
 - Enable creating and deleting payment methods via the Shop API for logged in customers

--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.3.0 (2025-06-10)
 
 - Enable updating payment method on a subscription via the Shop API for logged in customers
+- Bug fix: Prevent updating a subscription to a payment method type (Visa, MasterCard, etc) that is not allowed. Only allow the methods set via the Admin UI.
 
 # 3.2.0 (2025-06-06)
 

--- a/packages/vendure-plugin-accept-blue/README.md
+++ b/packages/vendure-plugin-accept-blue/README.md
@@ -198,6 +198,19 @@ mutation {
 
 To create a check payment method, you can use the `createAcceptBlueCheckPaymentMethod` mutation.
 
+To connect a new payment method to a subscription, you can use the `updateAcceptBlueSubscription` mutation.
+
+```graphql
+mutation {
+  updateAcceptBlueSubscription(input: { id: 12345, paymentMethodId: 67890 }) {
+    id
+    paymentMethodId
+  }
+}
+```
+
+For the Shop API, you need to be logged in as the customer and be owner of the payment method and the recurring schedule. For the Admin API, you only need to be logged in as an admin and have `UpdateOrder` permissions.
+
 ## Fetching Transactions and Subscriptions for placed orders
 
 After an order is placed, the `order.lines.acceptBlueSubscriptions` is populated with the actual subscription values from the Accept Blue platform, so it will not call your strategy anymore. This is to better reflect the subscription that was actually created at the time of ordering.

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-admin-resolver.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-admin-resolver.ts
@@ -4,7 +4,6 @@ import { AcceptBlueService } from '../service/accept-blue-service';
 import {
   Mutation as GraphqlMutation,
   MutationRefundAcceptBlueTransactionArgs,
-  MutationUpdateAcceptBlueSubscriptionArgs,
 } from './generated/graphql';
 
 @Resolver()
@@ -24,15 +23,5 @@ export class AcceptBlueAdminResolver {
       amount ?? undefined,
       cvv2 ?? undefined
     );
-  }
-
-  @Mutation()
-  @Allow(Permission.UpdateOrder)
-  async updateAcceptBlueSubscription(
-    @Ctx() ctx: RequestContext,
-    @Args()
-    { input }: MutationUpdateAcceptBlueSubscriptionArgs
-  ): Promise<GraphqlMutation['updateAcceptBlueSubscription']> {
-    return await this.acceptBlueService.updateSubscription(ctx, input);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/accept-blue-common-resolvers.ts
@@ -35,6 +35,7 @@ import {
   MutationDeleteAcceptBluePaymentMethodArgs,
   MutationCreateAcceptBlueCardPaymentMethodArgs,
   MutationCreateAcceptBlueCheckPaymentMethodArgs,
+  MutationUpdateAcceptBlueSubscriptionArgs,
 } from './generated/graphql';
 
 @Resolver()
@@ -236,5 +237,15 @@ export class AcceptBlueCommonResolver {
     }
     // For Shop API, we use the ctx.activeUserId
     return await this.acceptBlueService.createCheckPaymentMethod(ctx, input);
+  }
+
+  @Mutation()
+  @Allow(Permission.UpdateOrder, Permission.Authenticated)
+  async updateAcceptBlueSubscription(
+    @Ctx() ctx: RequestContext,
+    @Args()
+    { input }: MutationUpdateAcceptBlueSubscriptionArgs
+  ): Promise<GraphqlMutation['updateAcceptBlueSubscription']> {
+    return await this.acceptBlueService.updateSubscription(ctx, input);
   }
 }

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -22,6 +22,7 @@ const commonApiExtensions = gql`
     variantId: ID!
     amountDueNow: Int!
     priceIncludesTax: Boolean!
+    paymentMethodId: Int!
     recurring: AcceptBlueSubscriptionRecurringPayment!
     transactions: [AcceptBlueTransaction!]!
   }
@@ -134,26 +135,6 @@ const commonApiExtensions = gql`
     annually
   }
 
-  input UpdateAcceptBlueSubscriptionInput {
-    id: Int!
-    title: String
-    frequency: AcceptBlueFrequencyInput
-    """
-    Amount in cents to bill customer
-    """
-    amount: Int
-    nextRunDate: DateTime
-    """
-    Number of times the schedule has left to bill. Set to 0 for ongoing
-    """
-    numLeft: Int
-    active: Boolean
-    """
-    An email address to send a customer receipt to each time the schedule runs
-    """
-    receiptEmail: String
-  }
-
   enum AcceptBluePaymentMethodType {
     Visa
     MasterCard
@@ -245,6 +226,11 @@ const commonApiExtensions = gql`
 export const shopApiExtensions = gql`
   ${commonApiExtensions}
 
+  input UpdateAcceptBlueSubscriptionInput {
+    id: Int!
+    paymentMethodId: Int
+  }
+
   extend type Mutation {
     """
     Creating a card payment method is only allowed with a nonce token.
@@ -256,11 +242,38 @@ export const shopApiExtensions = gql`
     createAcceptBlueCheckPaymentMethod(
       input: CreateAcceptBlueCheckPaymentMethodInput!
     ): AcceptBlueCheckPaymentMethod!
+    """
+    Update the given subscription in Accept Blue
+    """
+    updateAcceptBlueSubscription(
+      input: UpdateAcceptBlueSubscriptionInput!
+    ): AcceptBlueSubscription!
   }
 `;
 
 export const adminApiExtensions = gql`
   ${commonApiExtensions}
+
+  input UpdateAcceptBlueSubscriptionInput {
+    id: Int!
+    title: String
+    frequency: AcceptBlueFrequencyInput
+    """
+    Amount in cents to bill customer
+    """
+    amount: Int
+    nextRunDate: DateTime
+    """
+    Number of times the schedule has left to bill. Set to 0 for ongoing
+    """
+    numLeft: Int
+    active: Boolean
+    """
+    An email address to send a customer receipt to each time the schedule runs
+    """
+    receiptEmail: String
+    paymentMethodId: Int
+  }
 
   extend type Mutation {
     """

--- a/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-accept-blue/src/api/api-extensions.ts
@@ -22,7 +22,7 @@ const commonApiExtensions = gql`
     variantId: ID!
     amountDueNow: Int!
     priceIncludesTax: Boolean!
-    paymentMethodId: Int!
+    paymentMethodId: Int
     recurring: AcceptBlueSubscriptionRecurringPayment!
     transactions: [AcceptBlueTransaction!]!
   }

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-service.ts
@@ -428,7 +428,7 @@ export class AcceptBlueService implements OnApplicationBootstrap {
     input: UpdateAcceptBlueCardPaymentMethodInput
   ): Promise<AcceptBlueCardPaymentMethod> {
     const client = await this.getClientForChannel(ctx);
-    await this.isAllowedToMutatePaymentMethod(ctx, client, input.id, 'card');
+    await this.isOwnerOfPaymentMethod(ctx, client, input.id, 'card');
     return (await client.updatePaymentMethod(input.id, {
       name: input.name || undefined,
       expiry_month: input.expiry_month ?? undefined,
@@ -443,7 +443,7 @@ export class AcceptBlueService implements OnApplicationBootstrap {
     input: UpdateAcceptBlueCheckPaymentMethodInput
   ): Promise<AcceptBlueCheckPaymentMethod> {
     const client = await this.getClientForChannel(ctx);
-    await this.isAllowedToMutatePaymentMethod(ctx, client, input.id, 'check');
+    await this.isOwnerOfPaymentMethod(ctx, client, input.id, 'check');
     return (await client.updatePaymentMethod(input.id, {
       name: input.name ?? undefined,
       routing_number: input.routing_number ?? undefined,
@@ -454,7 +454,7 @@ export class AcceptBlueService implements OnApplicationBootstrap {
 
   async deletePaymentMethod(ctx: RequestContext, id: number): Promise<boolean> {
     const client = await this.getClientForChannel(ctx);
-    await this.isAllowedToMutatePaymentMethod(ctx, client, id, false);
+    await this.isOwnerOfPaymentMethod(ctx, client, id, false);
     await client.deletePaymentMethod(id);
     return true;
   }
@@ -495,10 +495,17 @@ export class AcceptBlueService implements OnApplicationBootstrap {
     })) as AcceptBlueCheckPaymentMethod;
   }
 
+  /**
+   * Update a subscription as admin or customer.
+   *
+   * For a customer, we verify if the customer owns the schedule and the payment method.
+   * Admin permissions are checked at the resolver level.
+   */
   async updateSubscription(
     ctx: RequestContext,
     input: UpdateAcceptBlueSubscriptionInput
   ): Promise<AcceptBlueSubscription> {
+    const client = await this.getClientForChannel(ctx);
     const scheduleId = input.id;
     const orderLine = await this.findOrderLineByScheduleId(ctx, scheduleId);
     if (!orderLine) {
@@ -506,10 +513,25 @@ export class AcceptBlueService implements OnApplicationBootstrap {
         `No order exists with an Accept Blue subscription id of ${scheduleId}`
       );
     }
+    if (ctx.apiType === 'shop') {
+      // Verify ownership of schedule and payment method
+      if (input.paymentMethodId) {
+        await this.isOwnerOfPaymentMethod(
+          ctx,
+          client,
+          input.paymentMethodId,
+          false
+        );
+      }
+      const acceptBlueCustomerId = await this.getAcceptBlueCustomerId(ctx);
+      const schedule = await client.getRecurringSchedules([scheduleId]);
+      if (schedule?.[0].customer_id != acceptBlueCustomerId) {
+        throw new ForbiddenError();
+      }
+    }
     await this.entityHydrator.hydrate(ctx, orderLine, {
       relations: ['order', 'productVariant'],
     });
-    const client = await this.getClientForChannel(ctx);
     const schedule = await client.updateRecurringSchedule(scheduleId, {
       title: input.title ?? undefined,
       amount: input.amount ?? undefined,
@@ -518,6 +540,7 @@ export class AcceptBlueService implements OnApplicationBootstrap {
       num_left: input.numLeft ?? undefined,
       active: input.active ?? undefined,
       receipt_email: input.receiptEmail || undefined,
+      payment_method_id: input.paymentMethodId ?? undefined,
     });
     // Write History entry on order
     await this.orderService.addNoteToOrder(ctx, {
@@ -545,7 +568,7 @@ export class AcceptBlueService implements OnApplicationBootstrap {
    *
    * @param shouldBeOfType If false, no payment type check is performed
    */
-  private async isAllowedToMutatePaymentMethod(
+  private async isOwnerOfPaymentMethod(
     ctx: RequestContext,
     client: AcceptBlueClient,
     paymentMethodId: number,
@@ -1000,33 +1023,34 @@ export class AcceptBlueService implements OnApplicationBootstrap {
    * Map a subscription from Accept Blue to the GraphQL Subscription type
    */
   private mapToGraphqlSubscription(
-    subscription: AcceptBlueRecurringSchedule,
+    schedule: AcceptBlueRecurringSchedule,
     variantId: ID,
     transactions: AcceptBlueTransaction[] = []
   ): AcceptBlueSubscription {
     const { interval, intervalCount } = toSubscriptionInterval(
-      subscription.frequency
+      schedule.frequency
     );
     return {
-      id: subscription.id,
+      id: schedule.id,
       amountDueNow: 0,
-      name: subscription.title,
+      name: schedule.title,
       priceIncludesTax: true,
       variantId,
+      paymentMethodId: schedule.payment_method_id,
       recurring: {
-        amount: subscription.amount,
+        amount: schedule.amount,
         interval,
         intervalCount,
-        createdAt: subscription.created_at
-          ? new Date(subscription.created_at)
+        createdAt: schedule.created_at
+          ? new Date(schedule.created_at)
           : undefined,
-        nextRunDate: subscription.next_run_date
-          ? new Date(subscription.next_run_date)
+        nextRunDate: schedule.next_run_date
+          ? new Date(schedule.next_run_date)
           : undefined,
-        previousRunDate: subscription.prev_run_date
-          ? new Date(subscription.prev_run_date)
+        previousRunDate: schedule.prev_run_date
+          ? new Date(schedule.prev_run_date)
           : undefined,
-        numLeft: subscription.num_left,
+        numLeft: schedule.num_left,
       },
       transactions,
     };

--- a/packages/vendure-plugin-accept-blue/test/accept-blue.spec.ts
+++ b/packages/vendure-plugin-accept-blue/test/accept-blue.spec.ts
@@ -802,6 +802,7 @@ describe('Payment method management', () => {
       id: 14969,
       payment_method_type: 'card',
       customer_id: haydenZiemeCustomerDetails.id,
+      card_type: 'Visa',
     });
     // Mock the update payment method call
     nockInstance.patch('/payment-methods/14969').reply(200, {
@@ -864,6 +865,7 @@ describe('Payment method management', () => {
       id: 14969,
       payment_method_type: 'card',
       customer_id: 123456, // Not Hayden
+      card_type: 'Visa',
     });
     const updateRequest = shopClient.query(UPDATE_CARD_PAYMENT_METHOD, {
       input: {
@@ -904,6 +906,7 @@ describe('Payment method management', () => {
       id: 14969,
       payment_method_type: 'card',
       customer_id: haydenZiemeCustomerDetails.id,
+      card_type: 'Visa',
     });
     // Mock the update payment method call
     nockInstance.patch('/payment-methods/14969').reply(200, {
@@ -1028,6 +1031,7 @@ describe('Payment method management', () => {
       id: 14969,
       payment_method_type: 'card',
       customer_id: haydenZiemeCustomerDetails.id,
+      card_type: 'Visa',
     });
     // Mock the delete payment method call to return an error
     nockInstance.delete('/payment-methods/14969').reply(409, {
@@ -1222,6 +1226,7 @@ describe('Payment method management', () => {
       id: 456789,
       payment_method_type: 'shouldnt matter',
       customer_id: haydenZiemeCustomerDetails.id,
+      card_type: 'Visa',
     });
     nockInstance
       .persist()
@@ -1265,6 +1270,7 @@ describe('Payment method management', () => {
       id: 456789,
       payment_method_type: 'shouldnt matter',
       customer_id: 999999, // Different customer ID, not Hayden
+      card_type: 'Visa',
     });
     await shopClient.asUserWithCredentials(
       'hayden.zieme12@hotmail.com',

--- a/packages/vendure-plugin-accept-blue/test/dev-server.ts
+++ b/packages/vendure-plugin-accept-blue/test/dev-server.ts
@@ -117,6 +117,7 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
           { name: 'allowGooglePay', value: 'true' },
           { name: 'allowApplePay', value: 'true' },
           { name: 'allowVisa', value: 'true' },
+          { name: 'allowMasterCard', value: 'true' },
           {
             name: 'tokenizationSourceKey',
             value: process.env.ACCEPT_BLUE_TOKENIZATION_SOURCE_KEY ?? null,
@@ -184,10 +185,10 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
       input: {
         method: 'accept-blue',
         // metadata,
-        metadata: { paymentMethodId: 14556 }, // Use a saved payment method
+        metadata: { paymentMethodId: 14969 }, // Use a saved payment method
       },
     });
-    console.log(JSON.stringify);
+    console.log(JSON.stringify(addPaymentToOrder, null, 2));
     console.log(
       `Successfully transitioned order to ${addPaymentToOrder.state}`
     );

--- a/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/graphql-helpers.ts
@@ -319,10 +319,12 @@ export const GET_CUSTOMER_WITH_ID = gql`
 export const UPDATE_SUBSCRIPTION = gql`
   mutation UpdateSubscription($input: UpdateAcceptBlueSubscriptionInput!) {
     updateAcceptBlueSubscription(input: $input) {
+      id
       name
       variantId
       amountDueNow
       priceIncludesTax
+      paymentMethodId
       recurring {
         amount
         interval

--- a/packages/vendure-plugin-accept-blue/test/helpers/mocks.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/mocks.ts
@@ -172,11 +172,15 @@ export const haydenZiemeCustomerDetails = {
   active: true,
 };
 
-export function createMockRecurringScheduleResult(id?: number) {
+export function createMockRecurringScheduleResult(input: {
+  id?: number;
+  payment_method_id?: number;
+  customer_id?: number;
+}) {
   return {
-    id: id ?? Math.floor(Math.random() * 10000),
+    id: input.id ?? Math.floor(Math.random() * 10000),
     created_at: '2024-02-07T23:57:55.000Z',
-    customer_id: 181937,
+    customer_id: input.customer_id ?? 181937,
     title: 'Subscription Laptop 13 inch 8GB',
     frequency: 'monthly',
     amount: 129900,
@@ -186,7 +190,7 @@ export function createMockRecurringScheduleResult(id?: number) {
     num_left: 0,
     active: true,
     status: 'active',
-    payment_method_id: 15035,
+    payment_method_id: input.payment_method_id ?? 15035,
     receipt_email: 'hayden.zieme12@hotmail.com',
   };
 }


### PR DESCRIPTION
# 3.3.0 (2025-06-10)

- Enable updating payment method on a subscription via the Shop API for logged in customers
- Bug fix: Prevent updating a subscription to a payment method type (Visa, MasterCard, etc) that is not allowed. Only allow the methods set via the Admin UI.

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
