### PR TITLE
feat(qls): replace saveRawWarehouseStockData with saveAdditionalData hook

### DIFF
--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.1 (2026-04-24)
+
+- Replaced `saveRawWarehouseStockData` boolean with `saveAdditionalData` hook, allowing you to handle and persist any QLS product data yourself
+
 # 1.8.0 (2026-04-21)
 
 - Added configurable `saveRawWarehouseStockData` option

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/custom-fields.ts
@@ -34,20 +34,6 @@ export function getVariantCustomFields(
       readonly: true,
       ui: { tab: uiTab },
     },
-    {
-      name: 'qlsRawWarehouseStockData',
-      type: 'text',
-      label: [
-        {
-          value: 'QLS Raw Warehouse Stock Data',
-          languageCode: LanguageCode.en,
-        },
-      ],
-      nullable: true,
-      public: false,
-      readonly: true,
-      ui: { tab: uiTab },
-    },
   ];
 }
 

--- a/packages/vendure-plugin-qls-fulfillment/src/qls-plugin.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/qls-plugin.ts
@@ -55,7 +55,6 @@ export class QlsPlugin {
       synchronizeStockLevels: true,
       autoPushOrders: true,
       qlsProductIdUiTab: 'QLS',
-      saveRawWarehouseStockData: false,
       ...options,
     };
     return QlsPlugin;

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -192,6 +192,27 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
             // Wait only if we created or updated a product, otherwise no calls have been made yet.
             await waitToPreventRateLimit();
           }
+          if (result.qlsProductId && this.options.saveAdditionalData) {
+            try {
+              const qlsProduct = await client.getFulfillmentProductById(
+                result.qlsProductId
+              );
+              if (qlsProduct) {
+                await this.options.saveAdditionalData(
+                  ctx,
+                  new Injector(this.moduleRef),
+                  qlsProduct
+                );
+              }
+            } catch (e) {
+              Logger.error(
+                `Error in saveAdditionalData for variant '${variant.sku}': ${
+                  asError(e).message
+                }`,
+                loggerCtx
+              );
+            }
+          }
         } catch (e) {
           const error = asError(e);
           Logger.error(
@@ -321,21 +342,24 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         } else if (result.status === 'updated') {
           updatedInQls.push(variant);
         }
-        if (result.qlsProductId && this.options.saveRawWarehouseStockData) {
-          const qlsProduct = await client.getFulfillmentProductById(
-            result.qlsProductId
-          );
-          // Update QLS warehouse stock data in Vendure, only on sync variants to prevent rate limit issues, and only if the option is enabled
-          if (qlsProduct && qlsProduct.warehouse_stocks) {
-            await this.connection.getRepository(ctx, ProductVariant).update(
-              { id: variant.id },
-              {
-                customFields: {
-                  qlsRawWarehouseStockData: JSON.stringify(
-                    qlsProduct.warehouse_stocks
-                  ),
-                },
-              }
+        if (result.qlsProductId && this.options.saveAdditionalData) {
+          try {
+            const qlsProduct = await client.getFulfillmentProductById(
+              result.qlsProductId
+            );
+            if (qlsProduct) {
+              await this.options.saveAdditionalData(
+                ctx,
+                new Injector(this.moduleRef),
+                qlsProduct
+              );
+            }
+          } catch (e) {
+            Logger.error(
+              `Error in saveAdditionalData for variant '${variant.sku}': ${
+                asError(e).message
+              }`,
+              loggerCtx
             );
           }
         }

--- a/packages/vendure-plugin-qls-fulfillment/src/types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/types.ts
@@ -10,6 +10,7 @@ import {
   CustomValue,
   FulfillmentOrderInput,
   FulfillmentOrderLineInput,
+  FulfillmentProduct,
   FulfillmentProductInput,
 } from './lib/client-types';
 
@@ -90,11 +91,16 @@ export interface QlsPluginOptions {
    */
   qlsProductIdUiTab?: string | null;
   /**
-   * After syncing a variant to QLS, fetch the full product from QLS and save
-   * the raw warehouse stock data in the `qlsRawWarehouseStockData` custom field.
-   * Defaults to false.
+   * Optional hook called after syncing a variant to QLS.
+   * Receives the full QLS product, a RequestContext, and an Injector, allowing
+   * you to save any additional data to your own database. The saving itself
+   * happens inside this hook — if not provided, nothing is persisted.
    */
-  saveRawWarehouseStockData?: boolean;
+  saveAdditionalData?: (
+    ctx: RequestContext,
+    injector: Injector,
+    qlsProduct: FulfillmentProduct
+  ) => Promise<void> | void;
   /**
    * Additional order items to add to the QLS order.
    */

--- a/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
@@ -98,6 +98,10 @@ import { createSettledOrder } from '../../test/src/shop-utils';
             },
           ];
         },
+        saveAdditionalData: async (ctx, injector, qlsProduct) => {
+          // Just a test implementation
+          console.log('Saving additional data for QLS product:', qlsProduct);
+        },
       }),
       DefaultSchedulerPlugin,
       DefaultSearchPlugin,


### PR DESCRIPTION
## Description

Replaces the `saveRawWarehouseStockData` boolean option with a `saveAdditionalData` hook, giving consumers full control over how QLS product data is persisted. Also removes the `qlsRawWarehouseStockData` custom field.

## To do before merge

- [ ] Run e2e tests

## Breaking changes

- `saveRawWarehouseStockData` option removed — replace with `saveAdditionalData` hook
- `qlsRawWarehouseStockData` custom field removed from `ProductVariant`

## Checklist

📌 Always:

- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:

- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:

- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`