### PR TITLE
feat(invoices): save local invoices in channel-token subfolder

### DIFF
--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.1.0 (2026-07-09)
 
-- Local storage strategy now saves invoices in a subfolder per channel (`invoices/<channelToken>/<filename>`), consistent with the Google Storage strategy.
+- Local storage strategy now saves invoices in a subfolder per channel (`invoices/<channelToken>/<filename>`), consistent with the Google Storage strategy. No need to migrate old paths, references stay in tact.
 
 # 6.0.1 (2026-06-09)
 

--- a/packages/vendure-plugin-invoices/CHANGELOG.md
+++ b/packages/vendure-plugin-invoices/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.0 (2026-07-09)
+
+- Local storage strategy now saves invoices in a subfolder per channel (`invoices/<channelToken>/<filename>`), consistent with the Google Storage strategy.
+
 # 6.0.1 (2026-06-09)
 
 - Fixed server crash when invoice file is missing from disk. `LocalFileStrategy.streamFile()` and `streamMultiple()` now check file existence before streaming and attach error handlers to prevent unhandled stream errors.

--- a/packages/vendure-plugin-invoices/package.json
+++ b/packages/vendure-plugin-invoices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/pinelab-invoice-plugin",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Vendure plugin for PDF invoice generation",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-invoices/src/strategies/storage/local-file-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/strategies/storage/local-file-strategy.ts
@@ -19,13 +19,8 @@ export class LocalFileStrategy implements LocalStorageStrategy {
     channelToken: string,
     isCreditInvoice: boolean
   ) {
-    if (!(await exists(this.invoiceDir))) {
-      await fs.mkdir(this.invoiceDir);
-    }
     const channelDir = `${this.invoiceDir}/${channelToken}`;
-    if (!(await exists(channelDir))) {
-      await fs.mkdir(channelDir);
-    }
+    await fs.mkdir(channelDir, { recursive: true });
     let name = `${invoiceNumber}.pdf`;
     if (isCreditInvoice) {
       name = `${invoiceNumber}-credit.pdf`;

--- a/packages/vendure-plugin-invoices/src/strategies/storage/local-file-strategy.ts
+++ b/packages/vendure-plugin-invoices/src/strategies/storage/local-file-strategy.ts
@@ -22,11 +22,15 @@ export class LocalFileStrategy implements LocalStorageStrategy {
     if (!(await exists(this.invoiceDir))) {
       await fs.mkdir(this.invoiceDir);
     }
+    const channelDir = `${this.invoiceDir}/${channelToken}`;
+    if (!(await exists(channelDir))) {
+      await fs.mkdir(channelDir);
+    }
     let name = `${invoiceNumber}.pdf`;
     if (isCreditInvoice) {
       name = `${invoiceNumber}-credit.pdf`;
     }
-    const newPath = `${this.invoiceDir}/${name}`;
+    const newPath = `${channelDir}/${name}`;
     await fs.copyFile(tmpFile, newPath);
     await fs.unlink(tmpFile);
     return newPath;


### PR DESCRIPTION
- Local storage strategy now saves invoices in a subfolder per channel (`invoices/<channelToken>/<filename>`), consistent with the Google Storage strategy.
- Bumps `@pinelab/pinelab-invoice-plugin` to `6.1.0`.