### PR TITLE
feat(accept-blue): using amount due now, and delete created subscriptions on failure

### DIFF
--- a/packages/util/src/subscription/subscription-helper.ts
+++ b/packages/util/src/subscription/subscription-helper.ts
@@ -112,17 +112,6 @@ export class SubscriptionHelper {
       })
     );
     const flattenedSubscriptionsArray = subscriptions.flat();
-    // Validate recurring amount
-    flattenedSubscriptionsArray.forEach((subscription) => {
-      if (
-        !subscription.recurring.amount ||
-        subscription.recurring.amount <= 0
-      ) {
-        throw Error(
-          `[${this.loggerCtx}]: Defined subscription for order line ${subscription.variantId} must have a recurring amount greater than 0`
-        );
-      }
-    });
     return flattenedSubscriptionsArray;
   }
 

--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.5.0 (2025-09-18)
+
+- Breaking: `amountDueNow` was not actually being used to calculate the line price! If you used `variant.price` in your subscription strategy, or used the default subscription strategy, everything still works as expected.
+- Allow subscriptions with `amount=0`
+- Delete created subscriptions if the one-time charge fails after that.
+
 # 3.4.0 (2025-08-18)
 
 - Store payment metadata for declined transactions. Create recurring schedule after successful charge.

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",

--- a/packages/vendure-plugin-accept-blue/src/accept-blue-plugin.ts
+++ b/packages/vendure-plugin-accept-blue/src/accept-blue-plugin.ts
@@ -9,6 +9,7 @@ import { AcceptBlueController } from './api/accept-blue-controller';
 import { DefaultSubscriptionStrategy } from '../../util/src/subscription/default-subscription-strategy';
 import { rawBodyMiddleware } from '../../util/src/raw-body.middleware';
 import { AcceptBlueAdminResolver } from './api/accept-blue-admin-resolver';
+import { SubscriptionOrderItemCalculation } from './service/subscription-order-item-calculation';
 
 interface AcceptBluePluginOptionsInput {
   subscriptionStrategy?: SubscriptionStrategy;
@@ -55,6 +56,9 @@ export type AcceptBluePluginOptions = Required<AcceptBluePluginOptionsInput>;
       readonly: true,
       type: 'int',
     });
+    // Set the order item price calculation strategy, so that order line price is the price of the calculation
+    config.orderOptions.orderItemPriceCalculationStrategy =
+      new SubscriptionOrderItemCalculation();
     return config;
   },
   compatibility: '>=3.2.0',

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
@@ -366,6 +366,11 @@ export class AcceptBlueClient {
     return result;
   }
 
+  async deleteRecurringSchedule(scheduleId: number): Promise<void> {
+    await this.request('delete', `recurring-schedules/${scheduleId}`);
+    Logger.info(`Deleted recurring schedule ${scheduleId}`, loggerCtx);
+  }
+
   /**
    * Only supports charge with saved payment method id
    */

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-service.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-service.ts
@@ -237,7 +237,7 @@ export class AcceptBlueService implements OnApplicationBootstrap {
       client,
       paymentMethod.id
     );
-    // Create charge transaction if
+    // Create charge transaction if amount is greater than 0
     let chargeTransaction: AcceptBlueChargeTransaction | undefined;
     if (amount > 0) {
       const subscriptionOrderLines =

--- a/packages/vendure-plugin-accept-blue/src/service/subscription-order-item-calculation.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/subscription-order-item-calculation.ts
@@ -1,0 +1,68 @@
+import {
+  Injector,
+  Order,
+  OrderItemPriceCalculationStrategy,
+  PriceCalculationResult,
+  ProductVariant,
+  RequestContext,
+} from '@vendure/core';
+import { DefaultOrderItemPriceCalculationStrategy } from '@vendure/core/dist/config/order/default-order-item-price-calculation-strategy';
+import { CustomOrderLineFields } from '@vendure/core/dist/entity/custom-entity-fields';
+import { AcceptBlueService } from './accept-blue-service';
+
+let injector: Injector;
+
+export class SubscriptionOrderItemCalculation
+  extends DefaultOrderItemPriceCalculationStrategy
+  implements OrderItemPriceCalculationStrategy
+{
+  init(_injector: Injector): void | Promise<void> {
+    injector = _injector;
+  }
+
+  // @ts-expect-error - Our strategy takes more arguments than the super class. These arguments are coming from the interface, so this is valid
+  async calculateUnitPrice(
+    ctx: RequestContext,
+    productVariant: ProductVariant,
+    orderLineCustomFields: CustomOrderLineFields,
+    order: Order,
+    orderLineQuantity: number
+  ): Promise<PriceCalculationResult> {
+    const subscriptionService = injector.get(AcceptBlueService);
+    if (!subscriptionService) {
+      throw new Error('Subscription service not initialized');
+    }
+    if (
+      !(await subscriptionService.subscriptionHelper.isSubscription(
+        ctx,
+        productVariant
+      ))
+    ) {
+      return super.calculateUnitPrice(ctx, productVariant);
+    }
+    const subscription =
+      await subscriptionService.subscriptionHelper.defineSubscription(
+        ctx,
+        productVariant,
+        order,
+        orderLineCustomFields,
+        orderLineQuantity
+      );
+    if (!Array.isArray(subscription)) {
+      return {
+        priceIncludesTax: subscription.priceIncludesTax,
+        price: subscription.amountDueNow ?? 0,
+      };
+    }
+    if (!subscription.length) {
+      throw Error(
+        `Subscription strategy returned an empty array. Must contain at least 1 subscription`
+      );
+    }
+    const total = subscription.reduce((acc, sub) => acc + sub.amountDueNow, 0);
+    return {
+      priceIncludesTax: subscription[0].priceIncludesTax,
+      price: total,
+    };
+  }
+}

--- a/packages/vendure-plugin-accept-blue/test/helpers/test-subscription-strategy.ts
+++ b/packages/vendure-plugin-accept-blue/test/helpers/test-subscription-strategy.ts
@@ -36,9 +36,9 @@ export class TestSubscriptionStrategy implements SubscriptionStrategy {
     return {
       name: `Test Subscription ${productVariant.name}`,
       priceIncludesTax: true,
-      amountDueNow: 0,
+      amountDueNow: productVariant.priceWithTax,
       recurring: {
-        amount: 4567, // 12.34 per week, starting tomorrow
+        amount: 0,
         interval: 'week',
         intervalCount: 1,
         startDate: this.getTomorrow(),

--- a/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
+++ b/packages/vendure-plugin-stripe-subscription/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.9.2 (2025-09-19)
+
+- Don't throw errors for subscription with $0 amount.
+
 # 2.9.1 (2025-07-07)
 
 - skip intent processing in handleIntentSucceeded if order is already PaymentSettled

--- a/packages/vendure-plugin-stripe-subscription/package.json
+++ b/packages/vendure-plugin-stripe-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stripe-subscription",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Vendure plugin for selling subscriptions via Stripe",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab-plugins.com/",


### PR DESCRIPTION
# 3.5.0 (2025-09-18)

- Breaking: `amountDueNow` was not actually being used to calculate the line price! If you used `variant.price` in your subscription strategy, or used the default subscription strategy, everything still works as expected.
- Allow subscriptions with `amount=0`
- Delete created subscriptions if the one-time charge fails after that.

# Checklist

📌 Always:
- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:
- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:
- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`
