### PR TITLE
feat(docs-website): guides section with SEO checklist

### DIFF
--- a/docs-website/astro.config.mjs
+++ b/docs-website/astro.config.mjs
@@ -23,6 +23,20 @@ export default defineConfig({
       optimizedFallbacks: true,
     },
   ],
+  markdown: {
+    // Single dark theme: site has no light/dark toggle, body is dark.
+    // https://docs.astro.build/en/guides/syntax-highlighting/
+    shikiConfig: {
+      theme: 'github-dark',
+    },
+  },
+  image: {
+    // Authorize remote image hosts used in guide hero images. Images
+    // from these hosts can be optimized and have their dimensions
+    // inferred at build time via `inferSize`.
+    // https://docs.astro.build/en/guides/images/#authorizing-remote-images
+    domains: ['images.unsplash.com'],
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/docs-website/src/components/HeroSection.astro
+++ b/docs-website/src/components/HeroSection.astro
@@ -27,11 +27,11 @@ import Cta from './base/Cta.astro';
     <!-- CTA Buttons -->
     <div class="mt-6 flex flex-wrap gap-4">
       <Cta
-        href="https://pinelab.studio/contact/"
+        href="https://pinelab.studio/contact/?q=I+would+like+a+custom+plugin"
         target="_blank"
         variant="primary"
       >
-        Build me something custom
+        Build me a custom plugin
       </Cta>
       <Cta href="/#plugins" variant="secondary">Plugins ↓</Cta>
     </div>

--- a/docs-website/src/components/Navigation.astro
+++ b/docs-website/src/components/Navigation.astro
@@ -12,7 +12,8 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { label: 'Plugins', href: '/#plugins' },
-  { label: 'AI integration', href: '/ai-integration' },
+  { label: 'AI integration', href: '/ai-integration/' },
+  { label: 'Guides', href: '/guides/' },
 ];
 
 const contactHref = 'https://pinelab.studio/contact/';

--- a/docs-website/src/content.config.ts
+++ b/docs-website/src/content.config.ts
@@ -1,0 +1,44 @@
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
+
+/**
+ * Build-time content collections for the docs site.
+ *
+ * `guides` — long-form Markdown articles rendered at /guides/<slug>.
+ * Add new files to `src/content/guides/` and they will be picked up on
+ * the next build, included in the sitemap, and rendered through the
+ * shared site Layout.
+ */
+const guides = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/guides' }),
+  schema: z.object({
+    /**
+     * URL slug for the guide. Required.
+     * Determines the route: /guides/<slug>.
+     */
+    slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+      message: 'slug must be kebab-case (lowercase, digits, hyphens)',
+    }),
+    /** Page H1 and SEO `<title>`. */
+    title: z.string(),
+    /** Meta description / OG description. Aim for ~150 chars. */
+    description: z.string().min(50).max(200),
+    /** Original publish date. Used for Article JSON-LD `datePublished`. */
+    pubDate: z.coerce.date(),
+    /** Optional last-updated date. Falls back to `pubDate` when absent. */
+    updatedDate: z.coerce.date().optional(),
+    /** Author name shown in Article JSON-LD. Defaults to Pinelab. */
+    author: z.string().default('Pinelab'),
+    /**
+     * Optional remote hero image URL. Rendered at the top of the guide
+     * AND used as the OG image. Host must be authorized in
+     * `astro.config.mjs#image.domains` (or `image.remotePatterns`).
+     */
+    heroImage: z.string().url().optional(),
+    /** Alt text for `heroImage`. Falls back to `title` when omitted. */
+    heroImageAlt: z.string().optional(),
+  }),
+});
+
+export const collections = { guides };

--- a/docs-website/src/content/guides/vendure-seo-checklist.md
+++ b/docs-website/src/content/guides/vendure-seo-checklist.md
@@ -1,7 +1,7 @@
 ---
 slug: vendure-seo-checklist
 title: SEO checklist for Vendure
-description: A practical SEO baseline for Vendure storefronts — meta tags, JSON-LD structured data, image alt text, robots.txt and sitemaps.
+description: A practical SEO implementation guid for Vendure shops; meta tags, JSON-LD structured data, image alt text, robots.txt and sitemaps.
 pubDate: 2026-05-06
 author: Martijn
 heroImage: https://images.unsplash.com/photo-1560472354-b33ff0c44a43

