### PR TITLE
Fix duplicate Stripe subscription on webhook retries

### DIFF
--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.9.1 (2025-07-07)
+
+- skip intent processing in handleIntentSucceeded if order is already PaymentSettled
+
 # 2.9.0 (2025-06-04)
 
 - Upgrade to Vendure to 3.3.2

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",


### PR DESCRIPTION
# Description
- Skip intent processing in handleIntentSucceeded if the order is already in PaymentSettled state

# Breaking Changes
None

# Reason
- There was no check before creating the stripe subscription to see if the order was already settled. sometimes the order is already settled, but the API responds with an error. Stripe retries the request and ends up creating another subscription. after that, when the code tries to settle the payment (which is already done), it throws an error. This check should have happened before creating the subscription to avoid these issues.

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
