### PR TITLE
feat(qls): Pushing and pulling additional fields on orders

### DIFF
--- a/packages/vendure-plugin-invoices/src/gql/graphql-env.d.ts
+++ b/packages/vendure-plugin-invoices/src/gql/graphql-env.d.ts
@@ -538,6 +538,6 @@ import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
   interface setupSchema {
-    introspection: introspection
+    introspection: introspection;
   }
 }

--- a/packages/vendure-plugin-invoices/src/gql/graphql.ts
+++ b/packages/vendure-plugin-invoices/src/gql/graphql.ts
@@ -2,13 +2,13 @@ import type { introspection } from './graphql-env.d.ts';
 import { initGraphQLTada } from 'gql.tada';
 
 export const graphql = initGraphQLTada<{
-    disableMasking: true;
-    introspection: introspection;
-    scalars: {
-        DateTime: string;
-        JSON: any;
-        Money: number;
-    };
+  disableMasking: true;
+  introspection: introspection;
+  scalars: {
+    DateTime: string;
+    JSON: any;
+    Money: number;
+  };
 }>();
 
 export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';

--- a/packages/vendure-plugin-invoices/test/e2e.spec.ts
+++ b/packages/vendure-plugin-invoices/test/e2e.spec.ts
@@ -121,7 +121,6 @@ const mockAccountingStrategySpy = {
   exportCreditInvoice: vi.spyOn(mockAccountingStrategy, 'exportCreditInvoice'),
 };
 
-
 /**
  * Get latest invoice via admin API
  */

--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0 (2026-06-10)
+
+- Restructure plugin options into nested `orderSync` and `productSync` objects. This is a **breaking change**: all plugin options must now be organized under `orderSync` (for order-related hooks) and `productSync` (for product-related hooks).
+- Renamed `getAdditionalOrderFields` to `pushAdditionalOrderFields` in `orderSync` options.
+
 # 1.9.0 (2026-08-05)
 
 - Upgraded to Vendure 3.6.3

--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Restructure plugin options into nested `orderSync` and `productSync` objects. This is a **breaking change**: all plugin options must now be organized under `orderSync` (for order-related hooks) and `productSync` (for product-related hooks).
 - Renamed `getAdditionalOrderFields` to `pushAdditionalOrderFields` in `orderSync` options.
+- Added `pullAdditionalOrderFields` hook in `orderSync` options, called after an order is successfully created in QLS. Errors in this hook are caught and logged, and will not fail the order push job.
 
 # 1.9.0 (2026-08-05)
 

--- a/packages/vendure-plugin-qls-fulfillment/README.md
+++ b/packages/vendure-plugin-qls-fulfillment/README.md
@@ -23,7 +23,52 @@ This plugin contains:
 
 ## Getting started
 
