### PR TITLE
fix(invoices,frequently-bought-together): removed vendure hub license check

### DIFF
--- a/packages/vendure-plugin-frequently-bought-together/CHANGELOG.md
+++ b/packages/vendure-plugin-frequently-bought-together/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.1 (2025-09-15)
+
+- Removed license check completely, also removed the dependency on @vendure-hub/vendure-hub-plugin
+
 # 1.2.0 (2025-06-04)
 
 - Upgrade to Vendure to 3.3.2

--- a/packages/vendure-plugin-frequently-bought-together/package.json
+++ b/packages/vendure-plugin-frequently-bought-together/package.json
@@ -32,7 +32,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@vendure-hub/vendure-hub-plugin": "^0.0.2",
     "catch-unknown": "^2.0.0",
     "node-fpgrowth": "^1.2.1"
   }

--- a/packages/vendure-plugin-frequently-bought-together/src/frequently-bought-together.plugin.ts
+++ b/packages/vendure-plugin-frequently-bought-together/src/frequently-bought-together.plugin.ts
@@ -1,6 +1,5 @@
 import {
   LanguageCode,
-  Logger,
   PluginCommonModule,
   Product,
   Type,
@@ -8,22 +7,13 @@ import {
 } from '@vendure/core';
 import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
 
-import {
-  FREQUENTLY_BOUGHT_TOGETHER_PLUGIN_OPTIONS,
-  loggerCtx,
-} from './constants';
-import { FrequentlyBoughtTogetherService } from './services/frequently-bought-together.service';
-import { PluginInitOptions } from './types';
 import path from 'path';
 import { adminApiExtensions, shopApiExtensions } from './api/api-extensions';
 import { FrequentlyBoughtTogetherAdminResolver } from './api/frequently-bought-together-admin.resolver';
-import { OnApplicationBootstrap } from '@nestjs/common';
-import {
-  LicenseService,
-  VendureHubPlugin,
-} from '@vendure-hub/vendure-hub-plugin';
-import { asError } from 'catch-unknown';
 import { FrequentlyBoughtTogetherShopResolver } from './api/frequently-bought-together-shop.resolver';
+import { FREQUENTLY_BOUGHT_TOGETHER_PLUGIN_OPTIONS } from './constants';
+import { FrequentlyBoughtTogetherService } from './services/frequently-bought-together.service';
+import { PluginInitOptions } from './types';
 
 export type FrequentlyBoughtTogetherPluginOptions = Partial<
   Omit<PluginInitOptions, 'hasValidLicense'>
@@ -36,7 +26,7 @@ export type FrequentlyBoughtTogetherPluginOptions = Partial<
  * @category Plugin
  */
 @VendurePlugin({
-  imports: [PluginCommonModule, VendureHubPlugin],
+  imports: [PluginCommonModule],
   providers: [
     {
       provide: FREQUENTLY_BOUGHT_TOGETHER_PLUGIN_OPTIONS,
@@ -87,7 +77,7 @@ export type FrequentlyBoughtTogetherPluginOptions = Partial<
     resolvers: [FrequentlyBoughtTogetherShopResolver],
   },
 })
-export class FrequentlyBoughtTogetherPlugin implements OnApplicationBootstrap {
+export class FrequentlyBoughtTogetherPlugin {
   static options: PluginInitOptions = {
     licenseKey: '',
     customFieldUiTab: 'Related products',
@@ -96,36 +86,6 @@ export class FrequentlyBoughtTogetherPlugin implements OnApplicationBootstrap {
     maxRelatedProducts: 10,
     hasValidLicense: false,
   };
-
-  constructor(private licenseService: LicenseService) {}
-
-  onApplicationBootstrap() {
-    this.licenseService
-      .checkLicenseKey(
-        FrequentlyBoughtTogetherPlugin.options.licenseKey,
-        '@vendure-hub/pinelab-frequently-bought-together-plugin'
-      )
-      .then((result) => {
-        if (!result.valid) {
-          Logger.error(
-            `Your license key is invalid. Make sure to obtain a valid license key from the Vendure Hub if you want to keep using this plugin.`,
-            loggerCtx
-          );
-          FrequentlyBoughtTogetherPlugin.options.hasValidLicense = false;
-        } else {
-          FrequentlyBoughtTogetherPlugin.options.hasValidLicense = true;
-        }
-      })
-      .catch((err) => {
-        Logger.error(
-          `Error checking license key: ${
-            asError(err).message
-          }. Some functionality might be disabled`,
-          loggerCtx
-        );
-        FrequentlyBoughtTogetherPlugin.options.hasValidLicense = false;
-      });
-  }
 
   static init(
     options: FrequentlyBoughtTogetherPluginOptions

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.4.2 (2025-09-15)
+
+- Removed license check completely, also removed the dependency on @vendure-hub/vendure-hub-plugin
+
 # 4.4.1 (2025-07-31)
 
 - Disabled license check, because Vendure license server is offline

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -26,7 +26,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@vendure-hub/vendure-hub-plugin": "^0.0.2",
     "adm-zip": "0.5.9",
     "puppeteer": "23.1.0",
     "tmp": "0.2.1"

--- a/packages/vendure-plugin-invoices/src/api/invoice-admin.resolver.ts
+++ b/packages/vendure-plugin-invoices/src/api/invoice-admin.resolver.ts
@@ -37,7 +37,6 @@ export class InvoiceAdminResolver {
     @Ctx() ctx: RequestContext,
     @Args('invoiceNumber') invoiceNumber: number
   ): Promise<boolean> {
-    this.invoiceService.throwIfInvalidLicense();
     await this.accountingService.exportInvoiceToAccountingPlatform(
       ctx,
       invoiceNumber
@@ -52,7 +51,6 @@ export class InvoiceAdminResolver {
     @Ctx() ctx: RequestContext,
     @Args('input') input: InvoiceConfigInput
   ): Promise<InvoiceConfigEntity> {
-    this.invoiceService.throwIfInvalidLicense();
     return this.invoiceService.upsertConfig(ctx, input);
   }
 
@@ -98,7 +96,6 @@ export class InvoiceAdminResolver {
   async invoiceConfig(
     @Ctx() ctx: RequestContext
   ): Promise<InvoiceConfigEntity | undefined> {
-    this.invoiceService.throwIfInvalidLicense();
     return this.invoiceService.getConfig(ctx);
   }
 
@@ -108,7 +105,6 @@ export class InvoiceAdminResolver {
     @Ctx() ctx: RequestContext,
     @Args() args: QueryInvoicesArgs
   ): Promise<PaginatedList<Invoice>> {
-    this.invoiceService.throwIfInvalidLicense();
     return this.invoiceService.findAll(ctx, args.options || undefined);
   }
 }

--- a/packages/vendure-plugin-invoices/src/invoice.plugin.ts
+++ b/packages/vendure-plugin-invoices/src/invoice.plugin.ts
@@ -1,3 +1,5 @@
+import { OnModuleInit } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import {
   Injector,
   Logger,
@@ -6,8 +8,6 @@ import {
   Type,
   VendurePlugin,
 } from '@vendure/core';
-import { OnApplicationBootstrap, OnModuleInit } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import { AdminUiExtension } from '@vendure/ui-devkit/compiler';
 import path from 'path';
 import {
@@ -20,19 +20,15 @@ import {
   invoicePermission,
 } from './api/invoice-common.resolver';
 import { InvoiceController } from './api/invoice.controller';
-import { defaultLoadDataFn, LoadDataFn } from './strategies/load-data-fn';
-import { LocalFileStrategy } from './strategies/storage/local-file-strategy';
-import { PLUGIN_INIT_OPTIONS, loggerCtx } from './constants';
+import { loggerCtx, PLUGIN_INIT_OPTIONS } from './constants';
 import { InvoiceConfigEntity } from './entities/invoice-config.entity';
 import { InvoiceEntity } from './entities/invoice.entity';
-import { StorageStrategy } from './strategies/storage/storage-strategy';
-import { InvoiceService } from './services/invoice.service';
-import {
-  LicenseService,
-  VendureHubPlugin,
-} from '@vendure-hub/vendure-hub-plugin';
-import { AccountingExportStrategy } from './strategies/accounting/accounting-export-strategy';
 import { AccountingService } from './services/accounting.service';
+import { InvoiceService } from './services/invoice.service';
+import { AccountingExportStrategy } from './strategies/accounting/accounting-export-strategy';
+import { defaultLoadDataFn, LoadDataFn } from './strategies/load-data-fn';
+import { LocalFileStrategy } from './strategies/storage/local-file-strategy';
+import { StorageStrategy } from './strategies/storage/storage-strategy';
 
 export interface InvoicePluginConfigInput {
   /**
@@ -74,7 +70,7 @@ export interface InvoicePluginConfig extends InvoicePluginConfigInput {
  * Vendure plugin to generate PDF invoices for orders.
  */
 @VendurePlugin({
-  imports: [PluginCommonModule, VendureHubPlugin],
+  imports: [PluginCommonModule],
   entities: [InvoiceConfigEntity, InvoiceEntity],
   providers: [
     InvoiceService,
@@ -96,13 +92,10 @@ export interface InvoicePluginConfig extends InvoicePluginConfigInput {
     return config;
   },
 })
-export class InvoicePlugin implements OnApplicationBootstrap, OnModuleInit {
+export class InvoicePlugin implements OnModuleInit {
   static config: InvoicePluginConfig;
 
-  constructor(
-    private licenseService: LicenseService,
-    private moduleRef: ModuleRef
-  ) {}
+  constructor(private moduleRef: ModuleRef) {}
 
   async onModuleInit(): Promise<void> {
     // Initialize accounting export strategies, if they define an init function
@@ -123,33 +116,6 @@ export class InvoicePlugin implements OnApplicationBootstrap, OnModuleInit {
         loggerCtx
       );
     }
-  }
-
-  onApplicationBootstrap(): void {
-    this.licenseService
-      .checkLicenseKey(
-        InvoicePlugin.config.licenseKey,
-        '@vendure-hub/pinelab-invoice-plugin'
-      )
-      .then((result) => {
-        if (!result.valid) {
-          Logger.error(
-            `Your license key is invalid. Make sure to obtain a valid license key from the Vendure Hub if you want to keep using this plugin. Viewing invoices is disabled. Invoice generation will continue as usual.`,
-            loggerCtx
-          );
-          InvoicePlugin.config.hasValidLicense = false;
-        } else {
-          InvoicePlugin.config.hasValidLicense = true;
-        }
-      })
-      .catch((err) => {
-        Logger.error(
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          `Error checking license key: ${err?.message}. Viewing invoices is disabled. Invoice generation will continue as usual.`,
-          loggerCtx
-        );
-        InvoicePlugin.config.hasValidLicense = false;
-      });
   }
 
   static init(config: InvoicePluginConfigInput): Type<InvoicePlugin> {

--- a/packages/vendure-plugin-invoices/src/services/invoice.service.ts
+++ b/packages/vendure-plugin-invoices/src/services/invoice.service.ts
@@ -808,20 +808,6 @@ export class InvoiceService implements OnModuleInit, OnApplicationBootstrap {
     return !!result?.enabled;
   }
 
-  throwIfInvalidLicense(): void {
-    if (this.config.hasValidLicense) {
-      return;
-    }
-    const message = `Invalid license key. Viewing invoices is disabled. Invoice generation will continue as usual.`;
-    Logger.error(message, loggerCtx);
-    if (process.env.NODE_ENV === 'test') {
-      // Only log in test, don't throw
-      return;
-    }
-    // FIXME Disabled because Vendure license server is offline
-    // throw Error(message);
-  }
-
   /**
    * Creates a new invoice row in the database, so we can be sure that we have reserved the given invoiceNumber.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6684,13 +6684,6 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vendure-hub/vendure-hub-plugin@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.vendure.io/@vendure-hub/vendure-hub-plugin/-/vendure-hub-plugin-0.0.2.tgz"
-  integrity sha512-SmZ/HiQlVWkcVEErinW5MJIBHp9VCjH8F31Iyyynta1/kusD6h1m8KLCxeUFEvmuAMfzSOERMMqfNqMtpJ1UVA==
-  dependencies:
-    node-fetch "^2.6.1"
-
 "@vendure/admin-ui-plugin@3.3.2":
   version "3.3.2"
   resolved "https://registry.npmjs.org/@vendure/admin-ui-plugin/-/admin-ui-plugin-3.3.2.tgz"


### PR DESCRIPTION
# Description

Removed the license check from paid plugins. Too much hassle with keeping the Auth token up to date, which causes builds to fail, which blocks plugin publishing.

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