--- a/docs-website/src/content/guides/vendure-seo-checklist.md
+++ b/docs-website/src/content/guides/vendure-seo-checklist.md
@@ -4,7 +4,7 @@ title: SEO checklist for Vendure
 description: A practical SEO baseline for Vendure storefronts — meta tags, JSON-LD structured data, image alt text, robots.txt and sitemaps.
 pubDate: 2026-05-06
 author: Martijn
-heroImage: https://images.unsplash.com/photo-1560472354-b33ff0c44a43?q=80&w=951&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+heroImage: https://images.unsplash.com/photo-1560472354-b33ff0c44a43
 heroImageAlt: SEO analytics dashboard on a laptop screen
 ---
 

--- a/docs-website/src/content/guides/vendure-seo-checklist.md
+++ b/docs-website/src/content/guides/vendure-seo-checklist.md
@@ -1,0 +1,265 @@
+---
+slug: vendure-seo-checklist
+title: SEO checklist for Vendure
+description: A practical SEO baseline for Vendure storefronts — meta tags, JSON-LD structured data, image alt text, robots.txt and sitemaps.
+pubDate: 2026-05-06
+author: Martijn
+heroImage: https://images.unsplash.com/photo-1560472354-b33ff0c44a43?q=80&w=951&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+heroImageAlt: SEO analytics dashboard on a laptop screen
+---
+
+This article walks through the practical steps we take at Pinelab to wire up the basics needed for SEO: meta tags, structured data, alt text, robots.txt and sitemaps.
+
+The examples are framework-agnostic where possible. The Vendure side is the same for everyone; the storefront snippets are illustrative and will look different depending on your framework.
+
+**No plugins are needed for this setup, just some custom fields.**
+
+## Meta title and description
+
+Vendure does not ship with `metaTitle` / `metaDescription` fields out of the box, so the first step is to add them as custom fields on `Product` and `Collection`. Make them localized, public, and group them under an "SEO" UI tab so content editors find them easily.
+
+```ts
+// vendure/src/custom-fields.ts
+import { CustomFields } from '@vendure/core';
+export const customFields: CustomFields = {
+  Product: [
+    {
+      name: 'metaTitle',
+      type: 'localeString',
+      public: true,
+      nullable: true,
+      ui: { tab: 'SEO' },
+    },
+    {
+      name: 'metaDescription',
+      type: 'localeText',
+      public: true,
+      nullable: true,
+      ui: { tab: 'SEO', component: 'textarea-form-input' },
+    },
+  ],
+  Collection: [
+    {
+      name: 'metaTitle',
+      type: 'localeString',
+      public: true,
+      nullable: true,
+      ui: { tab: 'SEO' },
+    },
+    {
+      name: 'metaDescription',
+      type: 'localeText',
+      public: true,
+      nullable: true,
+      ui: { tab: 'SEO', component: 'textarea-form-input' },
+    },
+  ],
+};
+```
+
+After adding the fields, **generate and run a database migration**. Without it the columns won't exist and the dashboard will throw on save.
+
+```bash
+npm run migration:generate add-seo-fields
+npm run migration:run
+```
+
+Next, fetch these fields in your storefront's product and collection queries:
+
+```graphql
+fragment ProductDetail on Product {
+  id
+  name
+  slug
+  description
+  customFields {
+    metaTitle
+    metaDescription
+  }
+}
+```
+
+Finally, render them. In our setup we pass `metaTitle` and `metaDescription` as props to a shared layout component which renders the actual `<title>` and `<meta>` tags in `<head>` — but how exactly you wire this up depends entirely on your storefront's structure. The important part is the fallback chain:
+
+```ts
+const metaTitle = product.customFields?.metaTitle;
+const metaDescription = product.customFields?.metaDescription?.trim();
+```
+
+That way, editors only have to fill in the SEO fields when they want to override the defaults.
+Don't forget the canonical URL on every page:
+
+```html
+<link rel="canonical" href="https://example.com/en/p/black-t-shirt" />
+```
+
+## Structured data for products and collections
+
+Structured data (JSON-LD) helps search engines understand your pages and unlocks rich results: price, availability, ratings, image carousels. Vendure already exposes everything you need: SKUs, prices, currency, stock levels, images. You can use this util function to generate JSON-LD for a product:
+
+```ts
+// lib/util/structured-data.ts
+export function buildProductJsonLd(product, productUrl: string) {
+  const description =
+    stripHtml(product.customFields?.metaDescription) ||
+    stripHtml(product.description);
+  const offers = product.variants.map((variant) => ({
+    '@type': 'Offer',
+    sku: variant.sku,
+    price: (variant.priceWithTax / 100).toFixed(2),
+    priceCurrency: variant.currencyCode,
+    availability:
+      variant.stockLevel === 'OUT_OF_STOCK'
+        ? 'https://schema.org/OutOfStock'
+        : 'https://schema.org/InStock',
+    url: productUrl,
+  }));
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: product.name,
+    description,
+    sku: product.variants[0]?.sku,
+    image: product.assets.map((a) => a.preview),
+    offers: offers.length === 1 ? offers[0] : offers,
+  };
+}
+```
+
+Two important details:
+
+- **Prices in Vendure are in minor units** (cents). Schema.org expects a decimal string, so divide by 100 and `toFixed(2)`.
+- **Map `stockLevel`** (`IN_STOCK`, `LOW_STOCK`, `OUT_OF_STOCK`) to schema.org's `InStock` / `OutOfStock` URLs.
+- Make sure you are fetching all the required fields in your GraphQL query.
+
+For collections, build a `CollectionPage` with an embedded `ItemList`:
+
+```ts
+export function buildCollectionJsonLd(
+  collection,
+  collectionUrl,
+  productUrlBuilder
+) {
+  const seen = new Set<string>();
+  const items = [];
+  for (const variant of collection.productVariants.items) {
+    if (seen.has(variant.product.id)) continue;
+    seen.add(variant.product.id);
+    items.push({
+      '@type': 'ListItem',
+      position: items.length + 1,
+      url: productUrlBuilder(variant.product.slug),
+      name: variant.product.name,
+    });
+  }
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: collection.name,
+    url: collectionUrl,
+    mainEntity: { '@type': 'ItemList', itemListElement: items },
+  };
+}
+```
+
+Note the deduplication: Vendure returns one entry per `ProductVariant`, but the structured data is about products.
+Render the result as a JSON-LD `<script>` on the page:
+
+```html
+<script type="application/ld+json">
+  {
+    /* JSON.stringify(productJsonLd) */
+  }
+</script>
+```
+
+## Breadcrumb structured data
+
+If your storefront already has a visible breadcrumb component, mirroring it as structured data is essentially free. Use Vendure's `Collection.breadcrumbs` field on products to derive the trail:
+
+```ts
+export function buildBreadcrumbJsonLd(
+  items: Array<{ name: string; url: string }>
+) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+```
+
+The URLs must be absolute. We render this script directly inside the Breadcrumb component itself so they stay in sync.
+
+## Alt text for images
+
+Vendure's `Asset.name` is a great default for alt text — editors set it when uploading and it's typically descriptive. Add `name` to every asset selection in your GraphQL queries:
+
+```graphql
+featuredAsset {
+  id
+  name
+  preview
+}
+assets {
+  id
+  name
+  preview
+}
+```
+
+Don't forget assets nested on `ProductVariant`, `OrderLine.featuredAsset`, and `Collection.featuredAsset` (including children). Then use it with a sensible fallback:
+
+```tsx
+<img src={getPreset(asset.preview, 'small')} alt={asset.name || product.name} />
+```
+
+## 5. robots.txt
+
+Drop a `robots.txt` at the root of your storefront. The minimum is:
+
+```
+User-agent: *
+Allow: /
+Sitemap: https://example.com/sitemap.xml
+```
+
+Block search/filter URLs and other crawler traps you don't want indexed, and reference your sitemap so crawlers discover it without guesswork.
+
+## Sitemap
+
+A sitemap lists every indexable URL with its last-modified date so crawlers can prioritize what changed. Vendure exposes everything you need via the `products` and `collections` queries — pagination plus `slug` and `updatedAt`:
+
+```graphql
+query GetSitemapProducts($skip: Int!, $take: Int!) {
+  products(options: { skip: $skip, take: $take }) {
+    items {
+      slug
+      updatedAt
+    }
+    totalItems
+  }
+}
+```
+
+Loop through pages of 100 (or whatever your API can handle), build the XML, and serve it from `/sitemap.xml`. The exact mechanism — static generation, an API route, an SSR endpoint, on-the-fly with caching — depends heavily on your storefront framework, so we won't elaborate here. Just make sure it exists, it's referenced from `robots.txt`, and it includes both products and collections.
+
+## Submit to Search Console
+
+The final step is the easiest to forget. None of the above matters if you don't tell Google (and Bing, and friends) that your site exists.
+
+1. Verify ownership in [Google Search Console](https://search.google.com/search-console) (DNS TXT or a meta tag).
+2. Submit your sitemap URL.
+3. Repeat for [Bing Webmaster Tools](https://www.bing.com/webmasters) — same sitemap.
+4. Check back after a few days for crawl errors, indexing status, and Core Web Vitals.
+
+Search Console also surfaces structured data warnings, so it's a great feedback loop for the JSON-LD work from steps 2 and 3.
+
+## Wrapping up
+
+That's the SEO baseline we apply to every Vendure storefront we build. The pattern is always the same: **add the field in Vendure, expose it via GraphQL, render it in the storefront**. Once meta tags, structured data, alt text, robots.txt and the sitemap are in place, you've covered the technical foundations and can shift focus to content and performance.

--- a/docs-website/src/pages/ai-integration.astro
+++ b/docs-website/src/pages/ai-integration.astro
@@ -38,12 +38,5 @@ const examplePrompt = `I want to implement B2B ordering, where customers can vie
 {examplePrompt}</code></pre>
 
     <div class="mt-12"></div>
-
-    <Paragraph>
-      <i
-        >Coming soon: guides on how to combine different plugins for larger
-        features.</i
-      >
-    </Paragraph>
   </section>
 </Layout>

--- a/docs-website/src/pages/guides/[slug].astro
+++ b/docs-website/src/pages/guides/[slug].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection, render, type CollectionEntry } from 'astro:content';
-import { Image } from 'astro:assets';
+import { Image, getImage } from 'astro:assets';
 import Layout from '../../layouts/Layout.astro';
 import {
   buildBreadcrumbs,
@@ -33,11 +33,23 @@ const { Content, headings } = await render(entry);
 const toc = headings.filter((h) => h.depth === 2);
 
 const url = `https://plugins.pinelab.studio/guides/${entry.data.slug}`;
-// `heroImage` is rendered at the top of the page AND used as the OG
-// image for SEO/social sharing. Must be an absolute URL on a host
-// authorized via `image.domains` in astro.config.mjs.
-const heroImage = entry.data.heroImage;
 const heroAlt = entry.data.heroImageAlt ?? entry.data.title;
+
+// Download and optimize the remote image at build time.
+// Converts to WebP format with 80% quality for smaller file size.
+// The resulting `localImage.src` is a local path used for both
+// rendering and structured data (OG image / SEO).
+let localImage: Awaited<ReturnType<typeof getImage>> | undefined;
+if (entry.data.heroImage) {
+  localImage = await getImage({
+    src: entry.data.heroImage,
+    inferSize: true,
+    format: 'webp',
+    quality: 80,
+    width: 1200, // Set a max width to prevent excessively large images
+    height: 630, // Set a max height to prevent excessively large images
+  });
+}
 
 const structuredData = [
   buildGuideArticle({
@@ -47,7 +59,7 @@ const structuredData = [
     datePublished: entry.data.pubDate,
     dateModified: entry.data.updatedDate,
     authorName: entry.data.author,
-    image: heroImage,
+    image: localImage?.src ?? entry.data.heroImage,
   }),
   buildBreadcrumbs([
     { name: 'Home', url: 'https://plugins.pinelab.studio/' },
@@ -64,11 +76,12 @@ const structuredData = [
 >
   <article class="mt-8 mb-24">
     {
-      heroImage && (
-        <Image
-          src={heroImage}
+      localImage && (
+        <img
+          src={localImage.src}
           alt={heroAlt}
-          inferSize
+          width="1200"
+          height="630"
           class="mb-8 max-h-96 w-full rounded object-cover"
         />
       )

--- a/docs-website/src/pages/guides/[slug].astro
+++ b/docs-website/src/pages/guides/[slug].astro
@@ -1,0 +1,162 @@
+---
+import { getCollection, render, type CollectionEntry } from 'astro:content';
+import { Image } from 'astro:assets';
+import Layout from '../../layouts/Layout.astro';
+import {
+  buildBreadcrumbs,
+  buildGuideArticle,
+} from '../../utils/structured-data';
+
+/**
+ * Dynamic route for guides. Each Markdown file in `src/content/guides/`
+ * becomes /guides/<slug>, where `slug` is taken from the file's
+ * frontmatter (NOT the filename). Uses the `guides` build-time content
+ * collection.
+ */
+export async function getStaticPaths() {
+  const guides = await getCollection('guides');
+  return guides.map((entry) => ({
+    params: { slug: entry.data.slug },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: CollectionEntry<'guides'>;
+}
+
+const { entry } = Astro.props;
+const { Content, headings } = await render(entry);
+
+// Table of contents: only H2s. Each heading has a `slug` matching the
+// auto-generated id rendered on the heading element by Astro.
+const toc = headings.filter((h) => h.depth === 2);
+
+const url = `https://plugins.pinelab.studio/guides/${entry.data.slug}`;
+// `heroImage` is rendered at the top of the page AND used as the OG
+// image for SEO/social sharing. Must be an absolute URL on a host
+// authorized via `image.domains` in astro.config.mjs.
+const heroImage = entry.data.heroImage;
+const heroAlt = entry.data.heroImageAlt ?? entry.data.title;
+
+const structuredData = [
+  buildGuideArticle({
+    url,
+    title: entry.data.title,
+    description: entry.data.description,
+    datePublished: entry.data.pubDate,
+    dateModified: entry.data.updatedDate,
+    authorName: entry.data.author,
+    image: heroImage,
+  }),
+  buildBreadcrumbs([
+    { name: 'Home', url: 'https://plugins.pinelab.studio/' },
+    { name: 'Guides', url: 'https://plugins.pinelab.studio/guides' },
+    { name: entry.data.title, url },
+  ]),
+];
+---
+
+<Layout
+  metaTitle={entry.data.title}
+  metaDescription={entry.data.description}
+  structuredData={structuredData}
+>
+  <article class="mt-8 mb-24">
+    {
+      heroImage && (
+        <Image
+          src={heroImage}
+          alt={heroAlt}
+          inferSize
+          class="mb-8 max-h-96 w-full rounded object-cover"
+        />
+      )
+    }
+    <header class="mb-8">
+      <h1 class="text-4xl font-bold">{entry.data.title}</h1>
+      <p class="text-base-contrast/70 mt-2 text-sm">
+        <time datetime={entry.data.pubDate.toISOString()}>
+          {
+            entry.data.pubDate.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })
+          }
+        </time>
+        {entry.data.author ? ` · ${entry.data.author}` : ''}
+      </p>
+    </header>
+
+    {
+      toc.length > 0 && (
+        <details
+          id="toc-accordion"
+          class="toc-accordion border-base-contrast/20 mb-10 rounded border p-4"
+          open
+        >
+          <summary class="cursor-pointer font-semibold md:cursor-default">
+            On this page
+          </summary>
+          <nav aria-label="Table of contents" class="mt-2">
+            <ol class="list-decimal space-y-1 pl-6">
+              {toc.map((h) => (
+                <li>
+                  <a
+                    href={`#${h.slug}`}
+                    class="underline underline-offset-2 hover:opacity-80"
+                  >
+                    {h.text}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+        </details>
+      )
+    }
+
+    <div class="prose prose-invert blog-content !max-w-none">
+      <Content />
+    </div>
+  </article>
+</Layout>
+
+<style>
+  /* Desktop (md+, 768px+): hide the disclosure marker and disable
+     pointer interaction so the TOC reads as a static block. */
+  @media (min-width: 768px) {
+    .toc-accordion > summary {
+      list-style: none;
+      pointer-events: none;
+    }
+    .toc-accordion > summary::-webkit-details-marker {
+      display: none;
+    }
+    .toc-accordion > summary::marker {
+      content: '';
+    }
+  }
+</style>
+
+<script is:inline>
+  // Sync the <details open> attribute with viewport size. Default
+  // markup ships with `open` (so SSR + no-JS users see the TOC).
+  // On mobile (<768px) we collapse it; users can still toggle.
+  (function () {
+    var el = document.getElementById('toc-accordion');
+    if (!el) return;
+    var mq = window.matchMedia('(min-width: 768px)');
+    var userToggled = false;
+    el.addEventListener('toggle', function () {
+      userToggled = true;
+    });
+    function apply() {
+      if (userToggled) return;
+      el.open = mq.matches;
+    }
+    apply();
+    mq.addEventListener('change', apply);
+  })();
+</script>

--- a/docs-website/src/pages/guides/index.astro
+++ b/docs-website/src/pages/guides/index.astro
@@ -1,0 +1,90 @@
+---
+/**
+ * Index page listing every guide in the `guides` content collection.
+ * Sorted by `pubDate` descending (newest first).
+ */
+import { getCollection } from 'astro:content';
+import { Image } from 'astro:assets';
+import Layout from '../../layouts/Layout.astro';
+import Heading1 from '../../components/base/Heading1.astro';
+import Paragraph from '../../components/base/Paragraph.astro';
+import { buildBreadcrumbs } from '../../utils/structured-data';
+
+const guides = (await getCollection('guides')).sort(
+  (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime()
+);
+
+const url = 'https://plugins.pinelab.studio/guides';
+
+const structuredData = [
+  buildBreadcrumbs([
+    { name: 'Home', url: 'https://plugins.pinelab.studio/' },
+    { name: 'Guides', url },
+  ]),
+];
+---
+
+<Layout
+  metaTitle="Guides"
+  metaDescription="Practical guides for building with Vendure — SEO, integrations, and patterns proven in production."
+  structuredData={structuredData}
+>
+  <section class="mb-24">
+    <Heading1>Guides</Heading1>
+
+    <Paragraph>
+      Practical, production-tested guides for building with Vendure. Each guide
+      distills patterns we use in our own client projects. Each guide aims to be
+      an AI ready prompt to implement the described feature. So <a
+        href="/ai-integration/"
+        class="underline">point your AI assistant to our docs</a
+      >, and start building.
+    </Paragraph>
+
+    {
+      guides.length === 0 ? (
+        <Paragraph>
+          <i>No guides yet — check back soon.</i>
+        </Paragraph>
+      ) : (
+        <ul class="mt-10 grid gap-8 sm:grid-cols-2">
+          {guides.map((g) => (
+            <li class="border-base-contrast/20 hover:border-base-contrast/40 group rounded border transition-colors">
+              <a
+                href={`/guides/${g.data.slug}`}
+                class="block h-full overflow-hidden rounded"
+              >
+                {g.data.heroImage && (
+                  <Image
+                    src={g.data.heroImage}
+                    alt={g.data.heroImageAlt ?? g.data.title}
+                    inferSize
+                    class="h-48 w-full object-cover"
+                  />
+                )}
+                <div class="p-5">
+                  <h2 class="mb-2 text-xl font-semibold group-hover:underline">
+                    {g.data.title}
+                  </h2>
+                  <p class="text-base-contrast/80 mb-3 text-sm">
+                    {g.data.description}
+                  </p>
+                  <time
+                    datetime={g.data.pubDate.toISOString()}
+                    class="text-base-contrast/60 text-xs"
+                  >
+                    {g.data.pubDate.toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </time>
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </section>
+</Layout>

--- a/docs-website/src/pages/llms.txt.ts
+++ b/docs-website/src/pages/llms.txt.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
 import { getPlugins } from '../utils/plugins';
 
 const SITE = 'https://plugins.pinelab.studio';
@@ -10,9 +11,15 @@ const SITE = 'https://plugins.pinelab.studio';
  * linking to a single per-plugin markdown file at `/llms/<slug>.md` that
  * contains the full README, a link to the GitHub source directory, and
  * the full CHANGELOG appended at the bottom.
+ *
+ * Also lists every guide (from the `guides` content collection), each
+ * linking to a per-guide markdown file at `/llms/guides/<slug>.md`.
  */
 export const GET: APIRoute = async () => {
   const plugins = await getPlugins();
+  const guides = (await getCollection('guides')).sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime()
+  );
 
   const lines: string[] = [];
   lines.push('# Pinelab Vendure Plugins');
@@ -32,6 +39,18 @@ export const GET: APIRoute = async () => {
         ? ` Keywords: ${plugin.keywords.join(', ')}.`
         : '';
     lines.push(`- [${plugin.name}](${docUrl}): ${description}.${keywordsPart}`);
+  }
+
+  if (guides.length > 0) {
+    lines.push('');
+    lines.push('## Guides');
+    lines.push('');
+    for (const guide of guides) {
+      const docUrl = `${SITE}/llms/guides/${guide.data.slug}.md`;
+      lines.push(
+        `- [${guide.data.title}](${docUrl}): ${guide.data.description}`
+      );
+    }
   }
 
   lines.push('');

--- a/docs-website/src/pages/llms/guides/[slug].md.ts
+++ b/docs-website/src/pages/llms/guides/[slug].md.ts
@@ -1,0 +1,34 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+
+/**
+ * Static markdown endpoint per guide at `/llms/guides/<slug>.md`.
+ *
+ * Serves the raw guide markdown (with frontmatter stripped) prefixed by
+ * an H1 of the guide's `title`, so an LLM can fetch a single
+ * self-contained file per guide. Referenced from `llms.txt`.
+ */
+export const getStaticPaths: GetStaticPaths = async () => {
+  const guides = await getCollection('guides');
+  return guides.map((entry) => ({
+    params: { slug: entry.data.slug },
+    props: { entry },
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const entry = props.entry as Awaited<
+    ReturnType<typeof getCollection<'guides'>>
+  >[number];
+
+  // `entry.body` is the raw markdown without frontmatter.
+  const body = (entry.body ?? '').trimEnd();
+
+  const out = `# ${entry.data.title}\n\n> ${entry.data.description}\n\n${body}\n`;
+
+  return new Response(out, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });
+};

--- a/docs-website/src/utils/structured-data.ts
+++ b/docs-website/src/utils/structured-data.ts
@@ -131,6 +131,46 @@ export function buildChangelogArticle(plugin: Plugin): Record<string, unknown> {
 }
 
 /**
+ * Article JSON-LD for a guide page (/guides/<slug>).
+ */
+export function buildGuideArticle(args: {
+  url: string;
+  title: string;
+  description: string;
+  datePublished: Date;
+  dateModified?: Date;
+  authorName: string;
+  image?: string;
+}): Record<string, unknown> {
+  const {
+    url,
+    title,
+    description,
+    datePublished,
+    dateModified,
+    authorName,
+    image,
+  } = args;
+  return {
+    '@type': 'Article',
+    '@id': `${url}#article`,
+    headline: title,
+    description,
+    url,
+    inLanguage: 'en',
+    datePublished: datePublished.toISOString(),
+    dateModified: (dateModified ?? datePublished).toISOString(),
+    ...(image ? { image } : {}),
+    mainEntityOfPage: url,
+    author: {
+      '@type': authorName === 'Pinelab' ? 'Organization' : 'Person',
+      name: authorName,
+    },
+    publisher: { '@id': ORG_ID },
+  };
+}
+
+/**
  * ItemList of all plugins for the homepage.
  */
 export function buildPluginItemList(


### PR DESCRIPTION
# Description

This PR adds a new **Guides** section to the docs website with a content collection system for long-form Markdown articles. Includes:

- New `/guides/` pages with index listing and individual guide pages
- First guide: "SEO checklist for Vendure" covering meta tags, JSON-LD structured data, alt text, robots.txt, and sitemaps
- Build-time content collections using Astro's `defineCollection` with Zod schema validation
- JSON-LD structured data for guide articles and breadcrumbs
- LLM integration: guides listed in `llms.txt` with per-guide markdown endpoints at `/llms/guides/<slug>.md`
- Syntax highlighting with Shiki (github-dark theme)
- Authorized remote image domains for Unsplash hero images
- Updated navigation to include Guides link
- Updated CTA button text and URL

# To do before merge

- [ ] Review guide content for accuracy
- [ ] Verify all links work correctly

# Breaking changes

None

# Screenshots

New pages at `/guides/` and `/guides/vendure-seo-checklist`

# Checklist

📌 Always:

- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:

- [x] Added or updated test cases (N/A - content/documentation)
- [ ] Updated the README

📦 For publishable packages:

- [ ] Increased the version number in `package.json`
- [ ] Added changes to the `CHANGELOG.md`