### PR TITLE
fix: prefix delivery options with tag key

### DIFF
--- a/packages/vendure-plugin-qls-fulfillment/src/types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/types.ts
@@ -93,7 +93,7 @@ export type AdditionalVariantFields = Partial<
 
 export interface AdditionalOrderFields {
   servicepoint_code?: string;
-  delivery_options?: string[];
+  delivery_options?: { tag: string }[]; // Not consistent with the Redoc docs but matches the actual API
   custom_values?: CustomValue[];
 }
 


### PR DESCRIPTION
Fixes the delivery options. Not consistent with the QLS Redoc but it was communicated to implement it like this by QLS IT support