### PR TITLE
feat(address-lookup): added google palces api

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sharp": "^0.33.4",
     "ts-node": "^10.9.0",
     "typescript": "5.8.3",
-    "typescript-eslint": "^7.5.0",
+    "typescript-eslint": "^8.34.0",
     "unplugin-swc": "1.4.4",
     "vitest": "1.3.1",
     "wsdl-tsclient": "1.3.1"

--- a/packages/vendure-plugin-address-lookup/README.md
+++ b/packages/vendure-plugin-address-lookup/README.md
@@ -18,6 +18,10 @@ This Vendure plugin allows you to lookup addresses based on postalcode, housenum
           new PostNLLookupStrategy({
             apiKey: process.env.POSTNL_APIKEY!,
           }),
+                new GooglePlacesLookupStrategy({
+        supportedCountryCodes: ['DE'], // You can use the Google Places API for any country, but you need to register for an API key at https://developers.google.com/maps/documentation/places/web-service/get-api-key
+        apiKey: process.env.GOOGLE_PLACES_APIKEY!,
+      })
 
           // If you want to use the free Postcode.tech, get an API key at https://postcode.tech/ and uncomment the lines below
           // new PostcodeTechStrategy({
@@ -82,6 +86,68 @@ query {
     streetLine2
     postalCode
     city
+    country
+    countryCode
+  }
+}
+```
+
+## Google Places Strategy
+
+If you want to use the Google Places API, you can do so by registering the `GooglePlacesLookupStrategy` in your config:
+
+```ts
+import { GooglePlacesLookupStrategy } from '@pinelab/vendure-plugin-address-lookup';
+
+plugins: [
+  AddressLookupPlugin.init({
+    lookupStrategies: [
+      new GooglePlacesLookupStrategy({
+        supportedCountryCodes: ['DE'],
+        apiKey: process.env.GOOGLE_PLACES_APIKEY!,
+      }),
+    ],
+  }),
+],
+
+```
+
+The Google places API requires you to input the housenumber and streetname. It will mostly give you a single result, even when multiple results can exists.
+If that happens, you can pass the postalcode to get a specific result.
+
+```graphql
+# This example will give you 1 result: the Parkstraße 4 in Osnabrück
+{
+  lookupAddress(
+    input: { countryCode: "DE", streetName: "Parkstraße", houseNumber: "4" }
+  ) {
+    streetLine1
+    streetLine2
+    city
+    province
+    postalCode
+    country
+    countryCode
+  }
+}
+```
+
+```graphql
+# This example will give you another single result: the Parkstraße 4 in Löningen
+{
+  lookupAddress(
+    input: {
+      countryCode: "DE"
+      streetName: "Parkstraße"
+      houseNumber: "4"
+      postalCode: "49624"
+    }
+  ) {
+    streetLine1
+    streetLine2
+    city
+    province
+    postalCode
     country
     countryCode
   }

--- a/packages/vendure-plugin-address-lookup/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-address-lookup/src/api/api-extensions.ts
@@ -10,7 +10,7 @@ const _scalars = gql`
 export const shopApiExtensions = gql`
   input AddressLookupInput {
     countryCode: String!
-    postalCode: String!
+    postalCode: String
     houseNumber: String
     streetName: String
   }

--- a/packages/vendure-plugin-address-lookup/src/config/google-places-lookup-strategy.spec.ts
+++ b/packages/vendure-plugin-address-lookup/src/config/google-places-lookup-strategy.spec.ts
@@ -1,0 +1,236 @@
+import { RequestContext } from '@vendure/core';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { AddressLookupInput } from '../generated/graphql';
+import { GooglePlacesLookupStrategy } from './google-places-lookup-strategy';
+
+type MockFetch = Mock<Parameters<typeof fetch>, ReturnType<typeof fetch>>;
+
+describe('GooglePlacesLookupStrategy', () => {
+  let strategy: GooglePlacesLookupStrategy;
+  let mockFetch: MockFetch;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    strategy = new GooglePlacesLookupStrategy({
+      supportedCountryCodes: ['DE'],
+      apiKey: 'test-api-key',
+    });
+  });
+
+  it('throws error when searching with only postalcode', () => {
+    const input: AddressLookupInput = {
+      countryCode: 'DE',
+      postalCode: '1234AB',
+    };
+
+    const result = strategy.validateInput(input);
+    expect(result).toBe('House number is required for lookup');
+  });
+
+  it('searches with housenumber and streetname returns multiple results', async () => {
+    const input: AddressLookupInput = {
+      countryCode: 'DE',
+      houseNumber: '123',
+      streetName: 'Test Street',
+    };
+
+    const mockResponse = {
+      places: [
+        {
+          addressComponents: [
+            {
+              longText: '123',
+              shortText: '123',
+              types: ['street_number'],
+            },
+            {
+              longText: 'Test Street',
+              shortText: 'Test St',
+              types: ['route'],
+            },
+            {
+              longText: 'Berlin',
+              shortText: 'Berlin',
+              types: ['locality'],
+            },
+            {
+              longText: 'Berlin',
+              shortText: 'BE',
+              types: ['administrative_area_level_1'],
+            },
+            {
+              longText: 'Germany',
+              shortText: 'DE',
+              types: ['country'],
+            },
+            {
+              longText: '10115',
+              shortText: '10115',
+              types: ['postal_code'],
+            },
+          ],
+        },
+        {
+          addressComponents: [
+            {
+              longText: '123',
+              shortText: '123',
+              types: ['street_number'],
+            },
+            {
+              longText: 'Test Street',
+              shortText: 'Test St',
+              types: ['route'],
+            },
+            {
+              longText: 'Hamburg',
+              shortText: 'Hamburg',
+              types: ['locality'],
+            },
+            {
+              longText: 'Hamburg',
+              shortText: 'HH',
+              types: ['administrative_area_level_1'],
+            },
+            {
+              longText: 'Germany',
+              shortText: 'DE',
+              types: ['country'],
+            },
+            {
+              longText: '20095',
+              shortText: '20095',
+              types: ['postal_code'],
+            },
+          ],
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response);
+
+    const result = await strategy.lookup({} as RequestContext, input);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://places.googleapis.com/v1/places:searchText',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': 'test-api-key',
+          'X-Goog-FieldMask': 'places.addressComponents',
+        },
+        body: JSON.stringify({
+          textQuery: '123 Test Street',
+          regionCode: 'de',
+        }),
+      }
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      streetLine1: 'Test Street',
+      streetLine2: '123',
+      city: 'Berlin',
+      province: 'Berlin',
+      postalCode: '10115',
+      country: 'Germany',
+      countryCode: 'DE',
+    });
+    expect(result[1]).toEqual({
+      streetLine1: 'Test Street',
+      streetLine2: '123',
+      city: 'Hamburg',
+      province: 'Hamburg',
+      postalCode: '20095',
+      country: 'Germany',
+      countryCode: 'DE',
+    });
+  });
+
+  it('searches with housenumber, streetname and postalcode returns one result', async () => {
+    const input: AddressLookupInput = {
+      countryCode: 'DE',
+      houseNumber: '123',
+      streetName: 'Test Street',
+      postalCode: '10115',
+    };
+
+    const mockResponse = {
+      places: [
+        {
+          addressComponents: [
+            {
+              longText: '123',
+              shortText: '123',
+              types: ['street_number'],
+            },
+            {
+              longText: 'Test Street',
+              shortText: 'Test St',
+              types: ['route'],
+            },
+            {
+              longText: 'Berlin',
+              shortText: 'Berlin',
+              types: ['locality'],
+            },
+            {
+              longText: 'Berlin',
+              shortText: 'BE',
+              types: ['administrative_area_level_1'],
+            },
+            {
+              longText: 'Germany',
+              shortText: 'DE',
+              types: ['country'],
+            },
+            {
+              longText: '10115',
+              shortText: '10115',
+              types: ['postal_code'],
+            },
+          ],
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response);
+
+    const result = await strategy.lookup({} as RequestContext, input);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://places.googleapis.com/v1/places:searchText',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': 'test-api-key',
+          'X-Goog-FieldMask': 'places.addressComponents',
+        },
+        body: JSON.stringify({
+          textQuery: '123 Test Street, 10115',
+          regionCode: 'de',
+        }),
+      }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      streetLine1: 'Test Street',
+      streetLine2: '123',
+      city: 'Berlin',
+      province: 'Berlin',
+      postalCode: '10115',
+      country: 'Germany',
+      countryCode: 'DE',
+    });
+  });
+});

