### PR TITLE
fix(qls): verify barcode deletion and emit event on failure

### DIFF
--- a/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
+++ b/packages/vendure-plugin-accept-blue/src/service/accept-blue-client.ts
@@ -571,11 +571,26 @@ export class AcceptBlueClient {
     const converted: AdditionalChargeInput = { ...input };
     if (input.amount_details) {
       converted.amount_details = {
-        tax: input.amount_details.tax != null ? input.amount_details.tax / 100 : undefined,
-        surcharge: input.amount_details.surcharge != null ? input.amount_details.surcharge / 100 : undefined,
-        shipping: input.amount_details.shipping != null ? input.amount_details.shipping / 100 : undefined,
-        tip: input.amount_details.tip != null ? input.amount_details.tip / 100 : undefined,
-        discount: input.amount_details.discount != null ? input.amount_details.discount / 100 : undefined,
+        tax:
+          input.amount_details.tax != null
+            ? input.amount_details.tax / 100
+            : undefined,
+        surcharge:
+          input.amount_details.surcharge != null
+            ? input.amount_details.surcharge / 100
+            : undefined,
+        shipping:
+          input.amount_details.shipping != null
+            ? input.amount_details.shipping / 100
+            : undefined,
+        tip:
+          input.amount_details.tip != null
+            ? input.amount_details.tip / 100
+            : undefined,
+        discount:
+          input.amount_details.discount != null
+            ? input.amount_details.discount / 100
+            : undefined,
       };
     }
     if (input.line_items) {
@@ -583,7 +598,8 @@ export class AcceptBlueClient {
         ...item,
         cost: item.cost != null ? item.cost / 100 : undefined,
         tax_amount: item.tax_amount != null ? item.tax_amount / 100 : undefined,
-        discount_amount: item.discount_amount != null ? item.discount_amount / 100 : undefined,
+        discount_amount:
+          item.discount_amount != null ? item.discount_amount / 100 : undefined,
       }));
     }
     return converted;

--- a/packages/vendure-plugin-popularity-scores/test/e2e.spec.ts
+++ b/packages/vendure-plugin-popularity-scores/test/e2e.spec.ts
@@ -166,7 +166,9 @@ describe('Sort by Popularity Plugin', function () {
       products: { items: products },
     } = await adminClient.query(GET_PRODUCTS_WITH_POPULARITY_SCORES);
     const laptopProduct = products.find((p: any) => p.name === 'Laptop');
-    expect(laptopProduct.customFields.popularityScore).toBeGreaterThanOrEqual(0);
+    expect(laptopProduct.customFields.popularityScore).toBeGreaterThanOrEqual(
+      0
+    );
   });
 
   it('Fails for unauthenticated calls to calculate popularity endpoint', async () => {

--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.2 (2026-07-01)
+
+- Verify barcode deletion in QLS by fetching remaining barcodes after removal attempt
+- Emit `QlsVariantSyncFailedEvent` and log an error when barcodes fail to be removed from QLS
+
 # 2.0.1 (2026-06-15)
 
 - Fixed fulfillment product detail type

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/lib/qls-client.ts
@@ -60,7 +60,7 @@ export class QlsClient {
   async getFulfillmentProductById(
     fulfillmentProductId: string
   ): Promise<FulfillmentProductDetail | undefined> {
-    const result = await this.rawRequest<any>(
+    const result = await this.rawRequest<FulfillmentProductDetail>(
       'GET',
       `fulfillment/products/${fulfillmentProductId}`
     );
@@ -149,6 +149,19 @@ export class QlsClient {
       );
     }
     return response.data;
+  }
+
+  /**
+   * Get all barcodes for a fulfillment product in QLS
+   */
+  async getBarcodes(
+    productId: string
+  ): Promise<FulfillmentProduct['barcodes']> {
+    const result = await this.rawRequest<FulfillmentProduct['barcodes']>(
+      'GET',
+      `fulfillment/products/${productId}/barcodes`
+    );
+    return result.data ?? [];
   }
 
   /**

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -516,7 +516,8 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         ctx,
         client,
         qlsProduct,
-        additionalEANs
+        additionalEANs,
+        variant
       );
       if (createdOrUpdated === 'not-changed' && updatedEANs) {
         // If nothing changed so far, but EANs changed, then we did update the product in QLS
@@ -539,7 +540,8 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
     ctx: RequestContext,
     client: QlsClient,
     qlsProduct: FulfillmentProduct,
-    additionalEANs: string[] | undefined
+    additionalEANs: string[] | undefined,
+    variant: ProductVariant
   ): Promise<boolean> {
     const existingAdditionalEANs = qlsProduct?.barcodes_and_ean.filter(
       (ean) => ean !== qlsProduct.ean
@@ -580,9 +582,24 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
         client.removeBarcode(qlsProduct.id, barcodeId)
       )
     );
-    if (eansToUpdate.eansToRemove.length > 0) {
+    // Fetch remaining barcodes from QLS to verify deletion worked
+    const remainingBarcodes = await client.getBarcodes(qlsProduct.id);
+    const remainingEansToRemove = eansToUpdate.eansToRemove.filter((ean) =>
+      remainingBarcodes.some((barcode) => barcode.barcode === ean)
+    );
+    if (remainingEansToRemove.length > 0) {
+      const errorMessage = `Failed to remove EANs '${remainingEansToRemove.join(
+        ','
+      )}' from product '${
+        qlsProduct.sku
+      }' in QLS. Barcodes still present after deletion attempt.`;
+      Logger.error(errorMessage, loggerCtx);
+      await this.eventBus.publish(
+        new QlsVariantSyncFailedEvent(ctx, variant, new Date(), errorMessage)
+      );
+    } else if (eansToUpdate.eansToRemove.length > 0) {
       Logger.info(
-        `Removed EANs '${eansToUpdate.eansToRemove.join(',')} from product '${
+        `Removed EANs '${eansToUpdate.eansToRemove.join(',')}' from product '${
           qlsProduct.sku
         }' in QLS`,
         loggerCtx


### PR DESCRIPTION
- Added `getBarcodes()` to `QlsClient` to fetch remaining barcodes from QLS after deletion attempt
- After attempting to remove barcodes from QLS, the plugin now verifies the deletion by fetching the remaining barcodes
- If barcodes are still present after deletion, emits `QlsVariantSyncFailedEvent` and logs an error
- If barcodes are successfully deleted, logs the existing success message
- Fixed a typo in the "Removed EANs" log message (missing closing quote)
- Bumped version to 2.0.2