-// TODO
+```ts
+import { QlsPlugin } from '@pinelab/vendure-plugin-qls-fulfillment';
+
+// In your VendureConfig:
+plugins: [
+  QlsPlugin.init({
+    getConfig: (ctx) => {
+      // Return config for the current channel, or undefined to disable QLS for this channel
+      return {
+        username: 'qls-username',
+        password: 'qls-password',
+        companyId: 'your-company-id',
+        brandId: 'your-brand-id',
+      };
+    },
+    webhookSecret: 'your-random-secret',
+    productSync: {
+      // Required: map Vendure variants to QLS product fields
+      getAdditionalVariantFields: (ctx, variant) => ({
+        ean: variant.sku,
+        image_url: `https://your-cdn.com/${variant.featuredAsset?.preview}`,
+        additionalEANs: ['1234567890'],
+      }),
+      // Optional: exclude certain variants from being synced to QLS
+      excludeVariantFromSync: (ctx, injector, variant) => {
+        return variant.sku.startsWith('DONOTSYNC');
+      },
+    },
+    orderSync: {
+      // Optional: push additional fields to QLS when creating an order
+      pushAdditionalOrderFields: (ctx, injector, order) => ({
+        custom_values: [
+          {
+            key: 'vendureOrder',
+            value: `https://your-admin.com/admin/orders/${order.code}`,
+          },
+        ],
+      }),
+      // Optional: delay order processing in QLS by 2 hours
+      processOrderFrom: (ctx, order) => {
+        return new Date(Date.now() + 1000 * 60 * 60 * 2);
+      },
+    },
+  }),
+];
+```
 
 This plugin requires the default order process to be configured with `checkFulfillmentStates: false`, so that orders can be transitioned to Shipped and Delivered without the need of fulfillment. Fulfillment is the responsibility of Picqer, so we won't handle that in Vendure when using this plugin.
 

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/client-types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/client-types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * QLS API types only
  */

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/client-types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/client-types.ts
@@ -190,3 +190,421 @@ export type IncomingOrderWebhook = Pick<
   | 'amount_delivered'
   | 'amount_total'
 >;
+
+/**
+ * This is the full data returend by the QLS API when fetching a fulfillment product by ID
+ * Getting via list, sku or filtering does NOT return this full object
+ */
+export interface FulfillmentProductDetail {
+  data: Data;
+  meta: Meta;
+  errors: any[];
+  pagination: any;
+}
+
+export interface Data {
+  id: string;
+  company_id: string;
+  collection_id: any;
+  dimensions: Dimensions;
+  article_number: any;
+  ean: string;
+  name: string;
+  sku: string;
+  image_url: string;
+  country_code_of_origin: any;
+  hs_code: any;
+  need_barcode_picking: boolean;
+  need_best_before_stock: boolean;
+  need_serial_number: boolean;
+  amount_available: number;
+  amount_reserved: number;
+  amount_total: number;
+  price_cost: number;
+  price_store: any;
+  weight: number;
+  created: string;
+  modified: string;
+  foldable: boolean;
+  fulfillment_product_brand_id: string;
+  description: any;
+  amount_blocked: number;
+  status: any;
+  bundles: any[];
+  product_brand: ProductBrand;
+  product_values: ProductValue[];
+  suppliers: Supplier[];
+  vas: Va[];
+  product_master_cartons: any[];
+  product_measurements: ProductMeasurement[];
+  barcodes: any[];
+  warehouse_stock_transfers: WarehouseStockTransfer[];
+  bundle_products: any[];
+  warehouse_stocks: WarehouseStock[];
+  mappings: Mapping[];
+  order_unit: any;
+  image_url_handheld: string;
+  barcodes_and_ean: string[];
+}
+
+export interface Dimensions {
+  length: string;
+  width: string;
+  height: string;
+}
+
+export interface ProductBrand {
+  id: string;
+  company_id: string;
+  name: string;
+}
+
+export interface ProductValue {
+  id: number;
+  fulfillment_product_id: string;
+  key: string;
+  value: string;
+}
+
+export interface Supplier {
+  id: string;
+  company_id: string;
+  name: string;
+  _joinData: JoinData;
+}
+
+export interface JoinData {
+  id: number;
+  fulfillment_product_id: string;
+  supplier_id: string;
+  supplier_code: any;
+}
+
+export interface Va {
+  id: number;
+  fulfillment_product_id: string;
+  vas_id: number;
+  value_added_service: ValueAddedService;
+}
+
+export interface ValueAddedService {
+  id: number;
+  short: string;
+  name: string;
+  type_id: number;
+  price: number;
+  description: string;
+  entity_type?: string;
+  entity_id?: number;
+  company_id: any;
+  enabled: boolean;
+  parent_id: any;
+  sort: number;
+  visible: boolean;
+  setting: Setting;
+  vas_type: VasType;
+}
+
+export interface Setting {
+  use_for_tote_hash: number;
+}
+
+export interface VasType {
+  id: number;
+  short: string;
+  name: string;
+  description: any;
+  type: string;
+  info_text?: string;
+}
+
+export interface ProductMeasurement {
+  id: string;
+  product_id: string;
+  dimensions: Dimensions2;
+  weight: number;
+  product_measurementscol: any;
+  creator: string;
+  creator_company_id?: string;
+  creator_user_id?: string;
+  created: string;
+  creator_user?: CreatorUser;
+}
+
+export interface Dimensions2 {
+  length: string;
+  width: string;
+  height: string;
+}
+
+export interface CreatorUser {
+  id: string;
+  email: string;
+  firstname: string;
+  lastname: string;
+  role: string;
+  permissions: any;
+  created: string;
+  modified: string;
+  language_id: number;
+  personnel_number: string;
+  has_beta_version: boolean;
+  password_changed: string;
+  remember_token: string;
+  email_verified_at: any;
+}
+
+export interface WarehouseStockTransfer {
+  id: string;
+  company_id: string;
+  product_id: string;
+  source_stock_id: any;
+  amount_total: number;
+  amount_transferred: number;
+  remarks: any;
+  source: string;
+  status: string;
+  created: string;
+  modified: string;
+  best_before: any;
+  fulfillment_product_batch_id: any;
+  creator_user_id: string;
+  purchase_order_label_product_id: any;
+  purchase_order_label_product: any;
+  warehouse_stock_transfer_box_mappings: WarehouseStockTransferBoxMapping[];
+  creator: Creator;
+  company: Company;
+  amount_pending: number;
+}
+
+export interface WarehouseStockTransferBoxMapping {
+  id: string;
+  box_id: string;
+  transfer_id: string;
+  created: string;
+  modified: string;
+  deleted: any;
+  warehouse_box: WarehouseBox;
+}
+
+export interface WarehouseBox {
+  id: string;
+  company_id: string;
+  trolley_id: any;
+  warehouse_id: number;
+  type_id: any;
+  code: string;
+  position: any;
+  created: string;
+  modified: string;
+  deleted: any;
+  prefix: string;
+}
+
+export interface Creator {
+  id: string;
+  email: string;
+  firstname: string;
+  lastname: string;
+  role: string;
+  permissions: any;
+  created: string;
+  modified: string;
+  language_id: number;
+  personnel_number: any;
+  has_beta_version: boolean;
+  password_changed: string;
+  remember_token: string;
+  email_verified_at: any;
+}
+
+export interface Company {
+  id: string;
+  tenant_id: string;
+  affiliate_id: any;
+  name: string;
+  anonymous_name: string;
+  invoice_contact_id: string;
+  active: boolean;
+  shipments_last_7_days: number;
+  legacy_shipments_last_7_days: number;
+  heavy_shipments: boolean;
+  default_user_role_id: string;
+  financial_relation_id: string;
+  has_employee: boolean;
+  has_fulfillment: boolean;
+  has_route: boolean;
+  has_signed_gdpr: boolean;
+  pickup_timeframe_start: any;
+  pickup_timeframe_end: any;
+  fulfillment_average_handling_time: any;
+  outstanding_invoices_status: string;
+  outstanding_invoices_amount: number;
+  legal_companyname: any;
+  legal_coc: any;
+  legal_vat: any;
+  onboarding_status: string;
+  status: string;
+  created: string;
+  modified: string;
+  deleted: any;
+  price_change: any;
+  auto_secondwave: boolean;
+  priority_support: boolean;
+  mollie_customer_id: any;
+  company_group_id: any;
+  test: boolean;
+  enable_software_charge: boolean;
+}
+
+export interface WarehouseStock {
+  id: number;
+  product_id: string;
+  autostore_bin_id: string;
+  zone_id: number;
+  row_number: string;
+  rack_number: string;
+  shelf_number: string;
+  number: string;
+  amount_current: number;
+  amount_reserved: number;
+  best_before: any;
+  created: string;
+  modified: string;
+  deleted: any;
+  best_before_cutoff: any;
+  blocked: any;
+  autostore_bin: AutostoreBin;
+  warehouse_zone: WarehouseZone;
+  product_batch: any[];
+  amount_available: number;
+  code: string;
+  code_formatted: string;
+  is_changed_for_replenishment: boolean;
+  location: string;
+}
+
+export interface AutostoreBin {
+  id: string;
+  autostore_id: string;
+  autostore_bin_id: number;
+  autostore_bin_layout_id: string;
+  zone_id: number;
+  content_code: string;
+  bin_type: number;
+  created?: string;
+  modified: string;
+  deleted: any;
+  depth: number;
+  xpos: number;
+  ypos: number;
+  transferred_in: string;
+  mode: string;
+}
+
+export interface WarehouseZone {
+  id: number;
+  company_id: string;
+  name: string;
+  pickable: boolean;
+  flip_row_numbers: boolean;
+  warehouse_id: number;
+  batchable: boolean;
+  isolated: boolean;
+  autostore_id: string;
+  has_pallets: boolean;
+  block_reservation_after: any;
+  warehouse_zone_group_id: any;
+  has_quarantine: boolean;
+  partially_replenishment_allowed: boolean;
+  allow_automatic_replenishment: boolean;
+  company: Company2;
+}
+
+export interface Company2 {
+  id: string;
+  tenant_id: string;
+  affiliate_id: any;
+  name: string;
+  anonymous_name: string;
+  invoice_contact_id: string;
+  active: boolean;
+  shipments_last_7_days: number;
+  legacy_shipments_last_7_days: number;
+  heavy_shipments: boolean;
+  default_user_role_id: string;
+  financial_relation_id: string;
+  has_employee: boolean;
+  has_fulfillment: boolean;
+  has_route: boolean;
+  has_signed_gdpr: boolean;
+  pickup_timeframe_start: any;
+  pickup_timeframe_end: any;
+  fulfillment_average_handling_time: any;
+  outstanding_invoices_status: string;
+  outstanding_invoices_amount: number;
+  legal_companyname: any;
+  legal_coc: any;
+  legal_vat: any;
+  onboarding_status: string;
+  status: string;
+  created: string;
+  modified: string;
+  deleted: any;
+  price_change: any;
+  auto_secondwave: boolean;
+  priority_support: boolean;
+  mollie_customer_id: any;
+  company_group_id: any;
+  test: boolean;
+  enable_software_charge: boolean;
+}
+
+export interface Mapping {
+  id: string;
+  product_id: string;
+  shop_integration_id: string;
+  shop_integration_reference: string;
+  shop_integration_reference2: string;
+  stock: number;
+  sync_stock: boolean;
+  created: string;
+  modified: string;
+  deleted: any;
+  synced: string;
+  exception_count: number;
+  name: string;
+  ean: string;
+  sku: string;
+  shop_integration: ShopIntegration;
+}
+
+export interface ShopIntegration {
+  id: string;
+  company_id: string;
+  brand_id: string;
+  type_id: number;
+  name: string;
+  created: string;
+  modified: string;
+  deleted: any;
+  last_imported: string;
+  last_imported_order_insights: any;
+  last_imported_shipment_insights: any;
+  last_imported_purchase_order: any;
+  fulfillment_sync_orders: boolean;
+  fulfillment_sync_products: boolean;
+  fulfillment_sync_stock: boolean;
+  fulfillment_sync_purchase_orders: boolean;
+  fulfillment_product_create_new: boolean;
+  fulfillment_product_match_by_name: boolean;
+  fulfillment_product_match_by_ean: boolean;
+  fulfillment_product_match_by_sku: boolean;
+  fulfillment_product_match_fields: string;
+  last_imported_products: any;
+  exception_count_importing_products: number;
+}
+
+export interface Meta {
+  code: number;
+}

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -5,6 +5,7 @@ import type {
   FulfillmentOrder,
   FulfillmentOrderInput,
   FulfillmentProduct,
+  FulfillmentProductDetail,
   FulfillmentProductInput,
   QlsApiResponse,
 } from './client-types';
@@ -58,8 +59,8 @@ export class QlsClient {
 
   async getFulfillmentProductById(
     fulfillmentProductId: string
-  ): Promise<FulfillmentProduct | undefined> {
-    const result = await this.rawRequest<FulfillmentProduct>(
+  ): Promise<FulfillmentProductDetail | undefined> {
+    const result = await this.rawRequest<FulfillmentProductDetail>(
       'GET',
       `fulfillment/products/${fulfillmentProductId}`
     );

--- a/packages/vendure-plugin-qls-fulfillment/src/qls-plugin.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/qls-plugin.ts
@@ -31,7 +31,9 @@ import { QlsOrderEntity } from './entities/qls-order-entity.entity';
     config.authOptions.customPermissions.push(qlsFullSyncPermission);
     config.authOptions.customPermissions.push(qlsPushOrderPermission);
     config.customFields.ProductVariant.push(
-      ...getVariantCustomFields(QlsPlugin.options?.qlsProductIdUiTab)
+      ...getVariantCustomFields(
+        QlsPlugin.options?.productSync?.qlsProductIdUiTab
+      )
     );
     config.customFields.Order.push(...orderCustomFields);
     return config;
@@ -52,10 +54,16 @@ export class QlsPlugin {
 
   static init(options: QlsPluginOptions): Type<QlsPlugin> {
     this.options = {
-      synchronizeStockLevels: true,
-      autoPushOrders: true,
-      qlsProductIdUiTab: 'QLS',
       ...options,
+      orderSync: {
+        autoPushOrders: true,
+        ...options.orderSync,
+      },
+      productSync: {
+        synchronizeStockLevels: true,
+        qlsProductIdUiTab: 'QLS',
+        ...options.productSync,
+      },
     };
     return QlsPlugin;
   }

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
@@ -53,7 +53,7 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
   onApplicationBootstrap(): void {
     // Listen for OrderPlacedEvent and add a job to the queue
     this.eventBus.ofType(OrderPlacedEvent).subscribe((event) => {
-      if (!this.options.autoPushOrders) {
+      if (!this.options.orderSync.autoPushOrders) {
         Logger.info(
           `Auto push orders disabled, not triggering push order job for order ${event.order.code}`,
           loggerCtx
@@ -150,7 +150,7 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
         order.lines.map(async (line) => {
           // Check if product variant should be excluded from sync
           if (
-            await this.options.excludeVariantFromSync?.(
+            await this.options.productSync.excludeVariantFromSync?.(
               ctx,
               new Injector(this.moduleRef),
               line.productVariant
@@ -178,7 +178,7 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
       // Add additional order items, if any
       try {
         const additionalOrderItems =
-          await this.options.addAdditionalOrderItems?.(
+          await this.options.orderSync.addAdditionalOrderItems?.(
             ctx,
             new Injector(this.moduleRef),
             order
@@ -203,7 +203,7 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
         return message;
       }
       const additionalOrderFields =
-        await this.options.pushAdditionalOrderFields?.(
+        await this.options.orderSync.pushAdditionalOrderFields?.(
           ctx,
           new Injector(this.moduleRef),
           order
@@ -234,8 +234,12 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
         );
       }
       const processable =
-        (await this.options.processOrderFrom?.(ctx, order)) ?? new Date();
-      const receiverContact = this.options.getReceiverContact?.(ctx, order);
+        (await this.options.orderSync.processOrderFrom?.(ctx, order)) ??
+        new Date();
+      const receiverContact = this.options.orderSync.getReceiverContact?.(
+        ctx,
+        order
+      );
       const qlsOrder: Omit<FulfillmentOrderInput, 'brand_id'> = {
         customer_reference: order.code,
         processable: processable.toISOString(),

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
@@ -203,7 +203,7 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
         return message;
       }
       const additionalOrderFields =
-        await this.options.getAdditionalOrderFields?.(
+        await this.options.pushAdditionalOrderFields?.(
           ctx,
           new Injector(this.moduleRef),
           order

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
@@ -296,6 +296,21 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
             error.stack
           );
         });
+      try {
+        await this.options.orderSync.pullAdditionalOrderFields?.(
+          ctx,
+          new Injector(this.moduleRef),
+          order,
+          result
+        );
+      } catch (e) {
+        const error = asError(e);
+        Logger.error(
+          `Error in pullAdditionalOrderFields for order '${order.code}': ${error.message}`,
+          loggerCtx,
+          error.stack
+        );
+      }
       return `Order '${order.code}' created in QLS with id '${result.id}'`;
     } catch (e) {
       const error = asError(e);

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -321,13 +321,13 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         } else if (result.status === 'updated') {
           updatedInQls.push(variant);
         }
-        if (result.qlsProductId && this.options.saveAdditionalData) {
+        if (result.qlsProductId && this.options.saveAdditionalVariantData) {
           try {
             const qlsProduct = await client.getFulfillmentProductById(
               result.qlsProductId
             );
             if (qlsProduct) {
-              await this.options.saveAdditionalData(
+              await this.options.saveAdditionalVariantData(
                 ctx,
                 new Injector(this.moduleRef),
                 qlsProduct,

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -321,13 +321,16 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         } else if (result.status === 'updated') {
           updatedInQls.push(variant);
         }
-        if (result.qlsProductId && this.options.saveAdditionalVariantData) {
+        if (
+          result.qlsProductId &&
+          this.options.productSync.saveAdditionalVariantData
+        ) {
           try {
             const qlsProduct = await client.getFulfillmentProductById(
               result.qlsProductId
             );
             if (qlsProduct) {
-              await this.options.saveAdditionalVariantData(
+              await this.options.productSync.saveAdditionalVariantData(
                 ctx,
                 new Injector(this.moduleRef),
                 qlsProduct,
@@ -439,7 +442,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
     qlsProductId?: string;
   }> {
     if (
-      await this.options.excludeVariantFromSync?.(
+      await this.options.productSync.excludeVariantFromSync?.(
         ctx,
         new Injector(this.moduleRef),
         variant
@@ -469,7 +472,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
     let qlsProduct = existingProduct;
     let createdOrUpdated: 'created' | 'updated' | 'not-changed' = 'not-changed';
     const { additionalEANs, ...additionalVariantFields } =
-      this.options.getAdditionalVariantFields(ctx, variant);
+      this.options.productSync.getAdditionalVariantFields(ctx, variant);
     if (!existingProduct) {
       const result = await client.createFulfillmentProduct({
         name: variant.name,
@@ -665,7 +668,7 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
     variantId: ID,
     availableStock: number
   ) {
-    if (!this.options.synchronizeStockLevels) {
+    if (!this.options.productSync.synchronizeStockLevels) {
       Logger.warn(
         `Stock sync disabled. Not updating stock for variant '${variantId}'`,
         loggerCtx

--- a/packages/vendure-plugin-qls-fulfillment/src/types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/types.ts
@@ -11,6 +11,7 @@ import {
   FulfillmentOrderInput,
   FulfillmentOrderLineInput,
   FulfillmentProduct,
+  FulfillmentProductDetail,
   FulfillmentProductInput,
 } from './lib/client-types';
 
@@ -31,10 +32,10 @@ export interface QlsPluginOptions {
   ) => AdditionalVariantFields;
 
   /**
-   * Function to get the set service point code for an order.
-   * Return undefined to not use a service point at all.
+   * Function to get additional order fields when pushing an order to QLS.
+   * Return undefined to not use additional fields at all.
    */
-  getAdditionalOrderFields?: (
+  pushAdditionalOrderFields?: (
     ctx: RequestContext,
     injector: Injector,
     order: Order
@@ -96,10 +97,10 @@ export interface QlsPluginOptions {
    * you to save any additional data to your own database. The saving itself
    * happens inside this hook — if not provided, nothing is persisted.
    */
-  saveAdditionalData?: (
+  saveAdditionalVariantData?: (
     ctx: RequestContext,
     injector: Injector,
-    qlsProduct: FulfillmentProduct,
+    qlsProduct: FulfillmentProductDetail,
     variant: ProductVariant
   ) => Promise<void> | void;
   /**

--- a/packages/vendure-plugin-qls-fulfillment/src/types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/types.ts
@@ -8,6 +8,7 @@ import {
 } from '@vendure/core';
 import {
   CustomValue,
+  FulfillmentOrder,
   FulfillmentOrderInput,
   FulfillmentOrderLineInput,
   FulfillmentProductDetail,
@@ -65,6 +66,17 @@ export interface QlsPluginOptions {
       ctx: RequestContext,
       order: Order
     ) => FulfillmentOrderInput['receiver_contact'] | undefined;
+    /**
+     * Optional hook called after an order has been successfully created in QLS.
+     * Receives the Vendure order, the created QLS order, a RequestContext, and an Injector.
+     * Errors in this hook are caught and logged, and will not fail the order push job.
+     */
+    pullAdditionalOrderFields?: (
+      ctx: RequestContext,
+      injector: Injector,
+      order: Order,
+      createdQlsOrder: FulfillmentOrder
+    ) => Promise<void> | void;
     /**
      * Additional order items to add to the QLS order.
      */

--- a/packages/vendure-plugin-qls-fulfillment/src/types.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/types.ts
@@ -10,7 +10,6 @@ import {
   CustomValue,
   FulfillmentOrderInput,
   FulfillmentOrderLineInput,
-  FulfillmentProduct,
   FulfillmentProductDetail,
   FulfillmentProductInput,
 } from './lib/client-types';
@@ -23,94 +22,104 @@ export interface QlsPluginOptions {
     ctx: RequestContext
   ) => QlsClientConfig | undefined | Promise<QlsClientConfig | undefined>;
   /**
-   * Required to get the EAN and image URL for a product variant.
-   * Also allows you to override other product attributes like name, price, etc.
-   */
-  getAdditionalVariantFields: (
-    ctx: RequestContext,
-    variant: ProductVariant
-  ) => AdditionalVariantFields;
-
-  /**
-   * Function to get additional order fields when pushing an order to QLS.
-   * Return undefined to not use additional fields at all.
-   */
-  pushAdditionalOrderFields?: (
-    ctx: RequestContext,
-    injector: Injector,
-    order: Order
-  ) =>
-    | Promise<AdditionalOrderFields | undefined>
-    | AdditionalOrderFields
-    | undefined;
-  /**
    * A key used to verify if the caller is authorized to call the webhook.
    * Set this to a random string
    */
   webhookSecret: string;
   /**
-   * Allows you to disable the pulling in of stock levels from QLS. When disabled, stock in Vendure will not be modified based on QLS stock levels.
-   * Defaults to true.
+   * Options related to order pushing to QLS
    */
-  synchronizeStockLevels?: boolean;
+  orderSync: {
+    /**
+     * Function to get additional order fields when pushing an order to QLS.
+     * Return undefined to not use additional fields at all.
+     */
+    pushAdditionalOrderFields?: (
+      ctx: RequestContext,
+      injector: Injector,
+      order: Order
+    ) =>
+      | Promise<AdditionalOrderFields | undefined>
+      | AdditionalOrderFields
+      | undefined;
+    /**
+     * Allows you to disable the automatic pushing of orders to QLS. You can still push orders manually via the Admin UI.
+     * Defaults to true.
+     */
+    autoPushOrders?: boolean;
+    /**
+     * Allows you to define a date from when the order should be processed by QLS.
+     * You can for example make orders processable 2 hours from now, so that you can still edit the order in QLS
+     * Defaults to now.
+     */
+    processOrderFrom?: (
+      ctx: RequestContext,
+      order: Order
+    ) => Date | Promise<Date>;
+    /**
+     * Optional function to customize the receiver contact details when creating a QLS order.
+     * Allows you to set different fields or override default mapping from the order's shipping address and customer.
+     * If not provided, default mapping will be used.
+     */
+    getReceiverContact?: (
+      ctx: RequestContext,
+      order: Order
+    ) => FulfillmentOrderInput['receiver_contact'] | undefined;
+    /**
+     * Additional order items to add to the QLS order.
+     */
+    addAdditionalOrderItems?: (
+      ctx: RequestContext,
+      injector: Injector,
+      order: Order
+    ) => FulfillmentOrderLineInput[] | Promise<FulfillmentOrderLineInput[]>;
+  };
   /**
-   * Allows you to disable the automatic pushing of orders to QLS. You can still push orders manually via the Admin UI.
-   * Defaults to true.
+   * Options related to product syncing to QLS
    */
-  autoPushOrders?: boolean;
-  /**
-   * Allows you to define a date from when the order should be processed by QLS.
-   * You can for example make orders processable 2 hours from now, so that you can still edit the order in QLS
-   * Defaults to now.
-   */
-  processOrderFrom?: (
-    ctx: RequestContext,
-    order: Order
-  ) => Date | Promise<Date>;
-  /**
-   * Optional function to determine if a product variant should be excluded from syncing to QLS.
-   * Return true to exclude the variant from sync, false or undefined to include it.
-   */
-  excludeVariantFromSync?: (
-    ctx: RequestContext,
-    injector: Injector,
-    variant: ProductVariant
-  ) => boolean | Promise<boolean>;
-  /**
-   * Optional function to customize the receiver contact details when creating a QLS order.
-   * Allows you to set different fields or override default mapping from the order's shipping address and customer.
-   * If not provided, default mapping will be used.
-   */
-  getReceiverContact?: (
-    ctx: RequestContext,
-    order: Order
-  ) => FulfillmentOrderInput['receiver_contact'] | undefined;
-  /**
-   * Admin UI tab name where the QLS Product ID custom field is shown on ProductVariant.
-   * `null` will show the custom field on the default tab.
-   * Defaults to 'QLS'.
-   */
-  qlsProductIdUiTab?: string | null;
-  /**
-   * Optional hook called after syncing a variant to QLS.
-   * Receives the full QLS product, a RequestContext, and an Injector, allowing
-   * you to save any additional data to your own database. The saving itself
-   * happens inside this hook — if not provided, nothing is persisted.
-   */
-  saveAdditionalVariantData?: (
-    ctx: RequestContext,
-    injector: Injector,
-    qlsProduct: FulfillmentProductDetail,
-    variant: ProductVariant
-  ) => Promise<void> | void;
-  /**
-   * Additional order items to add to the QLS order.
-   */
-  addAdditionalOrderItems?: (
-    ctx: RequestContext,
-    injector: Injector,
-    order: Order
-  ) => FulfillmentOrderLineInput[] | Promise<FulfillmentOrderLineInput[]>;
+  productSync: {
+    /**
+     * Required to get the EAN and image URL for a product variant.
+     * Also allows you to override other product attributes like name, price, etc.
+     */
+    getAdditionalVariantFields: (
+      ctx: RequestContext,
+      variant: ProductVariant
+    ) => AdditionalVariantFields;
+    /**
+     * Allows you to disable the pulling in of stock levels from QLS. When disabled, stock in Vendure will not be modified based on QLS stock levels.
+     * Defaults to true.
+     */
+    synchronizeStockLevels?: boolean;
+    /**
+     * Optional function to determine if a product variant should be excluded from syncing to QLS.
+     * Return true to exclude the variant from sync, false or undefined to include it.
+     * This is also used during order pushing: variants that are excluded from sync will not be pushed to QLS in an order.
+     */
+    excludeVariantFromSync?: (
+      ctx: RequestContext,
+      injector: Injector,
+      variant: ProductVariant
+    ) => boolean | Promise<boolean>;
+    /**
+     * Optional hook called after syncing a variant to QLS.
+     * Receives the full QLS product, a RequestContext, and an Injector, allowing
+     * you to save any additional data to your own database. The saving itself
+     * happens inside this hook — if not provided, nothing is persisted.
+     */
+    saveAdditionalVariantData?: (
+      ctx: RequestContext,
+      injector: Injector,
+      qlsProduct: FulfillmentProductDetail,
+      variant: ProductVariant
+    ) => Promise<void> | void;
+    /**
+     * Admin UI tab name where the QLS Product ID custom field is shown on ProductVariant.
+     * `null` will show the custom field on the default tab.
+     * Defaults to 'QLS'.
+     */
+    qlsProductIdUiTab?: string | null;
+  };
 }
 
 /**

--- a/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
@@ -65,9 +65,16 @@ import { createSettledOrder } from '../../test/src/shop-utils';
           url: process.env.QLS_URL,
           brandId: process.env.QLS_BRAND_ID!,
         }),
-        getAdditionalOrderFields: () => {
+        pushAdditionalOrderFields: () => {
           return {
             delivery_options: [{ tag: 'dhl-germany-national' }],
+            custom_values: [
+              {
+                key: 'vendureOrder',
+                value:
+                  'https://vendure.huidpraktijkshop.nl/admin/orders/420113',
+              },
+            ],
           };
         },
         getAdditionalVariantFields: (ctx, variant) => ({
@@ -98,7 +105,7 @@ import { createSettledOrder } from '../../test/src/shop-utils';
             },
           ];
         },
-        saveAdditionalData: async (ctx, injector, qlsProduct) => {
+        saveAdditionalVariantData: async (ctx, injector, qlsProduct) => {
           // Just a test implementation
           console.log('Saving additional data for QLS product:', qlsProduct);
         },
@@ -138,10 +145,7 @@ import { createSettledOrder } from '../../test/src/shop-utils';
     shopClient,
     1,
     true,
-    [
-      { id: 'T_1', quantity: 1 },
-      { id: 'T_2', quantity: 2 },
-    ],
+    [{ id: 'T_1', quantity: 1 }],
     undefined,
     {
       input: {

--- a/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
@@ -7,6 +7,7 @@ import {
   EntityHydrator,
   LogLevel,
   mergeConfig,
+  Order,
   OrderProcess,
   ProductVariant,
   TransactionalConnection,
@@ -23,6 +24,7 @@ import { QlsPlugin, qlsSyncAllProductsTask } from '../src';
 import { compileUiExtensions } from '@vendure/ui-devkit/compiler';
 import path from 'path';
 import { createSettledOrder } from '../../test/src/shop-utils';
+import { convertProcessSignalToExitCode } from 'util';
 
 /**
  * The dev-server is just for development. Feel free to break anything here.
@@ -94,6 +96,17 @@ import { createSettledOrder } from '../../test/src/shop-utils';
                 amount_ordered: 1,
               },
             ];
+          },
+          pullAdditionalOrderFields: async (ctx, injector, order, qlsOrder) => {
+            console.log('Order created in QLS:', qlsOrder);
+            console.log('Order created in QLS:', order);
+            // Example: log or save additional data after order is created in QLS
+            injector
+              .get(TransactionalConnection)
+              .rawConnection.getRepository(Order)
+              .update(order.id, {
+                code: order.code + '-JUST_TESTING_HOOK',
+              });
           },
         },
         productSync: {

--- a/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/dev-server.ts
@@ -8,6 +8,8 @@ import {
   LogLevel,
   mergeConfig,
   OrderProcess,
+  ProductVariant,
+  TransactionalConnection,
   VendureConfig,
 } from '@vendure/core';
 import {
@@ -65,49 +67,53 @@ import { createSettledOrder } from '../../test/src/shop-utils';
           url: process.env.QLS_URL,
           brandId: process.env.QLS_BRAND_ID!,
         }),
-        pushAdditionalOrderFields: () => {
-          return {
-            delivery_options: [{ tag: 'dhl-germany-national' }],
-            custom_values: [
-              {
-                key: 'vendureOrder',
-                value:
-                  'https://vendure.huidpraktijkshop.nl/admin/orders/420113',
-              },
-            ],
-          };
-        },
-        getAdditionalVariantFields: (ctx, variant) => ({
-          ean: variant.sku,
-          image_url: `https://pinelab.studio/remote-img/6fa890c7-cd4c-4715-ad73-daa99cd6fe7f_pinelab_e-commerce_hero_image_medium.webp`,
-          // Just testing additionalEANs: [Math.floor(Math.random() * 1000).toString()],
-          additionalEANs: ['somethingelse'],
-        }),
         webhookSecret: '121231',
