### PR TITLE
fix(goedgepickt): send house numbers as strings to Goedgepickt API

### DIFF
--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.3.1 (2026-06-30)
 
 - Send house numbers as strings to Goedgepickt API to prevent "Billing house number moet een tekst zijn" errors
+- Reduced push order job retries from 10 to 3
 
 # 2.3.0 (2026-08-05)
 

--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.1 (2026-06-30)
+
+- Send house numbers as strings to Goedgepickt API to prevent "Billing house number moet een tekst zijn" errors
+
 # 2.3.0 (2026-08-05)
 
 - Upgraded to Vendure 3.6.3

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -668,7 +668,7 @@ export class GoedgepicktService
         shippingLastName: order.customer?.lastName,
         shippingCompany: order.shippingAddress.company,
         shippingAddress: order.shippingAddress.streetLine1,
-        shippingHouseNumber: houseNumber ?? 0,
+        shippingHouseNumber: houseNumber ?? '0',
         shippingHouseNumberAddition: addition,
         shippingZipcode: order.shippingAddress.postalCode,
         shippingCity: order.shippingAddress.city,
@@ -900,7 +900,7 @@ export class GoedgepicktService
   }
 
   static splitHouseNumberAndAddition(houseNumberString: string): {
-    houseNumber?: number;
+    houseNumber?: string;
     addition?: string;
   } {
     const result = houseNumberString.match(/[a-z]+|\d+/gi);
@@ -912,7 +912,7 @@ export class GoedgepicktService
     }
     const [houseNumber, ...addition] = result;
     return {
-      houseNumber: parseInt(houseNumber),
+      houseNumber: houseNumber,
       addition: addition.join() || undefined, // .join() can result in empty string
     };
   }

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -192,7 +192,7 @@ export class GoedgepicktService
           orderCode: event.order.code,
           ctx: event.ctx.serialize(),
         },
-        { retries: 10 }
+        { retries: 3 }
       );
     });
     // Listen for Variant changes

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.types.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.types.ts
@@ -71,7 +71,7 @@ export interface OrderInput {
   shippingLastName?: string;
   shippingCompany?: string;
   shippingAddress: string;
-  shippingHouseNumber: number;
+  shippingHouseNumber: string;
   shippingHouseNumberAddition?: string;
   shippingAddress2?: string;
   shippingZipcode?: string;
@@ -82,7 +82,7 @@ export interface OrderInput {
   billingFirstName?: string;
   billingLastName?: string;
   billingCompany?: string;
-  billingHouseNumber?: number;
+  billingHouseNumber?: string;
   billingHouseNumberAddition?: string;
   billingZipcode?: string;
   billingCity?: string;

--- a/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
+++ b/packages/vendure-plugin-goedgepickt/test/goedgepickt.spec.ts
@@ -267,7 +267,7 @@ describe('Goedgepickt plugin', function () {
     await expect(createOrderPayload.shippingFirstName).toBe('Hayden');
     await expect(createOrderPayload.shippingLastName).toBe('Zieme');
     await expect(createOrderPayload.shippingAddress).toBe('Verzetsstraat');
-    await expect(createOrderPayload.shippingHouseNumber).toBe(12);
+    await expect(createOrderPayload.shippingHouseNumber).toBe('12');
     await expect(createOrderPayload.shippingHouseNumberAddition).toBe('a');
     await expect(createOrderPayload.shippingZipcode).toBe('8923CP');
     await expect(createOrderPayload.shippingCity).toBe('Liwwa');


### PR DESCRIPTION
This fixes the "Billing house number moet een tekst zijn" errors from the Goedgepickt API.

- House numbers are now sent as strings instead of parsed integers.
- Updated the OrderInput types for shippingHouseNumber and billingHouseNumber to string.
- Updated the test expectation to match the new string type.
- Bumped version to 2.3.1 and added a changelog entry.