### PR TITLE
feat(metrics): detect mobile via regex

### DIFF
--- a/packages/vendure-plugin-metrics/CHANGELOG.md
+++ b/packages/vendure-plugin-metrics/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.0 (2025-07-02)
+
+- Removed `device-detector-js` dependency and replaced with regex
+
 # 2.2.0 (2025-06-04)
 
 - Upgrade to Vendure to 3.3.2

--- a/packages/vendure-plugin-metrics/CHANGELOG.md
+++ b/packages/vendure-plugin-metrics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.3.0 (2025-07-02)
 
-- Removed `device-detector-js` dependency and replaced with regex
+- Removed `device-detector-js` dependency and replaced with regex from https://stackoverflow.com/questions/11381673/detecting-a-mobile-browser
 
 # 2.2.0 (2025-06-04)
 

--- a/packages/vendure-plugin-metrics/package.json
+++ b/packages/vendure-plugin-metrics/package.json
@@ -42,8 +42,7 @@
   "dependencies": {
     "catch-unknown": "^2.0.0",
     "chartist-plugin-tooltips-updated": "^1.0.0",
-    "date-fns": "^2.29.3",
-    "device-detector-js": "^3.0.3"
+    "date-fns": "^2.29.3"
   },
   "gitHead": "476f36da3aafea41fbf21c70774a30306f1d238f"
 }

--- a/packages/vendure-plugin-metrics/package.json
+++ b/packages/vendure-plugin-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-metrics",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Vendure plugin measuring and visualizing e-commerce metrics",
   "keywords": [
     "vendure",

--- a/packages/vendure-plugin-metrics/src/metrics/sessions-metric.ts
+++ b/packages/vendure-plugin-metrics/src/metrics/sessions-metric.ts
@@ -20,11 +20,6 @@ export class SessionsMetric implements MetricStrategy {
     orders: Order[],
     sessions: Session[] = []
   ): NamedDatapoint[] {
-    const deviceTypeCounts: { [deviceType: string]: number } = {};
-    sessions.forEach((session) => {
-      const deviceType = session.deviceType || 'Unknown';
-      deviceTypeCounts[deviceType] = (deviceTypeCounts[deviceType] || 0) + 1;
-    });
     const totalSessions = sessions.length;
     const dataPoints: NamedDatapoint[] = [
       {
@@ -32,30 +27,14 @@ export class SessionsMetric implements MetricStrategy {
         value: totalSessions,
       },
       {
-        legendLabel: 'Unknown',
-        value: sessions.filter(
-          ({ deviceType }) => !deviceType || deviceType === 'Unknown'
-        ).length,
-      },
-      {
         legendLabel: 'Mobile',
         value: sessions.filter(({ deviceType }) => deviceType === 'mobile')
           .length,
       },
       {
-        legendLabel: 'Desktop',
-        value: sessions.filter(({ deviceType }) => deviceType === 'desktop')
-          .length,
-      },
-      {
         legendLabel: 'Other',
-        value: sessions.filter(
-          ({ deviceType }) =>
-            deviceType &&
-            deviceType !== 'mobile' &&
-            deviceType !== 'desktop' &&
-            deviceType !== 'Unknown'
-        ).length,
+        value: sessions.filter(({ deviceType }) => deviceType === 'other')
+          .length,
       },
     ];
     return dataPoints;

--- a/packages/vendure-plugin-metrics/src/services/request-service.ts
+++ b/packages/vendure-plugin-metrics/src/services/request-service.ts
@@ -15,7 +15,7 @@ import { asError } from 'catch-unknown';
 import crypto, { createHash } from 'crypto';
 import { addMonths, differenceInHours } from 'date-fns';
 import { DataSource } from 'typeorm';
-import DeviceDetector from 'device-detector-js';
+
 import { loggerCtx, PLUGIN_INIT_OPTIONS } from '../constants';
 import { MetricRequestSalt } from '../entities/metric-request-salt';
 import { MetricRequest } from '../entities/metric-request.entity';
@@ -133,7 +133,7 @@ export class RequestService implements OnModuleInit, OnApplicationBootstrap {
       const device = this.extractDeviceInfo(request.userAgent);
       const entity = new MetricRequest();
       entity.identifier = hash;
-      entity.deviceType = device || 'Unknown';
+      entity.deviceType = device;
       entity.channelId = request.channelId;
       entity.path = request.path;
       entity.productId = request.productId;
@@ -253,9 +253,18 @@ export class RequestService implements OnModuleInit, OnApplicationBootstrap {
   /**
    * Extracts basic device information from user agent string
    */
-  private extractDeviceInfo(userAgent: string): string {
-    const deviceDetector = new DeviceDetector();
-    const parsed = deviceDetector.parse(userAgent);
-    return parsed.device?.type || 'Unknown';
+  extractDeviceInfo(userAgent: string): 'mobile' | 'other' {
+    const ua = userAgent.toLowerCase();
+    if (
+      /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(
+        ua
+      ) ||
+      /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
+        ua.substring(0, 4)
+      )
+    ) {
+      return 'mobile';
+    }
+    return 'other';
   }
 }

--- a/packages/vendure-plugin-metrics/test/metrics-e2e.spec.ts
+++ b/packages/vendure-plugin-metrics/test/metrics-e2e.spec.ts
@@ -214,6 +214,20 @@ describe('Metrics', () => {
     });
   });
 
+  it('Extracts device info from user agent', () => {
+    const requestService = server.app.get(RequestService);
+    expect(
+      requestService.extractDeviceInfo(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36'
+      )
+    ).toEqual('other');
+    expect(
+      requestService.extractDeviceInfo(
+        'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36'
+      )
+    ).toEqual('mobile');
+  });
+
   if (process.env.TEST_ADMIN_UI) {
     it('Should compile admin', async () => {
       const files = await getFilesInAdminUiFolder(__dirname, MetricsPlugin.ui);


### PR DESCRIPTION
# 2.3.0 (2025-07-02)

- Removed `device-detector-js` dependency and replaced with regex from https://stackoverflow.com/questions/11381673/detecting-a-mobile-browser

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
