### PR TITLE
feat(accept-blue): V3.7.0 additional charge input

### DIFF
--- a/packages/vendure-plugin-accept-blue/CHANGELOG.md
+++ b/packages/vendure-plugin-accept-blue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.7.0 (2026-01-06)
+
+- Allow passing additional input when creating a charge via the `additionalChargeInput` option.
+- Use parent `order` instead of `orderLine.order` in `getSubscriptionsForOrderLine` to prevent hydration issues.
+
 # 3.6.2 (2025-11-13)
 
 - Documentation update

--- a/packages/vendure-plugin-accept-blue/README.md
+++ b/packages/vendure-plugin-accept-blue/README.md
@@ -370,3 +370,57 @@ mutation {
 Make sure that your amount equals the amount of the order! The amount is passed in as whole amount, not in cents, because this is how you will receive it from Google.
 
 You can configure the Merchant ID and Gateway Merchant ID on the payment method in Vendure, and fetch them via `eligiblePaymentMethods` or `eligibleAcceptBluePaymentMethods`.
+
+## Additional Charge Input
+
+For the initial charge, you can pass additional input to the charge creation. This is useful if you want to add additional information to the charge, such as tax, surcharges,shipping information, etc.
+
+In your plugin initialization, you can pass a function that returns the additional input:
+
+```ts
+AcceptBluePlugin.init({
+  additionalChargeInput: async (ctx, injector, order) => {
+    // Here you can construct the additional input based on the order and the context
+    // See https://docs.accept.blue/api/v2#tag/processing-charges for the fields available
+    return {
+      amount_details: {
+        surcharge: 1,
+      },
+      transaction_details: {
+        description: 'Test description',
+      },
+      billing_info: {
+        first_name: 'John',
+        last_name: 'Doe',
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        country: 'US',
+        phone: '1234567890',
+      },
+      shipping_info: {
+        first_name: 'John',
+        last_name: 'Doe',
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        country: 'US',
+        phone: '1234567890',
+      },
+      line_items: [
+        {
+          sku: '1234567890',
+          name: 'Test item',
+          description: 'Test description',
+          cost: 100,
+          quantity: 1,
+          tax_rate: 0.1,
+          tax_amount: 10,
+        },
+      ],
+    };
+  },
+});
+```

--- a/packages/vendure-plugin-accept-blue/package.json
+++ b/packages/vendure-plugin-accept-blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-accept-blue",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Vendure plugin for creating subscriptions with the Accept Blue platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
@@ -18,6 +18,7 @@ import {
   AcceptBlueTransaction,
   AcceptBlueWebhook,
   AcceptBlueWebhookInput,
+  AdditionalChargeInput,
   AllowedPaymentMethodInput,
   AppleOrGooglePayInput,
   CheckPaymentMethodInput,
@@ -380,7 +381,8 @@ export class AcceptBlueClient {
      */
     paymentMethodId: number,
     amountInCents: number,
-    customFields: CustomFields
+    customFields: CustomFields,
+    additionalChargeInput?: AdditionalChargeInput
   ): Promise<AcceptBlueChargeTransaction> {
     const amount = amountInCents / 100;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -388,6 +390,7 @@ export class AcceptBlueClient {
       source: `pm-${paymentMethodId}`,
       amount,
       custom_fields: customFields,
+      ...(additionalChargeInput ? additionalChargeInput : {}),
     });
     if (
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -415,7 +418,8 @@ export class AcceptBlueClient {
    */
   async createDigitalWalletCharge(
     input: AppleOrGooglePayInput,
-    customFields: CustomFields
+    customFields: CustomFields,
+    additionalChargeInput?: AdditionalChargeInput
   ): Promise<AcceptBlueChargeTransaction> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const result = await this.request('post', `transactions/charge`, {
@@ -425,6 +429,7 @@ export class AcceptBlueClient {
       avs_zip: input.avs_zip,
       avs_address: input.avs_address,
       custom_fields: customFields,
+      ...(additionalChargeInput ? additionalChargeInput : {}),
     });
     if (
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/packages/vendure-plugin-accept-blue/src/types.ts
+++ b/packages/vendure-plugin-accept-blue/src/types.ts
@@ -75,15 +75,53 @@ interface TransactionDetails {
   schedule_id: number;
 }
 
-export interface AcceptBlueAmountInput {
+export interface AdditionalChargeInput {
+  amount_details?: AcceptBlueAmountDetailsInput;
+  transaction_details?: AcceptBlueTransactionDetailsInput;
+  billing_info?: Partial<AcceptBlueAddress>;
+  shipping_info?: Partial<AcceptBlueAddress>;
+  line_items?: AcceptBlueLineItemInput[];
+}
+
+export interface AcceptBlueAmountDetailsInput {
+  tax?: number;
+  surcharge?: number;
+  shipping?: number;
+  tip?: number;
+  discount?: number;
+}
+
+export interface AcceptBlueTransactionDetailsInput {
+  description?: string;
+  clerk?: string;
+  terminal?: string;
+  client_ip?: string;
+  signature?: string;
+  invoice_number?: string;
+  po_number?: string;
+  order_number?: string;
+}
+
+export interface AcceptBlueLineItemInput {
+  sku?: string;
+  name?: string;
+  description?: string;
+  cost?: number;
+  quantity?: number;
+  tax_rate?: number;
+  tax_amount?: number;
+  unit_of_measure?: string;
+  commodity_code?: string;
+  discount_rate?: number;
+  discount_amount?: number;
+}
+
+export interface AcceptBlueAmountDetails {
   tax: number;
   surcharge: number;
   shipping: number;
   tip: number;
   discount: number;
-}
-
-export interface AcceptBlueAmountDetails extends AcceptBlueAmountInput {
   amount: number;
   subtotal: number;
   original_requested_amount: number;

--- a/packages/vendure-plugin-accept-blue/test/dev-server.ts
+++ b/packages/vendure-plugin-accept-blue/test/dev-server.ts
@@ -79,6 +79,49 @@ import { testPaymentMethod } from '../../test/src/test-payment-method';
           'https://webhook.site/cdef50e0-0e6d-4e23-a4b1-6ffc9ca89df8',
         subscriptionStrategy: new TestSubscriptionStrategy(),
         sendReceiptEmail: false,
+        additionalChargeInput: async (ctx, injector, order) => {
+          // Here you can construct the additional input based on the order and the context
+          // See https://docs.accept.blue/api/v2#tag/processing-charges for the fields available
+          return {
+            amount_details: {
+              surcharge: 1,
+            },
+            transaction_details: {
+              description: 'Test description',
+            },
+            billing_info: {
+              first_name: 'John',
+              last_name: 'Doe',
+              street: '123 Main St',
+              city: 'Anytown',
+              state: 'CA',
+              zip: '12345',
+              country: 'US',
+              phone: '1234567890',
+            },
+            shipping_info: {
+              first_name: 'John',
+              last_name: 'Doe',
+              street: '123 Main St',
+              city: 'Anytown',
+              state: 'CA',
+              zip: '12345',
+              country: 'US',
+              phone: '1234567890',
+            },
+            line_items: [
+              {
+                sku: '1234567890',
+                name: 'Test item',
+                description: 'Test description',
+                cost: 100,
+                quantity: 1,
+                tax_rate: 0.1,
+                tax_amount: 10,
+              },
+            ],
+          };
+        },
       }),
       DefaultSearchPlugin,
       AdminUiPlugin.init({


### PR DESCRIPTION
# 3.7.0 (2026-01-06)

- Allow passing additional input when creating a charge via the `additionalChargeInput` option.
- Use parent `order` instead of `orderLine.order` in `getSubscriptionsForOrderLine` to prevent hydration issues.

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`
