### PR TITLE
fix(goedgepickt): update image placeholder check for .jpg and new products

### DIFF
--- a/packages/vendure-plugin-goedgepickt/CHANGELOG.md
+++ b/packages/vendure-plugin-goedgepickt/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2 (2026-07-02)
+
+- Fix image placeholder detection so Vendure images are sent when Goedgepickt's placeholder is `.jpg` and so new products get the Vendure image
+
 # 2.3.1 (2026-06-30)
 
 - Send house numbers as strings to Goedgepickt API to prevent "Billing house number moet een tekst zijn" errors

--- a/packages/vendure-plugin-goedgepickt/package.json
+++ b/packages/vendure-plugin-goedgepickt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-goedgepickt",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Vendure plugin for integration with the Goedgepickt order picking platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
+++ b/packages/vendure-plugin-goedgepickt/src/api/goedgepickt.service.ts
@@ -536,7 +536,10 @@ export class GoedgepicktService
       const ggProductInput = this.mapToProductInput(variant);
       const existing = await client.findProductBySku(sku);
       const uuid = existing?.uuid;
-      if (!existing?.picture?.toLowerCase().includes('image_placeholder.png')) {
+      if (
+        existing &&
+        !existing.picture?.toLowerCase().includes('image_placeholder')
+      ) {
         // The picture on GG is not a placeholder, so don't update it again.
         ggProductInput.picture = undefined; // Don't update picture on existing product
       }


### PR DESCRIPTION
Fix image placeholder detection so Vendure images are sent when Goedgepickt's placeholder is  and so new products get the Vendure image.