### PR TITLE
feat(validate-cart): return active order from validateActiveOrder mutation

### DIFF
--- a/packages/vendure-plugin-validate-cart/CHANGELOG.md
+++ b/packages/vendure-plugin-validate-cart/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.3.0 (2026-07-01)
+
+- `validateActiveOrder` now returns a `ValidateActiveOrderResult` object with both `errors` and `order` fields.
+- The active order is refetched after validation, so any modifications made by a custom validation strategy are reflected in the returned order.
+- Uses Vendure's built-in `@Relations` decorator to load the requested order relations in the response.
+- **Breaking change:** The `validateActiveOrder` mutation return type changed from `[ActiveOrderValidationError!]!` to `ValidateActiveOrderResult!`.
+
 # 1.2.0 (2026-08-05)
 
 - Upgraded to Vendure 3.6.3

--- a/packages/vendure-plugin-validate-cart/README.md
+++ b/packages/vendure-plugin-validate-cart/README.md
@@ -32,14 +32,26 @@ Depending on your validation strategy, you probably want to call the `validateAc
 ```gql
 mutation ValidateActiveOrderMutation {
   validateActiveOrder {
-    message
-    errorCode
-    relatedOrderLineIds
+    errors {
+      message
+      errorCode
+      relatedOrderLineIds
+    }
+    order {
+      id
+      lines {
+        productVariant {
+          product {
+            id
+          }
+        }
+      }
+    }
   }
 }
 ```
 
-If any validation errors are returned, you can display the error to the user with the corresponding order lines. You could even automatically remove the items from the cart based on the `relatedOrderLineIds`.
+If any validation errors are returned, you can display the error to the user with the corresponding order lines. You could even automatically remove the items from the cart based on the `relatedOrderLineIds`. The `order` field returns the active order after validation, including any modifications made by a custom validation strategy.
 
 This action is a mutation rather than a query, because your custom validation logic might need to modify the order, for example to 'lock' an order after validation until payment is completed.
 

--- a/packages/vendure-plugin-validate-cart/codegen.yml
+++ b/packages/vendure-plugin-validate-cart/codegen.yml
@@ -11,3 +11,4 @@ generates:
       scalars:
         DateTime: Date
         ID: string | number
+        Order: '@vendure/core#Order'

--- a/packages/vendure-plugin-validate-cart/package.json
+++ b/packages/vendure-plugin-validate-cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-validate-cart",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Vendure plugin for validating the cart before checkout",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-validate-cart/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-validate-cart/src/api/api-extensions.ts
@@ -7,13 +7,28 @@ export const shopApiExtensions = gql`
     relatedOrderLineIds: [ID!]
   }
 
+  type ValidateActiveOrderResult {
+    errors: [ActiveOrderValidationError!]!
+    order: Order!
+  }
+
   extend type Mutation {
     """
     Validate the active order. This will run all validation rules and return a list of errors if any.
-    Returns empty array if no validation errors are found.
+    Returns an empty errors array if no validation errors are found. The active order is returned as well,
+    so it can be used to display the latest state after validation, including any potential modifications
+    made by a custom validation strategy.
 
     This is a mutation, because it is valid to reserve stock, or transition the order to a custom state for example.
     """
-    validateActiveOrder: [ActiveOrderValidationError!]!
+    validateActiveOrder: ValidateActiveOrderResult!
   }