--- a/packages/vendure-plugin-address-lookup/src/config/google-places-lookup-strategy.ts
+++ b/packages/vendure-plugin-address-lookup/src/config/google-places-lookup-strategy.ts
@@ -1,0 +1,113 @@
+import { OrderAddress } from '@vendure/common/lib/generated-types';
+import { RequestContext } from '@vendure/core';
+import { AddressLookupInput } from '../generated/graphql';
+import { AddressLookupStrategy } from '../types';
+
+interface GooglePlacesResponse {
+  places: Array<{
+    addressComponents: Array<{
+      longText: string;
+      shortText: string;
+      types: Array<
+        | 'street_number'
+        | 'route'
+        | 'sublocality_level_1'
+        | 'sublocality'
+        | 'political'
+        | 'locality'
+        | 'administrative_area_level_3'
+        | 'administrative_area_level_1'
+        | 'country'
+        | 'postal_code'
+      >;
+    }>;
+  }>;
+}
+
+interface GooglePlacesStrategyInput {
+  supportedCountryCodes: string[];
+  apiKey: string;
+}
+
+/**
+ * This strategy is used to lookup addresses via Google Places API
+ *
+ * It requires street name and housenumber to do a good lookup. Optionally a city can be supplied
+ */
+export class GooglePlacesLookupStrategy implements AddressLookupStrategy {
+  readonly supportedCountryCodes: string[];
+
+  constructor(private readonly input: GooglePlacesStrategyInput) {
+    this.supportedCountryCodes = input.supportedCountryCodes;
+  }
+
+  validateInput(input: AddressLookupInput): true | string {
+    if (!input.houseNumber) {
+      return 'House number is required for lookup';
+    }
+    if (!input.streetName) {
+      return 'Street name is required for lookup';
+    }
+    return true;
+  }
+
+  async lookup(
+    ctx: RequestContext,
+    input: AddressLookupInput
+  ): Promise<OrderAddress[]> {
+    let query = `${input.houseNumber} ${input.streetName}`;
+    if (input.postalCode) {
+      query += `, ${input.postalCode}`;
+    }
+    const result = await fetch(
+      'https://places.googleapis.com/v1/places:searchText',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': this.input.apiKey,
+          'X-Goog-FieldMask': 'places.addressComponents',
+        },
+        body: JSON.stringify({
+          textQuery: query,
+          regionCode: input.countryCode?.toLowerCase(),
+        }),
+      }
+    );
+    if (!result.ok) {
+      throw new Error(
+        `Google Places API returned status ${result.status}: ${result.statusText}`
+      );
+    }
+    const jsonResult = (await result.json()) as GooglePlacesResponse;
+    return (jsonResult.places ?? []).map((place) => {
+      const streetNumber = place.addressComponents.find((comp) =>
+        comp.types.includes('street_number')
+      )?.longText;
+      const route = place.addressComponents.find((comp) =>
+        comp.types.includes('route')
+      )?.longText;
+      const city = place.addressComponents.find((comp) =>
+        comp.types.includes('locality')
+      )?.longText;
+      const province = place.addressComponents.find((comp) =>
+        comp.types.includes('administrative_area_level_1')
+      )?.longText;
+      const postalCode = place.addressComponents.find((comp) =>
+        comp.types.includes('postal_code')
+      )?.longText;
+      const country = place.addressComponents.find((comp) =>
+        comp.types.includes('country')
+      );
+      return {
+        streetLine1: route,
+        streetLine2: streetNumber,
+        city: city,
+        province: province,
+        postalCode: postalCode,
+        country: country?.longText,
+        countryCode: country?.shortText || input.countryCode,
+      };
+    });
+  }
+}