-        excludeVariantFromSync: async (ctx, injector, variant) => {
-          await injector.get(EntityHydrator).hydrate(ctx, variant, {
-            relations: ['facetValues'],
-          });
-          return variant.id == 1; // Just as a test
+        orderSync: {
+          pushAdditionalOrderFields: () => {
+            return {
+              delivery_options: [{ tag: 'dhl-germany-national' }],
+              custom_values: [
+                {
+                  key: 'vendureOrder',
+                  value:
+                    'https://vendure.huidpraktijkshop.nl/admin/orders/420113',
+                },
+              ],
+            };
+          },
+          autoPushOrders: true,
+          processOrderFrom: (ctx, order) => {
+            return new Date(Date.now() + 1000 * 60 * 60 * 2); // 2 hours from now
+          },
+          addAdditionalOrderItems: async (ctx, injector, order) => {
+            return [
+              {
+                // Just a test
+                name: 'ALHYDRAN 100ml 123421',
+                product_id: 'ec814961-8c84-4e3b-b54b-125efbf1764d',
+                amount_ordered: 1,
+              },
+            ];
+          },
         },
-        autoPushOrders: true,
-        processOrderFrom: (ctx, order) => {
-          return new Date(Date.now() + 1000 * 60 * 60 * 2); // 2 hours from now
-        },
-        qlsProductIdUiTab: null,
-        addAdditionalOrderItems: async (ctx, injector, order) => {
-          return [
-            {
-              // Just a test
-              name: 'ALHYDRAN 100ml 123421',
-              product_id: 'ec814961-8c84-4e3b-b54b-125efbf1764d',
-              amount_ordered: 1,
-            },
-          ];
-        },
-        saveAdditionalVariantData: async (ctx, injector, qlsProduct) => {
-          // Just a test implementation
-          console.log('Saving additional data for QLS product:', qlsProduct);
+        productSync: {
+          getAdditionalVariantFields: (ctx, variant) => ({
+            ean: variant.sku,
+            image_url: `https://pinelab.studio/remote-img/6fa890c7-cd4c-4715-ad73-daa99cd6fe7f_pinelab_e-commerce_hero_image_medium.webp`,
+            // Just testing additionalEANs: [Math.floor(Math.random() * 1000).toString()],
+            additionalEANs: ['somethingelse'],
+          }),
+          excludeVariantFromSync: async (ctx, injector, variant) => {
+            await injector.get(EntityHydrator).hydrate(ctx, variant, {
+              relations: ['facetValues'],
+            });
+            return variant.id == 1; // Just as a test
+          },
+          qlsProductIdUiTab: null,
+          saveAdditionalVariantData: async (ctx, injector, qlsProduct) => {
+            // Just a test implementation
+            console.log('Saving additional data for QLS product:', qlsProduct);
+          },
         },
       }),
       DefaultSchedulerPlugin,
