### PR TITLE
feat(qls-fulfillment): fetch QLS raw product data after upsert and add QlsVariantSyncSucceededEvent

### DIFF
--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.1 (2026-04-21)
+
+- Fetch QLS raw product data on upsert and save in read-only field
+
 # 1.7.0 (2026-03-15)
 
 - Pass order phone number to QLS

--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.7.1 (2026-04-21)
+# 1.8.0 (2026-04-21)
 
 - Fetch QLS raw product data on upsert and save in read-only field
 

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
@@ -11,6 +11,7 @@ import {
 declare module '@vendure/core' {
   interface CustomProductVariantFields {
     qlsProductId?: string;
+    qlsRawProductData?: string;
   }
 
   interface CustomOrderFields {
@@ -28,6 +29,15 @@ export function getVariantCustomFields(
       name: 'qlsProductId',
       type: 'string',
       label: [{ value: 'QLS Product ID', languageCode: LanguageCode.en }],
+      nullable: true,
+      public: false,
+      readonly: true,
+      ui: { tab: uiTab },
+    },
+    {
+      name: 'qlsRawProductData',
+      type: 'string',
+      label: [{ value: 'QLS Raw Product Data', languageCode: LanguageCode.en }],
       nullable: true,
       public: false,
       readonly: true,

--- a/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
@@ -36,7 +36,7 @@ export function getVariantCustomFields(
     },
     {
       name: 'qlsRawProductData',
-      type: 'string',
+      type: 'text',
       label: [{ value: 'QLS Raw Product Data', languageCode: LanguageCode.en }],
       nullable: true,
       public: false,

--- a/packages/vendure-plugin-qls-fulfillment/src/index.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/index.ts
@@ -7,5 +7,4 @@ export * from './qls-plugin';
 export * from './services/qls-order.service';
 export * from './services/qls-product.service';
 export * from './config/permissions';
-export * from './services/qls-variant-sync-failed-event';
 export * from './types';

--- a/packages/vendure-plugin-qls-fulfillment/src/index.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/index.ts
@@ -7,4 +7,5 @@ export * from './qls-plugin';
 export * from './services/qls-order.service';
 export * from './services/qls-product.service';
 export * from './config/permissions';
+export * from './services/qls-variant-sync-failed-event';
 export * from './types';

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -123,7 +123,9 @@ export class QlsClient {
       }
     } catch (e) {
       Logger.warn(
-        `Failed to fetch product '${response.data.id}' after creation: ${e}`,
+        `Failed to fetch product '${response.data.id}' after creation: ${String(
+          e
+        )}`,
         loggerCtx
       );
     }
@@ -134,7 +136,7 @@ export class QlsClient {
     fulfillmentProductId: string,
     data: FulfillmentProductInput
   ): Promise<FulfillmentProduct | undefined> {
-    const response = await this.rawRequest<FulfillmentProduct>(
+    await this.rawRequest<FulfillmentProduct>(
       'PUT',
       `fulfillment/products/${fulfillmentProductId}`,
       data
@@ -148,7 +150,9 @@ export class QlsClient {
       }
     } catch (e) {
       Logger.warn(
-        `Failed to fetch product '${fulfillmentProductId}' after update: ${e}`,
+        `Failed to fetch product '${fulfillmentProductId}' after update: ${String(
+          e
+        )}`,
         loggerCtx
       );
     }

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -57,6 +57,23 @@ export class QlsClient {
   }
 
   /**
+   * Get a fulfillment product by its ID.
+   * Returns undefined if no product is found.
+   */
+  async getFulfillmentProductById(
+    fulfillmentProductId: string
+  ): Promise<FulfillmentProduct | undefined> {
+    const result = await this.rawRequest<FulfillmentProduct>(
+      'GET',
+      `fulfillment/products/${fulfillmentProductId}`
+    );
+    if (!result.data) {
+      return undefined;
+    }
+    return result.data;
+  }
+
+  /**
    * Get stock for all fulfillment products.
    * Might require multiple requests if the result is paginated.
    */
@@ -97,18 +114,30 @@ export class QlsClient {
         'Failed to create fulfillment product. Got empty response.'
       );
     }
-    return response.data;
+    const productData = await this.getFulfillmentProductById(response.data.id);
+    if (!productData) {
+      throw new Error('Failed to retrieve fulfillment product after creation.');
+    }
+    return productData;
   }
 
   async updateFulfillmentProduct(
     fulfillmentProductId: string,
     data: FulfillmentProductInput
-  ): Promise<void> {
+  ): Promise<FulfillmentProduct> {
     await this.rawRequest<FulfillmentProduct>(
       'PUT',
       `fulfillment/products/${fulfillmentProductId}`,
       data
     );
+
+    const productData = await this.getFulfillmentProductById(
+      fulfillmentProductId
+    );
+    if (!productData) {
+      throw new Error('Failed to retrieve fulfillment product after update.');
+    }
+    return productData;
   }
 
   async deleteFulfillmentProduct(fulfillmentProductId: string): Promise<void> {

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -128,6 +128,7 @@ export class QlsClient {
         )}`,
         loggerCtx
       );
+      return response.data;
     }
     return undefined;
   }

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -103,7 +103,7 @@ export class QlsClient {
 
   async createFulfillmentProduct(
     data: FulfillmentProductInput
-  ): Promise<FulfillmentProduct> {
+  ): Promise<FulfillmentProduct | undefined> {
     const response = await this.rawRequest<FulfillmentProduct>(
       'POST',
       'fulfillment/products',
@@ -114,30 +114,45 @@ export class QlsClient {
         'Failed to create fulfillment product. Got empty response.'
       );
     }
-    const productData = await this.getFulfillmentProductById(response.data.id);
-    if (!productData) {
-      throw new Error('Failed to retrieve fulfillment product after creation.');
+    try {
+      const productData = await this.getFulfillmentProductById(
+        response.data.id
+      );
+      if (productData) {
+        return productData;
+      }
+    } catch (e) {
+      Logger.warn(
+        `Failed to fetch product '${response.data.id}' after creation: ${e}`,
+        loggerCtx
+      );
     }
-    return productData;
+    return undefined;
   }
 
   async updateFulfillmentProduct(
     fulfillmentProductId: string,
     data: FulfillmentProductInput
-  ): Promise<FulfillmentProduct> {
-    await this.rawRequest<FulfillmentProduct>(
+  ): Promise<FulfillmentProduct | undefined> {
+    const response = await this.rawRequest<FulfillmentProduct>(
       'PUT',
       `fulfillment/products/${fulfillmentProductId}`,
       data
     );
-
-    const productData = await this.getFulfillmentProductById(
-      fulfillmentProductId
-    );
-    if (!productData) {
-      throw new Error('Failed to retrieve fulfillment product after update.');
+    try {
+      const productData = await this.getFulfillmentProductById(
+        fulfillmentProductId
+      );
+      if (productData) {
+        return productData;
+      }
+    } catch (e) {
+      Logger.warn(
+        `Failed to fetch product '${fulfillmentProductId}' after update: ${e}`,
+        loggerCtx
+      );
     }
-    return productData;
+    return undefined;
   }
 
   async deleteFulfillmentProduct(fulfillmentProductId: string): Promise<void> {

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -451,7 +451,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         sku: variant.sku,
         ...additionalVariantFields,
       });
-      qlsProduct = result;
+      qlsProduct = result ?? null;
       Logger.info(`Created product '${variant.sku}' in QLS`, loggerCtx);
       createdOrUpdated = 'created';
     } else if (
@@ -461,11 +461,12 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         additionalVariantFields
       )
     ) {
-      qlsProduct = await client.updateFulfillmentProduct(existingProduct.id, {
-        sku: variant.sku,
-        name: variant.name,
-        ...additionalVariantFields,
-      });
+      qlsProduct =
+        (await client.updateFulfillmentProduct(existingProduct.id, {
+          sku: variant.sku,
+          name: variant.name,
+          ...additionalVariantFields,
+        })) ?? null;
       Logger.info(`Updated product '${variant.sku}' in QLS`, loggerCtx);
       createdOrUpdated = 'updated';
     }

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -461,7 +461,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         additionalVariantFields
       )
     ) {
-      await client.updateFulfillmentProduct(existingProduct.id, {
+      qlsProduct = await client.updateFulfillmentProduct(existingProduct.id, {
         sku: variant.sku,
         name: variant.name,
         ...additionalVariantFields,
@@ -476,10 +476,15 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         .getRepository(ctx, ProductVariant)
         .update(
           { id: variant.id },
-          { customFields: { qlsProductId: qlsProduct.id } }
+          {
+            customFields: {
+              qlsProductId: qlsProduct.id,
+              qlsRawProductData: JSON.stringify(qlsProduct),
+            },
+          }
         );
       Logger.info(
-        `Set QLS product ID for variant '${variant.sku}' to ${qlsProduct.id}`,
+        `Set QLS product data for variant '${variant.sku}' to ${qlsProduct.id}`,
         loggerCtx
       );
     }

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -472,17 +472,15 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
     if (qlsProduct && qlsProduct?.id !== variant.customFields.qlsProductId) {
       // Update variant with QLS product ID if it changed
       // Do not use variantService.update because it will trigger a change event and cause an infinite loop
-      await this.connection
-        .getRepository(ctx, ProductVariant)
-        .update(
-          { id: variant.id },
-          {
-            customFields: {
-              qlsProductId: qlsProduct.id,
-              qlsRawProductData: JSON.stringify(qlsProduct),
-            },
-          }
-        );
+      await this.connection.getRepository(ctx, ProductVariant).update(
+        { id: variant.id },
+        {
+          customFields: {
+            qlsProductId: qlsProduct.id,
+            qlsRawProductData: JSON.stringify(qlsProduct),
+          },
+        }
+      );
       Logger.info(
         `Set QLS product data for variant '${variant.sku}' to ${qlsProduct.id}`,
         loggerCtx


### PR DESCRIPTION
# Description

This PR adds the following to the QLS fulfillment plugin:

- Fetches raw QLS product data after upsert and stores it on custom fields.

# To do before merge

- [ ] N/A

# Screenshots

N/A

# Checklist

📌 Always:

- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:

- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:

- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`