### PR TITLE
fix(admin-social-auth): correct repository url for npm provenance verification

### DIFF
--- a/packages/vendure-plugin-admin-social-auth/CHANGELOG.md
+++ b/packages/vendure-plugin-admin-social-auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.1 (2026-07-10)
+
+- Fixed repository URL in package.json for npm provenance verification
+
 # 2.3.0 (2026-08-05)
 
 - Upgraded to Vendure 3.6.3

--- a/packages/vendure-plugin-admin-social-auth/package.json
+++ b/packages/vendure-plugin-admin-social-auth/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@pinelab/vendure-plugin-admin-social-auth",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Plugin to allow authentication for administrators with socials like Google",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
-  "repository": "https://github.com/vendure-ecommerce/plugin-template",
+  "repository": "https://github.com/Pinelab-studio/pinelab-vendure-plugins",
   "license": "MIT",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
This patch corrects the `repository` URL in `package.json` to match the actual GitHub repository (`https://github.com/Pinelab-studio/pinelab-vendure-plugins`), resolving the npm publish `E422 Unprocessable Entity` error caused by Sigstore provenance verification failure.

Also bumps the patch version to `2.3.1` and updates the changelog.