@@ -139,6 +145,11 @@ import { createSettledOrder } from '../../test/src/shop-utils';
       ],
     },
     productsCsvPath: '../test/src/products-import.csv',
+  });
+
+  const connection = server.app.get(TransactionalConnection);
+  await connection.rawConnection.getRepository(ProductVariant).update(1, {
+    customFields: { qlsProductId: 'f54acef4-5bb9-449d-a985-67d7998d21c6' },
   });
 
   await createSettledOrder(

--- a/packages/vendure-plugin-qls-fulfillment/test/e2e.spec.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/e2e.spec.ts
@@ -225,7 +225,7 @@ it('Pushes order to QLS', async () => {
     return false;
   };
   // Add additional order fields
-  QlsPlugin.options.getAdditionalOrderFields = (ctx, injector, order) => {
+  QlsPlugin.options.pushAdditionalOrderFields = (ctx, injector, order) => {
     return {
       delivery_options: [{ tag: 'dhl-germany-national' }],
     };

--- a/packages/vendure-plugin-qls-fulfillment/test/e2e.spec.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/e2e.spec.ts
@@ -37,19 +37,23 @@ beforeAll(async () => {
             brandId: 'mock-brand-id',
           };
         },
-        getAdditionalVariantFields: (ctx, variant) => ({
-          ean: variant.sku,
-          additionalEANs: ['1234567890'],
-        }),
         webhookSecret: '1234',
-        addAdditionalOrderItems: async (ctx, injector, order) => {
-          return [
-            {
-              name: 'Additional free gift',
-              product_id: '1234567890', // Just a test
-              amount_ordered: 3,
-            },
-          ];
+        productSync: {
+          getAdditionalVariantFields: (ctx, variant) => ({
+            ean: variant.sku,
+            additionalEANs: ['1234567890'],
+          }),
+        },
+        orderSync: {
+          addAdditionalOrderItems: async (ctx, injector, order) => {
+            return [
+              {
+                name: 'Additional free gift',
+                product_id: '1234567890', // Just a test
+                amount_ordered: 3,
+              },
+            ];
+          },
         },
       }),
     ],
@@ -198,7 +202,7 @@ it('Updates stock via webhook', async () => {
 });
 
 it('Does not update stock when stock sync is disabled', async () => {
-  QlsPlugin.options.synchronizeStockLevels = false;
+  QlsPlugin.options.productSync.synchronizeStockLevels = false;
   const res = await adminClient.fetch(
     `http://localhost:3050/qls/webhook/${E2E_DEFAULT_CHANNEL_TOKEN}?secret=1234`,
     {
@@ -218,14 +222,22 @@ it('Does not update stock when stock sync is disabled', async () => {
 
 it('Pushes order to QLS', async () => {
   // Test excluded product as well
-  QlsPlugin.options.excludeVariantFromSync = (ctx, injector, variant) => {
+  QlsPlugin.options.productSync.excludeVariantFromSync = (
+    ctx,
+    injector,
+    variant
+  ) => {
     if (variant.sku === 'L2201516') {
       return true;
     }
     return false;
   };
   // Add additional order fields
-  QlsPlugin.options.pushAdditionalOrderFields = (ctx, injector, order) => {
+  QlsPlugin.options.orderSync.pushAdditionalOrderFields = (
+    ctx,
+    injector,
+    order
+  ) => {
     return {
       delivery_options: [{ tag: 'dhl-germany-national' }],
     };

--- a/packages/vendure-plugin-qls-fulfillment/test/e2e.spec.ts
+++ b/packages/vendure-plugin-qls-fulfillment/test/e2e.spec.ts
@@ -242,6 +242,15 @@ it('Pushes order to QLS', async () => {
       delivery_options: [{ tag: 'dhl-germany-national' }],
     };
   };
+  const pulledOrders: Array<{ orderCode: string; qlsId: string }> = [];
+  QlsPlugin.options.orderSync.pullAdditionalOrderFields = (
+    ctx,
+    injector,
+    order,
+    qlsOrder
+  ) => {
+    pulledOrders.push({ orderCode: order.code, qlsId: qlsOrder.id });
+  };
   const createdOrders: string[] = [];
   vi.stubGlobal(
     'fetch',
@@ -294,6 +303,9 @@ it('Pushes order to QLS', async () => {
     ],
     brand_id: 'mock-brand-id',
   });
+  expect(pulledOrders.length).toBe(1);
+  expect(pulledOrders[0].orderCode).toBeDefined();
+  expect(pulledOrders[0].qlsId).toBe('1');
   // await new Promise(resolve => setTimeout(resolve, 5000));
 }, 20000);
 

--- a/packages/vendure-plugin-sendcloud/src/api/sendcloud.service.ts
+++ b/packages/vendure-plugin-sendcloud/src/api/sendcloud.service.ts
@@ -53,7 +53,7 @@ export class SendcloudService implements OnApplicationBootstrap {
     @Inject(PLUGIN_OPTIONS) private options: SendcloudPluginOptions,
     private entityHydrator: EntityHydrator,
     private historyService: HistoryService
-  ) { }
+  ) {}
 
   async onApplicationBootstrap(): Promise<void> {
     // Listen for Settled orders to sync to sendcloud

--- a/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
+++ b/packages/vendure-plugin-sendcloud/test/sendcloud.spec.ts
@@ -360,9 +360,12 @@ describe('SendCloud', () => {
       .post('/api/v2/parcels')
       .times(3) // 1 initial + 2 retries
       .reply(500, { error: { message: 'Internal Server Error' } });
-    const { id: failedOrderId } = await createSettledOrder(shopClient, 1, true, [
-      { id: 'T_1', quantity: 1 },
-    ]);
+    const { id: failedOrderId } = await createSettledOrder(
+      shopClient,
+      1,
+      true,
+      [{ id: 'T_1', quantity: 1 }]
+    );
     await waitFor(async () => {
       const o = await getOrder(adminClient, String(failedOrderId));
       return o?.state === 'PaymentSettled' ? true : undefined;
@@ -403,9 +406,7 @@ describe('SendCloud', () => {
         query OrderHistory($id: ID!) {
           order(id: $id) {
             history(
-              options: {
-                filter: { type: { eq: "SENDCLOUD_NOTIFICATION" } }
-              }
+              options: { filter: { type: { eq: "SENDCLOUD_NOTIFICATION" } } }
             ) {
               totalItems
               items {

--- a/packages/vendure-plugin-simple-cms/src/api/shop.resolver.ts
+++ b/packages/vendure-plugin-simple-cms/src/api/shop.resolver.ts
@@ -121,11 +121,10 @@ export function createShopResolver(
             }
             result[field.name] = ordered;
           } catch (error) {
-            const err = error instanceof Error ? error : new Error(String(error));
+            const err =
+              error instanceof Error ? error : new Error(String(error));
             Logger.error(
-              `Failed to load relation field '${
-                field.name
-              }' for content type '${typeDef.displayName}': ${err.message}`,
+              `Failed to load relation field '${field.name}' for content type '${typeDef.displayName}': ${err.message}`,
               loggerCtx,
               err.stack
             );
@@ -148,9 +147,7 @@ export function createShopResolver(
           );
           const loaded = (await repository.findOne({
             where: { id: relationValue.id as never },
-            ...(hasTranslationsRelation
-              ? { relations: ['translations'] }
-              : {}),
+            ...(hasTranslationsRelation ? { relations: ['translations'] } : {}),
           })) as unknown;
           if (!loaded) {
             continue;
@@ -166,9 +163,7 @@ export function createShopResolver(
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
           Logger.error(
-            `Failed to load relation field '${field.name}' for content type '${
-              typeDef.displayName
-            }': ${err.message}`,
+            `Failed to load relation field '${field.name}' for content type '${typeDef.displayName}': ${err.message}`,
             loggerCtx,
             err.stack
           );

--- a/packages/vendure-plugin-simple-cms/src/gql/graphql-env.d.ts
+++ b/packages/vendure-plugin-simple-cms/src/gql/graphql-env.d.ts
@@ -540,6 +540,6 @@ import * as gqlTada from 'gql.tada';
 
 declare module 'gql.tada' {
   interface setupSchema {
-    introspection: introspection
+    introspection: introspection;
   }
 }

--- a/packages/vendure-plugin-simple-cms/src/gql/graphql.ts
+++ b/packages/vendure-plugin-simple-cms/src/gql/graphql.ts
@@ -2,13 +2,13 @@ import type { introspection } from './graphql-env.d.ts';
 import { initGraphQLTada } from 'gql.tada';
 
 export const graphql = initGraphQLTada<{
-    disableMasking: true;
-    introspection: introspection;
-    scalars: {
-        DateTime: string;
-        JSON: any;
-        Money: number;
-    };
+  disableMasking: true;
+  introspection: introspection;
+  scalars: {
+    DateTime: string;
+    JSON: any;
+    Money: number;
+  };
 }>();
 
 export type { FragmentOf, ResultOf, VariablesOf } from 'gql.tada';

--- a/packages/vendure-plugin-simple-cms/src/services/content-entry.service.ts
+++ b/packages/vendure-plugin-simple-cms/src/services/content-entry.service.ts
@@ -37,7 +37,7 @@ export class ContentEntryService {
     private readonly eventBus: EventBus,
     @Inject(PLUGIN_INIT_OPTIONS)
     private readonly options: SimpleCmsPluginOptions
-  ) { }
+  ) {}
 
   /** Returns a paginated list of all content entries in the current channel. */
   findAll(
@@ -295,11 +295,7 @@ export class ContentEntryService {
       const value = fields[def.name];
       if (def.list && Array.isArray(value)) {
         fields[def.name] = (value as unknown[]).map((item: unknown) => {
-          if (
-            typeof item !== 'object' ||
-            item === null ||
-            !('id' in item)
-          ) {
+          if (typeof item !== 'object' || item === null || !('id' in item)) {
             return item;
           }
           const obj = item as Record<string, unknown>;


### PR DESCRIPTION
# Description

This PR restructures the QLS plugin options into nested \orderSync\ and \productSync\ objects for better clarity and separation of concerns. It also renames \getAdditionalOrderFields\ to \pushAdditionalOrderFields\ to better reflect its purpose.

## Use case
 We need this to:
* be able to save a link to the Vendure Order in QLS
* to save a link to the QLS order in Vendure
* to save 'foldable mailbox package' on a variant based on QLS data.

# Breaking changes

- All plugin options must now be organized under \orderSync\ (for order-related hooks) and \productSync\ (for product-related hooks)
- \getAdditionalOrderFields\ is renamed to \pushAdditionalOrderFields\ and moved under \orderSync\

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in package.json (2.0.0)
- [x] Added changes to the CHANGELOG.md
