### PR TITLE
Create pull request for version bump

### DIFF
--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.2 (2025-12-17)
+
+- Version bump
+
 # 2.1.1 (2025-06-24)
 
 - Improved error logging when incoming webhooks fail

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",


### PR DESCRIPTION
The GoedGepickt plugin's version was incremented by one patch.

*   The `version` field in `packages/vendure-plugin-goedgepickt/package.json` was updated from `2.1.1` to `2.1.2`.
*   A new entry for version `2.1.2` was added to `packages/vendure-plugin-goedgepickt/CHANGELOG.md`, including a "Version bump" note.
*   These changes were committed with the message "chore: bump GoedGepickt plugin version to 2.1.2".
*   A new branch, `cursor/create-pull-request-for-version-bump-fb7a`, was created and pushed, preparing the changes for a pull request.