+`;
+
+/**
+ * These scalars are only declared to satisfy the codegen tool, which only sees this plugin's schema.
+ * The Vendure runtime already defines the real `Order` type.
+ */
+export const scalars = gql`
+  scalar Order
 `;

--- a/packages/vendure-plugin-validate-cart/src/api/validate-cart.resolver.ts
+++ b/packages/vendure-plugin-validate-cart/src/api/validate-cart.resolver.ts
@@ -1,6 +1,12 @@
 import { Mutation, Resolver } from '@nestjs/graphql';
-import { Ctx, RequestContext } from '@vendure/core';
-import { ActiveOrderValidationError } from '../api/generated/graphql';
+import {
+  Ctx,
+  Order,
+  Relations,
+  RelationPaths,
+  RequestContext,
+} from '@vendure/core';
+import { ValidateActiveOrderResult } from '../api/generated/graphql';
 import { ValidateCartService } from '../services/validate-cart.service';
 
 @Resolver()
@@ -9,8 +15,9 @@ export class ValidateCartResolver {
 
   @Mutation()
   async validateActiveOrder(
-    @Ctx() ctx: RequestContext
-  ): Promise<ActiveOrderValidationError[]> {
-    return await this.validateCartService.validateActiveOrder(ctx);
+    @Ctx() ctx: RequestContext,
+    @Relations(Order) relations: RelationPaths<Order>
+  ): Promise<ValidateActiveOrderResult> {
+    return await this.validateCartService.validateActiveOrder(ctx, relations);
   }
 }

--- a/packages/vendure-plugin-validate-cart/src/services/validate-cart.service.ts
+++ b/packages/vendure-plugin-validate-cart/src/services/validate-cart.service.ts
@@ -5,6 +5,9 @@ import {
   EntityHydrator,
   Injector,
   Logger,
+  Order,
+  OrderService,
+  RelationPaths,
   RequestContext,
   UserInputError,
 } from '@vendure/core';
@@ -21,33 +24,35 @@ export class ValidateCartService {
     private readonly options: ValidateCartInitOptions,
     private readonly activeOrderService: ActiveOrderService,
     private readonly entityHydrator: EntityHydrator,
+    private readonly orderService: OrderService,
     readonly moduleRef: ModuleRef
   ) {
     this.injector = new Injector(this.moduleRef);
   }
 
   async validateActiveOrder(
-    ctx: RequestContext
-  ): Promise<ActiveOrderValidationError[]> {
+    ctx: RequestContext,
+    relations: RelationPaths<Order>
+  ): Promise<{ errors: ActiveOrderValidationError[]; order: Order }> {
     const start = Date.now();
-    const validationStrategy = this.options.validationStrategy;
-    if (!validationStrategy) {
-      return []; // A bit strange, but no strategy means always valid
-    }
     const activeOrder = await this.activeOrderService.getActiveOrder(ctx, {});
     if (!activeOrder) {
       throw new UserInputError('No active order found');
     }
-    if (validationStrategy.loadOrderRelations) {
-      await this.entityHydrator.hydrate(ctx, activeOrder, {
-        relations: validationStrategy.loadOrderRelations,
-      });
+    const validationStrategy = this.options.validationStrategy;
+    let result: ActiveOrderValidationError[] = [];
+    if (validationStrategy) {
+      if (validationStrategy.loadOrderRelations) {
+        await this.entityHydrator.hydrate(ctx, activeOrder, {
+          relations: validationStrategy.loadOrderRelations,
+        });
+      }
+      result = await validationStrategy.validate(
+        ctx,
+        activeOrder,
+        this.injector
+      );
     }
-    const result = await validationStrategy.validate(
-      ctx,
-      activeOrder,
-      this.injector
-    );
     const duration = Date.now() - start;
     if (
       this.options.logWarningAfterMs &&
@@ -55,6 +60,14 @@ export class ValidateCartService {
     ) {
       Logger.warn(`Active Order validation took ${duration}ms`, loggerCtx);
     }
-    return result;
+    const order = await this.orderService.findOne(
+      ctx,
+      activeOrder.id,
+      relations
+    );
+    if (!order) {
+      throw new UserInputError('No active order found');
+    }
+    return { errors: result, order };
   }
 }

--- a/packages/vendure-plugin-validate-cart/test/validate-cart.spec.ts
+++ b/packages/vendure-plugin-validate-cart/test/validate-cart.spec.ts
@@ -38,9 +38,21 @@ const UPDATE_PRODUCT_VARIANTS = gql`
 const VALIDATE_ACTIVE_ORDER = gql`
   mutation ValidateActiveOrderMutation {
     validateActiveOrder {
-      message
-      errorCode
-      relatedOrderLineIds
+      errors {
+        message
+        errorCode
+        relatedOrderLineIds
+      }
+      order {
+        id
+        lines {
+          productVariant {
+            product {
+              id
+            }
+          }
+        }
+      }
     }
   }
 `;
@@ -105,7 +117,12 @@ it('Adds 4 items to cart', async () => {
 
 it('Validates cart without errors', async () => {
   const { validateActiveOrder } = await shopClient.query(VALIDATE_ACTIVE_ORDER);
-  expect(validateActiveOrder.length).toBe(0);
+  expect(validateActiveOrder.errors.length).toBe(0);
+  expect(validateActiveOrder.order).toBeDefined();
+  expect(validateActiveOrder.order.lines.length).toBe(1);
+  expect(validateActiveOrder.order.lines[0].productVariant.product.id).toBe(
+    'T_1'
+  );
 });
 
 it('Logged a warning', async () => {
@@ -138,12 +155,17 @@ it('Updates stock for T_1 to 2', async () => {
 
 it('Returns errors on validation', async () => {
   const { validateActiveOrder } = await shopClient.query(VALIDATE_ACTIVE_ORDER);
-  expect(validateActiveOrder.length).toBe(1);
-  expect(validateActiveOrder[0].message).toBe(
+  expect(validateActiveOrder.errors.length).toBe(1);
+  expect(validateActiveOrder.errors[0].message).toBe(
     "Insufficient stock for variants: 'Laptop 13 inch 8GB'"
   );
-  expect(validateActiveOrder[0].errorCode).toBe('ITEM_UNAVAILABLE');
-  expect(validateActiveOrder[0].relatedOrderLineIds).toEqual(['T_1']);
+  expect(validateActiveOrder.errors[0].errorCode).toBe('ITEM_UNAVAILABLE');
+  expect(validateActiveOrder.errors[0].relatedOrderLineIds).toEqual(['T_1']);
+  expect(validateActiveOrder.order).toBeDefined();
+  expect(validateActiveOrder.order.lines.length).toBe(1);
+  expect(validateActiveOrder.order.lines[0].productVariant.product.id).toBe(
+    'T_1'
+  );
 });
 
 afterAll(async () => {


### PR DESCRIPTION
# Description

This PR changes the `validateActiveOrder` mutation to return both validation errors and the active order (refreshed after any strategy modifications). It uses Vendure's built-in `@Relations` decorator to load requested order relations in the response.

# To do before merge

- [ ] N/A

# Breaking changes

The `validateActiveOrder` mutation return type changed from `[ActiveOrderValidationError!]!` to `ValidateActiveOrderResult!`.

# Screenshots

N/A

# Checklist

📌 Always:

- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:

- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:

- [x] Increased the version number in `package.json`
- [x] Added changes to the `CHANGELOG.md`