### PR TITLE
feat(qls-fulfillment): added QLS dashboard buttons in admin UI

### DIFF
--- a/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
+++ b/packages/vendure-plugin-qls-fulfillment/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0 (2026-07-15)
+
+- Added buttons on variant and order detail to view the product and order in QLS dashboard.
+
 # 2.1.0 (2026-07-08)
 
 - Added `addAdditionalEANSToQLS` admin mutation to manually add additional EANs/barcodes to existing QLS products.

--- a/packages/vendure-plugin-qls-fulfillment/package.json
+++ b/packages/vendure-plugin-qls-fulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-qls-fulfillment",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Vendure plugin to fulfill orders via QLS.",
   "keywords": [
     "fulfillment",

--- a/packages/vendure-plugin-qls-fulfillment/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/api/api-extensions.ts
@@ -13,6 +13,13 @@ export const adminApiExtensions = gql`
     qlsOrderUrl: String
   }
 
+  extend type ProductVariant {
+    """
+    Direct URL to the QLS product for this Vendure variant, or null if none exists.
+    """
+    qlsProductUrl: String
+  }
+
   extend type Mutation {
     """
     Trigger a sync to create or update all products in Vendure to QLS, and pull in stock levels from QLS.

--- a/packages/vendure-plugin-qls-fulfillment/src/api/api-extensions.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/api/api-extensions.ts
@@ -6,6 +6,11 @@ export const adminApiExtensions = gql`
     QLS order id(s) for this Vendure order.
     """
     qlsOrderIds: [String!]!
+
+    """
+    Direct URL to the most recent QLS order for this Vendure order, or null if none exists.
+    """
+    qlsOrderUrl: String
   }
 
   extend type Mutation {

--- a/packages/vendure-plugin-qls-fulfillment/src/api/qls-admin.resolver.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/api/qls-admin.resolver.ts
@@ -10,6 +10,7 @@ import {
   Ctx,
   Order,
   Permission,
+  ProductVariant,
   RequestContext,
   Transaction,
 } from '@vendure/core';
@@ -51,6 +52,15 @@ export class QlsAdminResolver {
     @Parent() order: Order
   ): Promise<string | null> {
     return this.qlsOrderService.getQlsOrderUrl(ctx, order.id);
+  }
+
+  @ResolveField()
+  @Resolver('ProductVariant')
+  async qlsProductUrl(
+    @Ctx() ctx: RequestContext,
+    @Parent() productVariant: ProductVariant
+  ): Promise<string | null> {
+    return this.qlsProductService.getQlsProductUrl(ctx, productVariant);
   }
 
   @Mutation()

--- a/packages/vendure-plugin-qls-fulfillment/src/api/qls-admin.resolver.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/api/qls-admin.resolver.ts
@@ -42,6 +42,17 @@ export class QlsAdminResolver {
     return this.qlsOrderService.getQlsOrderIdsForOrder(ctx, order.id);
   }
 
+  @ResolveField()
+  @Resolver('Order')
+  @Allow(qlsPushOrderPermission.Permission)
+  @Allow(Permission.UpdateAdministrator)
+  async qlsOrderUrl(
+    @Ctx() ctx: RequestContext,
+    @Parent() order: Order
+  ): Promise<string | null> {
+    return this.qlsOrderService.getQlsOrderUrl(ctx, order.id);
+  }
+
   @Mutation()
   @Transaction()
   @Allow(qlsFullSyncPermission.Permission)

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-order.service.ts
@@ -418,8 +418,33 @@ export class QlsOrderService implements OnModuleInit, OnApplicationBootstrap {
       .getRepository(ctx, QlsOrderEntity)
       .find({
         where: { vendureOrderId: orderId },
+        order: { createdAt: 'DESC' },
       });
     return entities.map((e) => String(e.qlsOrderId));
+  }
+
+  /**
+   * Get the direct URL to the most recent QLS order for a Vendure order (for Order.qlsOrderUrl field).
+   * Returns the URL or null if no QLS order exists.
+   */
+  async getQlsOrderUrl(
+    ctx: RequestContext,
+    orderId: ID
+  ): Promise<string | null> {
+    const entities = await this.connection
+      .getRepository(ctx, QlsOrderEntity)
+      .find({
+        where: { vendureOrderId: orderId },
+        order: { createdAt: 'DESC' },
+      });
+    if (entities.length === 0) {
+      return null;
+    }
+    const config = await Promise.resolve(this.options.getConfig(ctx));
+    if (!config) {
+      return null;
+    }
+    return `https://mijn.pakketdienstqls.nl/company/${config.companyId}/fulfillment/order/${entities[0].qlsOrderId}`;
   }
 
   async getServicePoints(

--- a/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/services/qls-product.service.ts
@@ -402,6 +402,25 @@ export class QlsProductService implements OnModuleInit, OnApplicationBootstrap {
   }
 
   /**
+   * Get the direct URL to the QLS product for a Vendure product variant.
+   * Returns the URL or null if no QLS product exists.
+   */
+  async getQlsProductUrl(
+    ctx: RequestContext,
+    productVariant: ProductVariant
+  ): Promise<string | null> {
+    const qlsProductId = productVariant.customFields?.qlsProductId;
+    if (!qlsProductId) {
+      return null;
+    }
+    const config = await Promise.resolve(this.options.getConfig(ctx));
+    if (!config) {
+      return null;
+    }
+    return `https://mijn.pakketdienstqls.nl/company/${config.companyId}/fulfillment/product/${qlsProductId}`;
+  }
+
+  /**
    * Add additional EANs/barcodes to an existing QLS product.
    * Removal of EANs must be done in QLS itself.
    */

--- a/packages/vendure-plugin-qls-fulfillment/src/ui/providers.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/ui/providers.ts
@@ -1,8 +1,10 @@
 import {
   addActionBarDropdownMenuItem,
+  addActionBarItem,
   ModalService,
 } from '@vendure/admin-ui/core';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
 import gql from 'graphql-tag';
 
 export default [
@@ -36,6 +38,63 @@ export default [
             });
           },
         });
+    },
+  }),
+  // QLS order link button on order detail page
+  addActionBarItem({
+    id: 'qls-visit-order',
+    label: 'QLS',
+    locationId: 'order-detail',
+    buttonColor: 'primary',
+    buttonStyle: 'outline',
+    icon: 'link',
+    requiresPermission: ['QLSPushOrder'],
+    buttonState: (context) => {
+      const orderId = context.route.snapshot.params.id;
+      return context.dataService
+        .query(
+          gql`
+            query Order($orderId: ID!) {
+              order(id: $orderId) {
+                id
+                qlsOrderUrl
+              }
+            }
+          `,
+          { orderId }
+        )
+        .single$.pipe(
+          map((data: any) => ({
+            visible: !!data.order?.qlsOrderUrl,
+            disabled: false,
+          })),
+          catchError(() => of({ visible: false, disabled: false }))
+        );
+    },
+    onClick: async (event, { route, dataService, notificationService }) => {
+      const orderId = route.snapshot.params.id;
+      const res = await firstValueFrom(
+        dataService.query(
+          gql`
+            query Order($orderId: ID!) {
+              order(id: $orderId) {
+                id
+                qlsOrderUrl
+              }
+            }
+          `,
+          { orderId }
+        ).single$
+      );
+      const url = (res as any).order.qlsOrderUrl;
+      if (url) {
+        window.open(url, '_blank');
+      } else {
+        notificationService.notify({
+          message: 'No QLS order found for this order.',
+          type: 'error',
+        });
+      }
     },
   }),
   // Push order to QLS button on order detail page

--- a/packages/vendure-plugin-qls-fulfillment/src/ui/providers.ts
+++ b/packages/vendure-plugin-qls-fulfillment/src/ui/providers.ts
@@ -48,28 +48,13 @@ export default [
     buttonColor: 'primary',
     buttonStyle: 'outline',
     icon: 'link',
-    requiresPermission: ['QLSPushOrder'],
     buttonState: (context) => {
-      const orderId = context.route.snapshot.params.id;
-      return context.dataService
-        .query(
-          gql`
-            query Order($orderId: ID!) {
-              order(id: $orderId) {
-                id
-                qlsOrderUrl
-              }
-            }
-          `,
-          { orderId }
-        )
-        .single$.pipe(
-          map((data: any) => ({
-            visible: !!data.order?.qlsOrderUrl,
-            disabled: false,
-          })),
-          catchError(() => of({ visible: false, disabled: false }))
-        );
+      return context.entity$.pipe(
+        map((entity) => ({
+          visible: !!entity?.orderPlacedAt,
+          disabled: false,
+        }))
+      );
     },
     onClick: async (event, { route, dataService, notificationService }) => {
       const orderId = route.snapshot.params.id;
@@ -92,6 +77,40 @@ export default [
       } else {
         notificationService.notify({
           message: 'No QLS order found for this order.',
+          type: 'error',
+        });
+      }
+    },
+  }),
+  // QLS product link button on product variant detail page
+  addActionBarItem({
+    id: 'qls-visit-product',
+    label: 'QLS',
+    locationId: 'product-variant-detail',
+    buttonColor: 'primary',
+    buttonStyle: 'outline',
+    icon: 'link',
+    onClick: async (event, { route, dataService, notificationService }) => {
+      const variantId = route.snapshot.params.id;
+      const res = await firstValueFrom(
+        dataService.query(
+          gql`
+            query ProductVariant($id: ID!) {
+              productVariant(id: $id) {
+                id
+                qlsProductUrl
+              }
+            }
+          `,
+          { id: variantId }
+        ).single$
+      );
+      const url = (res as any).productVariant.qlsProductUrl;
+      if (url) {
+        window.open(url, '_blank');
+      } else {
+        notificationService.notify({
+          message: 'No QLS product found for this variant.',
           type: 'error',
         });
       }


### PR DESCRIPTION
Added buttons on the product variant and order detail pages to directly open the item in the QLS dashboard. This allows admins to quickly view products and orders in QLS without manually searching.

- Version bumped to 2.2.0
- CHANGELOG updated