### PR TITLE
feat(stock-monitoring): listen to StockMovementEvents for threshold checks

### DIFF
--- a/packages/vendure-plugin-stock-monitoring/CHANGELOG.md
+++ b/packages/vendure-plugin-stock-monitoring/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.0 (2026-07-15)
+
+- Listen to StockMovementEvent for ALLOCATION, SALE, and ADJUSTMENT movements to check if stock dropped below threshold
+- Removed OrderPlacedEvent-based stock monitoring in favor of StockMovementEvent-based monitoring
+- Renamed `StockDroppedBelowThresholdEvent` fields from `stockBeforeOrder`/`stockAfterOrder` to `stockBeforeAdjustment`/`stockAfterAdjustment`
+- Removed `order` field from `StockDroppedBelowThresholdEvent`
+
 # 2.2.1 (2026-05-29)
 
 - Fixed stock-monitoring widget to display items sorted from lowest to highest available stock

--- a/packages/vendure-plugin-stock-monitoring/README.md
+++ b/packages/vendure-plugin-stock-monitoring/README.md
@@ -40,4 +40,4 @@ When you start the server and login, you can find `stock-levels` under the `add 
 ### Caveats
 
 1. This plugin doesn't use the `StockLocationStrategy` because of performance reasons. Instead, it fetches the stock level for each variant from the database and calculates its absolute stock based on the `stockOnHand` and `stockAllocated` fields.
-2. Stock notifications are only emitted after an order is placed. Manual stock changes via the admin UI will not trigger a notification.
+2. Performance: Each allocation, sale or adjustment in `StockMovementEvent` will create a job that triggers a stock check: get saleable stock, compare with variant threshold, and emit event if variant dropped below threshold.

--- a/packages/vendure-plugin-stock-monitoring/package.json
+++ b/packages/vendure-plugin-stock-monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-stock-monitoring",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "Vendure plugin for monitoring stock levels per variant. View low stock in your dashboard or get notified through an event.",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",

--- a/packages/vendure-plugin-stock-monitoring/src/services/stock-dropped-below-threshold.ts
+++ b/packages/vendure-plugin-stock-monitoring/src/services/stock-dropped-below-threshold.ts
@@ -1,4 +1,4 @@
-import { Order, RequestContext, VendureEvent } from '@vendure/core';
+import { RequestContext, VendureEvent } from '@vendure/core';
 import { ProductVariant } from '@vendure/core';
 
 /**

--- a/packages/vendure-plugin-stock-monitoring/src/services/stock-dropped-below-threshold.ts
+++ b/packages/vendure-plugin-stock-monitoring/src/services/stock-dropped-below-threshold.ts
@@ -8,9 +8,8 @@ export class StockDroppedBelowThresholdEvent extends VendureEvent {
   constructor(
     public ctx: RequestContext,
     public productVariant: ProductVariant,
-    public stockBeforeOrder: number,
-    public stockAfterOrder: number,
-    public order?: Order
+    public stockBeforeAdjustment: number,
+    public stockAfterAdjustment: number
   ) {
     super();
   }

--- a/packages/vendure-plugin-stock-monitoring/src/services/stock-monitoring.service.ts
+++ b/packages/vendure-plugin-stock-monitoring/src/services/stock-monitoring.service.ts
@@ -11,9 +11,6 @@ import {
   JobQueue,
   JobQueueService,
   Logger,
-  Order,
-  OrderPlacedEvent,
-  OrderService,
   ProductVariant,
   ProductVariantService,
   RequestContext,
@@ -29,12 +26,14 @@ import { StockDroppedBelowThresholdEvent } from './stock-dropped-below-threshold
 
 type StockMonitoringJobData = {
   ctx: SerializedRequestContext;
-  orderId: ID;
-  lines: Array<{
-    variantId: ID;
-    variantStockThreshold?: number;
-    orderLineQuantity: number;
-  }>;
+  variantId: ID;
+  /**
+   * The amount with which the stock was decreased. E.g. 3 means stock was decreased by 3.
+   * This decrement already happened by the time this job is created.
+   *
+   * Decrement could be caused by adjustments, sales, or allocations.
+   */
+  saleableStockDecrement: number;
 };
 
 @Injectable()
@@ -51,8 +50,7 @@ export class StockMonitoringService
     private readonly variantService: ProductVariantService,
     private readonly cacheService: CacheService,
     private readonly stockLevelService: StockLevelService,
-    private readonly eventBus: EventBus,
-    private readonly orderService: OrderService
+    private readonly eventBus: EventBus
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -67,18 +65,8 @@ export class StockMonitoringService
   }
 
   onApplicationBootstrap(): void {
-    // Trigger stock monitoring event for each Order Placed Event
-    this.eventBus.ofType(OrderPlacedEvent).subscribe((event) => {
-      this.triggerStockMonitoring(event.ctx, event.order).catch((e) => {
-        Logger.error(
-          `Error triggering stock monitoring for order ${event.order.code}: ${e}`,
-          loggerCtx,
-          asError(e).stack
-        );
-      });
-    });
-    // Bust cache when stock is updated
     this.eventBus.ofType(StockMovementEvent).subscribe((event) => {
+      // Bust cache when stock is updated. This cache is used to cache variants that are out of stock (or below threshold)
       const cacheKey = this.getCacheKey(event.ctx);
       this.cacheService.delete(cacheKey).catch((e) => {
         Logger.error(
@@ -87,6 +75,32 @@ export class StockMonitoringService
           asError(e).stack
         );
       });
+      // Create jobs for stock movements that decrease saleable stock
+      for (const movement of event.stockMovements) {
+        let stockDecrement: number | undefined;
+        if (event.type === 'ALLOCATION') {
+          stockDecrement = movement.quantity; // Allocation movements are positive, because they add to allocated stock
+        } else if (event.type === 'SALE') {
+          stockDecrement = Math.abs(movement.quantity); // Sale movements are negative
+        } else if (event.type === 'ADJUSTMENT' && movement.quantity < 0) {
+          stockDecrement = Math.abs(movement.quantity);
+        }
+        if (stockDecrement !== undefined) {
+          this.jobQueue
+            .add({
+              ctx: event.ctx.serialize(),
+              variantId: movement.productVariant.id,
+              saleableStockDecrement: stockDecrement,
+            })
+            .catch((e) => {
+              Logger.error(
+                `Error adding stock monitoring job for variant ${movement.productVariant.id}: ${e}`,
+                loggerCtx,
+                asError(e).stack
+              );
+            });
+        }
+      }
     });
   }
 
@@ -136,62 +150,46 @@ export class StockMonitoringService
     return variants;
   }
 
-  async triggerStockMonitoring(
-    ctx: RequestContext,
-    order: Order
-  ): Promise<void> {
-    await this.jobQueue.add({
-      ctx: ctx.serialize(),
-      lines: order.lines.map((line) => ({
-        variantId: line.productVariant.id,
-        variantStockThreshold:
-          line.productVariant.customFields.stockMonitoringThreshold,
-        orderLineQuantity: line.quantity,
-      })),
-      orderId: order.id,
-    });
-  }
-
   /**
-   * Emit event when the stock level of a variant dropped below its threshold by a placed order.
+   * Emit event when the stock level of a variant dropped below its threshold.
    */
   async handleStockMonitoringJob(
     ctx: RequestContext,
     jobData: StockMonitoringJobData
   ): Promise<void> {
-    for (const line of jobData.lines) {
-      const threshold =
-        line.variantStockThreshold || this.options.globalThreshold;
-      const stockLevels = await this.stockLevelService.getAvailableStock(
-        ctx,
-        line.variantId
+    const stockLevels = await this.stockLevelService.getAvailableStock(
+      ctx,
+      jobData.variantId
+    );
+    const stockAfterAdjustment =
+      stockLevels.stockOnHand - stockLevels.stockAllocated;
+    const stockBeforeAdjustment =
+      stockAfterAdjustment + jobData.saleableStockDecrement;
+    const [variant] = await this.variantService.findByIds(ctx, [
+      jobData.variantId,
+    ]);
+    if (!variant) {
+      Logger.error(
+        `Variant ${jobData.variantId} not found while handling stock monitoring job`,
+        loggerCtx
       );
-      const currentStock = stockLevels.stockOnHand - stockLevels.stockAllocated;
-      const stockBeforeOrder = currentStock + line.orderLineQuantity;
-      const stockAfterOrder = currentStock;
-      if (stockAfterOrder <= threshold && stockBeforeOrder >= threshold) {
-        const productVariant = await this.variantService.findOne(
+      return;
+    }
+    const threshold =
+      variant.customFields.stockMonitoringThreshold ??
+      this.options.globalThreshold;
+    if (
+      stockBeforeAdjustment >= threshold &&
+      stockAfterAdjustment < threshold
+    ) {
+      this.eventBus.publish(
+        new StockDroppedBelowThresholdEvent(
           ctx,
-          line.variantId
-        );
-        if (!productVariant) {
-          Logger.error(
-            `Product variant not found for id ${line.variantId}. Can not emit stock notification event.`,
-            loggerCtx
-          );
-          continue;
-        }
-        const order = await this.orderService.findOne(ctx, jobData.orderId);
-        await this.eventBus.publish(
-          new StockDroppedBelowThresholdEvent(
-            ctx,
-            productVariant,
-            stockBeforeOrder,
-            stockAfterOrder,
-            order
-          )
-        );
-      }
+          variant,
+          stockBeforeAdjustment,
+          stockAfterAdjustment
+        )
+      );
     }
   }
 

--- a/packages/vendure-plugin-stock-monitoring/src/services/stock-monitoring.service.ts
+++ b/packages/vendure-plugin-stock-monitoring/src/services/stock-monitoring.service.ts
@@ -78,10 +78,13 @@ export class StockMonitoringService
       // Create jobs for stock movements that decrease saleable stock
       for (const movement of event.stockMovements) {
         let stockDecrement: number | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         if (event.type === 'ALLOCATION') {
           stockDecrement = movement.quantity; // Allocation movements are positive, because they add to allocated stock
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         } else if (event.type === 'SALE') {
           stockDecrement = Math.abs(movement.quantity); // Sale movements are negative
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         } else if (event.type === 'ADJUSTMENT' && movement.quantity < 0) {
           stockDecrement = Math.abs(movement.quantity);
         }
@@ -182,7 +185,7 @@ export class StockMonitoringService
       stockBeforeAdjustment >= threshold &&
       stockAfterAdjustment < threshold
     ) {
-      this.eventBus.publish(
+      void this.eventBus.publish(
         new StockDroppedBelowThresholdEvent(
           ctx,
           variant,

--- a/packages/vendure-plugin-stock-monitoring/test/stock.spec.ts
+++ b/packages/vendure-plugin-stock-monitoring/test/stock.spec.ts
@@ -166,9 +166,8 @@ describe('Stock monitoring plugin', function () {
     await waitFor(() => emittedEvents.length === 1);
     expect(emittedEvents.length).toBe(1);
     expect(emittedEvents[0].productVariant.id).toBe(1);
-    expect(emittedEvents[0].stockBeforeOrder).toBe(105);
-    expect(emittedEvents[0].stockAfterOrder).toBe(103);
-    expect(emittedEvents[0].order?.id).toBe(1);
+    expect(emittedEvents[0].stockBeforeAdjustment).toBe(105);
+    expect(emittedEvents[0].stockAfterAdjustment).toBe(103);
   });
 
   if (process.env.TEST_ADMIN_UI) {


### PR DESCRIPTION
# Description

This PR replaces the `OrderPlacedEvent`-based stock monitoring with `StockMovementEvent`-based monitoring. The plugin now listens to `StockMovementEvent` for `ALLOCATION`, `SALE`, and negative `ADJUSTMENT` movements to check if a variant's stock dropped below its threshold.

# Breaking changes

- `StockDroppedBelowThresholdEvent` fields renamed:
  - `stockBeforeOrder` → `stockBeforeAdjustment`
  - `stockAfterOrder` → `stockAfterAdjustment`
- Removed `order` field from `StockDroppedBelowThresholdEvent`
- Removed `OrderPlacedEvent` listener; use `StockMovementEvent` instead

# To do before merge

- [ ] Verify `SALE` event behavior with `saleableStock` threshold check (see note below)

# Note

For `SALE` events, both `stockOnHand` and `stockAllocated` decrease by the same amount, so `saleableStock` (`stockOnHand - stockAllocated`) does not change. The threshold check may behave differently for `SALE` events compared to `ALLOCATION` and `ADJUSTMENT` events.

# Checklist

- [x] Set a clear title
- [x] I have checked my own PR
- [x] Added or updated test cases
- [x] Updated the README
- [x] Increased the version number in `package.json` (3.0.0)
- [x] Added changes to the `CHANGELOG.md`