--- a/packages/vendure-plugin-address-lookup/src/config/post-nl-lookup-strategy.ts
+++ b/packages/vendure-plugin-address-lookup/src/config/post-nl-lookup-strategy.ts
@@ -27,7 +27,7 @@ interface PostNLLookupStrategyInput {
 export class PostNLLookupStrategy implements AddressLookupStrategy {
   readonly supportedCountryCodes = ['NL', 'BE'];
 
-  constructor(private readonly input: PostNLLookupStrategyInput) { }
+  constructor(private readonly input: PostNLLookupStrategyInput) {}
 
   validateInput(input: AddressLookupInput): true | string {
     const countryCode = input.countryCode.toLowerCase();
@@ -44,7 +44,7 @@ export class PostNLLookupStrategy implements AddressLookupStrategy {
     input: AddressLookupInput
   ): Promise<OrderAddress[]> {
     const countryCode = input.countryCode.toLowerCase();
-    const postalCode = normalizePostalCode(input.postalCode);
+    const postalCode = normalizePostalCode(input.postalCode!);
     const { houseNumber, addition } = this.parseHouseNumber(input.houseNumber!);
     let url = `https://api.postnl.nl/v2/address/benelux?countryIso=${countryCode}&houseNumber=${houseNumber}&postalCode=${postalCode}`;
     if (input.streetName) {
@@ -71,7 +71,9 @@ export class PostNLLookupStrategy implements AddressLookupStrategy {
       fullName: '',
       company: '',
       streetLine1: result.streetName,
-      streetLine2: result.houseNumberAddition ? `${result.houseNumber} ${result.houseNumberAddition}` : result.houseNumber,
+      streetLine2: result.houseNumberAddition
+        ? `${result.houseNumber} ${result.houseNumberAddition}`
+        : result.houseNumber,
       city: result.cityName,
       province: result.stateName,
       postalCode,
@@ -88,6 +90,9 @@ export class PostNLLookupStrategy implements AddressLookupStrategy {
   private validateBEPostalCode(input: AddressLookupInput): true | string {
     const countryCode = input.countryCode;
     const postalCode = input.postalCode;
+    if (!postalCode) {
+      return 'Postal code is required for lookup';
+    }
     if (postalCode.length !== 4) {
       return `Postal code for '${countryCode}' code must be 4 numbers`;
     }

--- a/packages/vendure-plugin-address-lookup/src/config/postcode-tech-strategy.ts
+++ b/packages/vendure-plugin-address-lookup/src/config/postcode-tech-strategy.ts
@@ -40,7 +40,7 @@ export class PostcodeTechStrategy implements AddressLookupStrategy {
     ctx: RequestContext,
     input: AddressLookupInput
   ): Promise<OrderAddress[]> {
-    const postalCode = normalizePostalCode(input.postalCode);
+    const postalCode = normalizePostalCode(input.postalCode!);
     const result = await fetch(
       `https://postcode.tech/api/v1/postcode/full?postcode=${postalCode}&number=${input.houseNumber}`,
       {

--- a/packages/vendure-plugin-address-lookup/src/config/validation-util.ts
+++ b/packages/vendure-plugin-address-lookup/src/config/validation-util.ts
@@ -3,6 +3,9 @@ import { AddressLookupInput } from '../generated/graphql';
 export function validateDutchPostalCode(
   input: AddressLookupInput
 ): true | string {
+  if (!input.postalCode) {
+    return 'Postal code is required for lookup';
+  }
   const postalCode = normalizePostalCode(input.postalCode);
   if (postalCode.length !== 6) {
     return 'Postal code must be 4 numbers and 2 letters';

--- a/packages/vendure-plugin-address-lookup/src/index.ts
+++ b/packages/vendure-plugin-address-lookup/src/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './generated/graphql';
 export * from './config/post-nl-lookup-strategy';
 export * from './config/postcode-tech-strategy';
+export * from './config/google-places-lookup-strategy';

--- a/packages/vendure-plugin-address-lookup/test/dev-server.ts
+++ b/packages/vendure-plugin-address-lookup/test/dev-server.ts
@@ -13,8 +13,11 @@ import {
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
 import { initialData } from '../../test/src/initial-data';
 import { AddressLookupPlugin } from '../src/address-lookup.plugin';
-import { PostNLLookupStrategy } from '../src';
-import { PostcodeTechStrategy } from '../src/config/postcode-tech-strategy';
+import {
+  GooglePlacesLookupStrategy,
+  PostNLLookupStrategy,
+  PostcodeTechStrategy,
+} from '../src';
 
 require('dotenv').config();
 
@@ -33,6 +36,10 @@ require('dotenv').config();
           }),
           new PostcodeTechStrategy({
             apiKey: process.env.POSTCODE_TECH_APIKEY!,
+          }),
+          new GooglePlacesLookupStrategy({
+            apiKey: process.env.GOOGLE_PLACES_APIKEY!,
+            supportedCountryCodes: ['DE'],
           }),
         ],
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2509,12 +2509,19 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz#7fc114af5f6563f19f73324b5d5ff36ece0803d1"
   integrity sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==
 
-"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
+"@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/eslint-utils@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz#607084630c6c033992a082de6e6fbc1a8b52175a"
+  integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
 
 "@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.6.1":
   version "4.10.1"
@@ -6568,86 +6575,102 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz"
-  integrity sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==
+"@typescript-eslint/eslint-plugin@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.0.tgz#96c9f818782fe24cd5883a5d517ca1826d3fa9c2"
+  integrity sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "7.13.1"
-    "@typescript-eslint/type-utils" "7.13.1"
-    "@typescript-eslint/utils" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/scope-manager" "8.34.0"
+    "@typescript-eslint/type-utils" "8.34.0"
+    "@typescript-eslint/utils" "8.34.0"
+    "@typescript-eslint/visitor-keys" "8.34.0"
     graphemer "^1.4.0"
-    ignore "^5.3.1"
+    ignore "^7.0.0"
     natural-compare "^1.4.0"
-    ts-api-utils "^1.3.0"
+    ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz"
-  integrity sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==
+"@typescript-eslint/parser@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.34.0.tgz#703270426ac529304ae6988482f487c856d9c13f"
+  integrity sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==
   dependencies:
-    "@typescript-eslint/scope-manager" "7.13.1"
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/typescript-estree" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/scope-manager" "8.34.0"
+    "@typescript-eslint/types" "8.34.0"
+    "@typescript-eslint/typescript-estree" "8.34.0"
+    "@typescript-eslint/visitor-keys" "8.34.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz"
-  integrity sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==
+"@typescript-eslint/project-service@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.34.0.tgz#449119b72fe9fae185013a6bdbaf1ffbfee6bcaf"
+  integrity sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
-
-"@typescript-eslint/type-utils@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz"
-  integrity sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "7.13.1"
-    "@typescript-eslint/utils" "7.13.1"
+    "@typescript-eslint/tsconfig-utils" "^8.34.0"
+    "@typescript-eslint/types" "^8.34.0"
     debug "^4.3.4"
-    ts-api-utils "^1.3.0"
 
-"@typescript-eslint/types@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz"
-  integrity sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==
-
-"@typescript-eslint/typescript-estree@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz"
-  integrity sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==
+"@typescript-eslint/scope-manager@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.34.0.tgz#9fedaec02370cf79c018a656ab402eb00dc69e67"
+  integrity sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/types" "8.34.0"
+    "@typescript-eslint/visitor-keys" "8.34.0"
+
+"@typescript-eslint/tsconfig-utils@8.34.0", "@typescript-eslint/tsconfig-utils@^8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.0.tgz#97d0a24e89a355e9308cebc8e23f255669bf0979"
+  integrity sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==
+
+"@typescript-eslint/type-utils@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.34.0.tgz#03e7eb3776129dfd751ba1cac0c6ea4b0fab5ec6"
+  integrity sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "8.34.0"
+    "@typescript-eslint/utils" "8.34.0"
     debug "^4.3.4"
-    globby "^11.1.0"
+    ts-api-utils "^2.1.0"
+
+"@typescript-eslint/types@8.34.0", "@typescript-eslint/types@^8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.34.0.tgz#18000f205c59c9aff7f371fc5426b764cf2890fb"
+  integrity sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA==
+
+"@typescript-eslint/typescript-estree@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.0.tgz#c9f3feec511339ef64e9e4884516c3e558f1b048"
+  integrity sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==
+  dependencies:
+    "@typescript-eslint/project-service" "8.34.0"
+    "@typescript-eslint/tsconfig-utils" "8.34.0"
+    "@typescript-eslint/types" "8.34.0"
+    "@typescript-eslint/visitor-keys" "8.34.0"
+    debug "^4.3.4"
+    fast-glob "^3.3.2"
     is-glob "^4.0.3"
     minimatch "^9.0.4"
     semver "^7.6.0"
-    ts-api-utils "^1.3.0"
+    ts-api-utils "^2.1.0"
 
-"@typescript-eslint/utils@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz"
-  integrity sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==
+"@typescript-eslint/utils@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.34.0.tgz#7844beebc1153b4d3ec34135c2da53a91e076f8d"
+  integrity sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ==
   dependencies:
-    "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "7.13.1"
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/typescript-estree" "7.13.1"
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/scope-manager" "8.34.0"
+    "@typescript-eslint/types" "8.34.0"
+    "@typescript-eslint/typescript-estree" "8.34.0"
 
-"@typescript-eslint/visitor-keys@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz"
-  integrity sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==
+"@typescript-eslint/visitor-keys@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.0.tgz#c7a149407be31d755dba71980617d638a40ac099"
+  integrity sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    eslint-visitor-keys "^3.4.3"
+    "@typescript-eslint/types" "8.34.0"
+    eslint-visitor-keys "^4.2.0"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
@@ -10495,6 +10518,11 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
+  integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
+
 eslint@^8.57.0:
   version "8.57.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz"
@@ -11586,7 +11614,7 @@ globals@^13.19.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.2, globby@^11.0.3, globby@^11.1.0:
+globby@^11.0.2, globby@^11.0.3:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -12216,12 +12244,12 @@ ignore-walk@^7.0.0:
   dependencies:
     minimatch "^9.0.0"
 
-ignore@^5.0.4, ignore@^5.2.0, ignore@^5.3.1:
+ignore@^5.0.4, ignore@^5.2.0:
   version "5.3.1"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
-ignore@^7.0.3:
+ignore@^7.0.0, ignore@^7.0.3:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
@@ -18724,10 +18752,10 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-ts-api-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz"
-  integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+ts-api-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
+  integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
 ts-invariant@^0.10.3:
   version "0.10.3"
@@ -18966,14 +18994,14 @@ typeorm@^0.3.21:
     uuid "^11.1.0"
     yargs "^17.7.2"
 
-typescript-eslint@^7.5.0:
-  version "7.13.1"
-  resolved "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.1.tgz"
-  integrity sha512-pvLEuRs8iS9s3Cnp/Wt//hpK8nKc8hVa3cLljHqzaJJQYP8oys8GUyIFqtlev+2lT/fqMPcyQko+HJ6iYK3nFA==
+typescript-eslint@^8.34.0:
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.34.0.tgz#5bc7e405cd0ed5d6f28d86017519700b77ca1298"
+  integrity sha512-MRpfN7uYjTrTGigFCt8sRyNqJFhjN0WwZecldaqhWm+wy0gaRt8Edb/3cuUy0zdq2opJWT6iXINKAtewnDOltQ==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "7.13.1"
-    "@typescript-eslint/parser" "7.13.1"
-    "@typescript-eslint/utils" "7.13.1"
+    "@typescript-eslint/eslint-plugin" "8.34.0"
+    "@typescript-eslint/parser" "8.34.0"
+    "@typescript-eslint/utils" "8.34.0"
 
 typescript@4.6.2:
   version "4.6.2"


### PR DESCRIPTION
# 1.2.0 (2025-06-11)

- Added Google Places API strategy for global address lookup
- BREAKING: Input `postalCode` is now optional

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
