### PR TITLE
fix(google-sheet): url-encode sheet names in google sheets api requests

### DIFF
--- a/docs-website/src/content/guides/vendure-common-errors-faq.md
+++ b/docs-website/src/content/guides/vendure-common-errors-faq.md
@@ -1,0 +1,34 @@
+---
+slug: vendure-common-errors-faq
+title: Vendure Common Errors
+description: Common Vendure errors and how to fix them. Short, concise entries for issues you might hit when running or extending a Vendure shop.
+pubDate: 2026-07-09
+author: Martijn
+heroImage: https://images.unsplash.com/photo-1516567832553-66232148f74c?q=80&w=2064&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+heroImageSmall: https://images.unsplash.com/photo-1516567832553-66232148f74c?q=80&w=500&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+heroImageAlt: Warning sign on a road
+---
+
+Common errors and how to fix them. Entries are kept short and concise because many more will be added over time.
+
+## `Enum "Permission" cannot represent value: "MyCustomPermission"`
+
+A custom permission can stay assigned to a role after a plugin is removed. This causes a `Permission` enum error because the value no longer exists. Remove the stale permission from the `role` table:
+
+```sql
+UPDATE role
+SET permissions = TRIM(BOTH ',' FROM
+  REPLACE(
+    REPLACE(
+      REPLACE(permissions, 'MyCustomPermission,', ''),
+      ',MyCustomPermission',
+      ''
+    ),
+    'MyCustomPermission',
+    ''
+  )
+)
+WHERE permissions LIKE '%MyCustomPermission%';
+```
+
+_More to come!_

--- a/packages/vendure-plugin-google-sheet-loader/CHANGELOG.md
+++ b/packages/vendure-plugin-google-sheet-loader/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.1 (2026-07-10)
+
+- Fixed URL encoding of sheet names in Google Sheets API requests
+
 # 1.2.0 (2026-08-05)
 
 - Upgraded to Vendure 3.6.3

--- a/packages/vendure-plugin-google-sheet-loader/package.json
+++ b/packages/vendure-plugin-google-sheet-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-google-sheet-loader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Vendure plugin for loading data from a Google Sheet",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-google-sheet-loader/src/services/google-sheet.service.ts
+++ b/packages/vendure-plugin-google-sheet-loader/src/services/google-sheet.service.ts
@@ -66,7 +66,11 @@ export class GoogleSheetService implements OnModuleInit {
     const sheetMetadata = dataStrategy.getSheetMetadata(ctx) as SheetMetadata; // We know it's a SheetMetadata because the strategy returned metadata above
     const sheets: SheetContent[] = [];
     for (const sheetName of sheetMetadata.sheets) {
-      const requestUrl = `${GOOGLE_SPREADSHEET_URL}/${sheetMetadata.spreadSheetId}/values/${sheetName}?key=${this.options.googleApiKey}`;
+      const requestUrl = `${GOOGLE_SPREADSHEET_URL}/${
+        sheetMetadata.spreadSheetId
+      }/values/${encodeURIComponent(sheetName)}?key=${
+        this.options.googleApiKey
+      }`;
       const result = await fetch(requestUrl);
       if (!result.ok) {
         throw new UserInputError(


### PR DESCRIPTION
Sheet names with spaces or special characters (like "Gazebos + Parasols") were sent unencoded in the Google Sheets API request URL, causing 400 Bad Request errors. This fix applies URL encoding to sheet names before constructing the API URL.