### PR TITLE
feat(qls-fulfillment): configurable saveRawWarehouseStockData option

### DIFF
--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.0 (2026-04-21)
+
+- Added configurable `saveRawWarehouseStockData` option
+
 # 1.7.0 (2026-03-15)
 
 - Pass order phone number to QLS

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
@@ -11,6 +11,7 @@ import {
 declare module '@vendure/core' {
   interface CustomProductVariantFields {
     qlsProductId?: string;
+    qlsRawWarehouseStockData?: string;
   }
 
   interface CustomOrderFields {
@@ -28,6 +29,20 @@ export function getVariantCustomFields(
       name: 'qlsProductId',
       type: 'string',
       label: [{ value: 'QLS Product ID', languageCode: LanguageCode.en }],
+      nullable: true,
+      public: false,
+      readonly: true,
+      ui: { tab: uiTab },
+    },
+    {
+      name: 'qlsRawWarehouseStockData',
+      type: 'text',
+      label: [
+        {
+          value: 'QLS Raw Warehouse Stock Data',
+          languageCode: LanguageCode.en,
+        },
+      ],
       nullable: true,
       public: false,
       readonly: true,

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/client-types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/client-types.ts
@@ -72,6 +72,7 @@ export type FulfillmentProduct = {
    * All EANs of the product, including the main EAN
    */
   barcodes_and_ean: string[];
+  warehouse_stocks?: unknown[];
 };
 
 export interface FulfillmentOrderInput {

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -56,6 +56,19 @@ export class QlsClient {
     return result.data[0];
   }
 
+  async getFulfillmentProductById(
+    fulfillmentProductId: string
+  ): Promise<FulfillmentProduct | undefined> {
+    const result = await this.rawRequest<FulfillmentProduct>(
+      'GET',
+      `fulfillment/products/${fulfillmentProductId}`
+    );
+    if (!result.data) {
+      return undefined;
+    }
+    return result.data;
+  }
+
   /**
    * Get stock for all fulfillment products.
    * Might require multiple requests if the result is paginated.

--- a/packages/vendure-plugin-qls-fulfillment/src/qls-plugin.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/qls-plugin.ts
@@ -55,6 +55,7 @@ export class QlsPlugin {
       synchronizeStockLevels: true,
       autoPushOrders: true,
       qlsProductIdUiTab: 'QLS',
+      saveRawWarehouseStockData: false,
       ...options,
     };
     return QlsPlugin;

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -183,12 +183,12 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
             variant,
             existingQlsProduct ?? null
           );
-          if (result === 'created') {
+          if (result.status === 'created') {
             createdQlsProducts.push(variant);
-          } else if (result === 'updated') {
+          } else if (result.status === 'updated') {
             updatedQlsProducts.push(variant);
           }
-          if (result === 'created' || result === 'updated') {
+          if (result.status === 'created' || result.status === 'updated') {
             // Wait only if we created or updated a product, otherwise no calls have been made yet.
             await waitToPreventRateLimit();
           }
@@ -316,10 +316,34 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
           variant,
           existingQlsProduct ?? null
         );
-        if (result === 'created') {
+        if (result.status === 'created') {
           createdInQls.push(variant);
-        } else if (result === 'updated') {
+        } else if (result.status === 'updated') {
           updatedInQls.push(variant);
+        }
+        if (result.qlsProductId && this.options.saveRawWarehouseStockData) {
+          const qlsProduct = await client.getFulfillmentProductById(
+            result.qlsProductId
+          );
+          // Update QLS warehouse stock data in Vendure, only on sync variants to prevent rate limit issues, and only if the option is enabled
+          if (
+            qlsProduct &&
+            qlsProduct.warehouse_stocks &&
+            this.options.saveRawWarehouseStockData
+          ) {
+            await this.connection
+              .getRepository(ctx, ProductVariant)
+              .update(
+                { id: variant.id },
+                {
+                  customFields: {
+                    qlsRawWarehouseStockData: JSON.stringify(
+                      qlsProduct.warehouse_stocks
+                    ),
+                  },
+                }
+              );
+          }
         }
       } catch (e) {
         const error = asError(e);
@@ -340,19 +364,6 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
       updatedStock: [],
       failed,
     };
-  }
-
-  /**
-   * Trigger a full product sync job
-   */
-  async triggerFullSync(ctx: RequestContext) {
-    return this.productJobQueue.add(
-      {
-        action: 'full-sync-products',
-        ctx: ctx.serialize(),
-      },
-      { retries: 5 }
-    );
   }
 
   /**
@@ -412,7 +423,10 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
     client: QlsClient,
     variant: ProductVariant,
     existingProduct: FulfillmentProduct | null
-  ): Promise<'created' | 'updated' | 'not-changed'> {
+  ): Promise<{
+    status: 'created' | 'updated' | 'not-changed';
+    qlsProductId?: string;
+  }> {
     if (
       await this.options.excludeVariantFromSync?.(
         ctx,
@@ -424,7 +438,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         `Variant '${variant.sku}' excluded from sync to QLS.`,
         loggerCtx
       );
-      return 'not-changed';
+      return { status: 'not-changed' };
     }
     if (!variant.enabled || !variant.product?.enabled) {
       const disabledEntity = !variant.enabled ? 'Variant' : 'Product';
@@ -439,7 +453,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
           loggerCtx
         );
       }
-      return 'not-changed';
+      return { status: 'not-changed', qlsProductId: existingProduct?.id };
     }
     let qlsProduct = existingProduct;
     let createdOrUpdated: 'created' | 'updated' | 'not-changed' = 'not-changed';
@@ -501,7 +515,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         loggerCtx
       );
     }
-    return createdOrUpdated;
+    return { status: createdOrUpdated, qlsProductId: qlsProduct?.id };
   }
 
   /**

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -331,18 +331,16 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
             qlsProduct.warehouse_stocks &&
             this.options.saveRawWarehouseStockData
           ) {
-            await this.connection
-              .getRepository(ctx, ProductVariant)
-              .update(
-                { id: variant.id },
-                {
-                  customFields: {
-                    qlsRawWarehouseStockData: JSON.stringify(
-                      qlsProduct.warehouse_stocks
-                    ),
-                  },
-                }
-              );
+            await this.connection.getRepository(ctx, ProductVariant).update(
+              { id: variant.id },
+              {
+                customFields: {
+                  qlsRawWarehouseStockData: JSON.stringify(
+                    qlsProduct.warehouse_stocks
+                  ),
+                },
+              }
+            );
           }
         }
       } catch (e) {

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -326,11 +326,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
             result.qlsProductId
           );
           // Update QLS warehouse stock data in Vendure, only on sync variants to prevent rate limit issues, and only if the option is enabled
-          if (
-            qlsProduct &&
-            qlsProduct.warehouse_stocks &&
-            this.options.saveRawWarehouseStockData
-          ) {
+          if (qlsProduct && qlsProduct.warehouse_stocks) {
             await this.connection.getRepository(ctx, ProductVariant).update(
               { id: variant.id },
               {

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -361,6 +361,19 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
   }
 
   /**
+   * Trigger a full product sync job
+   */
+  async triggerFullSync(ctx: RequestContext) {
+    return this.productJobQueue.add(
+      {
+        action: 'full-sync-products',
+        ctx: ctx.serialize(),
+      },
+      { retries: 5 }
+    );
+  }
+
+  /**
    * Trigger a product sync job for particular product variants
    */
   async triggerSyncVariants(ctx: RequestContext, productVariantIds: ID[]) {

--- a/packages/vendure-plugin-qls-fulfillment/src/types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/types.ts
@@ -90,6 +90,12 @@ export interface QlsPluginOptions {
    */
   qlsProductIdUiTab?: string | null;
   /**
+   * After syncing a variant to QLS, fetch the full product from QLS and save
+   * the raw warehouse stock data in the `qlsRawWarehouseStockData` custom field.
+   * Defaults to false.
+   */
+  saveRawWarehouseStockData?: boolean;
+  /**
    * Additional order items to add to the QLS order.
    */
   addAdditionalOrderItems?: (


### PR DESCRIPTION
# Description

This PR adds a configurable `saveRawWarehouseStockData` option to the QLS fulfillment plugin. When enabled, after syncing a variant to QLS, the plugin fetches the full product from QLS and saves the raw warehouse stock data in the `qlsRawWarehouseStockData` custom field on the product variant. Defaults to `false`.

Also includes:
- `createOrUpdateProductInQls` now returns the QLS product ID alongside the status.

# To do before merge

- [ ] Verify the option works as expected in a test environment

# Breaking changes

None. The new option defaults to `false`, preserving existing behavior.

# Checklist

📌 Always:

- [ ] Set a clear title
- [ ] I have checked my own PR

👍 Most of the time:

- [ ] Added or updated test cases
- [ ] Updated the README

📦 For publishable packages:

- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`