### PR TITLE
feat(e-boekhouden)!: migrated credentials from DB to code-based plugin options

### DIFF
--- a/packages/vendure-plugin-e-boekhouden/CHANGELOG.md
+++ b/packages/vendure-plugin-e-boekhouden/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 2.3.0 (2026-07-21)
+# 3.0.0 (2026-07-21)
 
-- Moved configurations from DB into code
+- Migrated to channel custom fields
 
 # 2.2.0 (2026-08-05)
 

--- a/packages/vendure-plugin-e-boekhouden/README.md
+++ b/packages/vendure-plugin-e-boekhouden/README.md
@@ -36,8 +36,7 @@ plugins: [
 2. Start the server and go to `Settings` > `Channels`, open the channel you want
    to configure and select the **E-boekhouden** tab. Tick `Enabled` and fill in
    your `Username`, `Security code 1`, `Security code 2`, `Account` and
-   `Contra account`. Configuration is stored per channel as Channel custom
-   fields, so no Admin UI extension needs to be compiled.
+   `Contra account`. Credentials are stored per channel as Channel custom fields.
 
 > The `eBoekhoudenEnabled` toggle controls whether e-Boekhouden is active for a
 > channel. When it is off (or the config is incomplete), the plugin is disabled

--- a/packages/vendure-plugin-e-boekhouden/package.json
+++ b/packages/vendure-plugin-e-boekhouden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinelab/vendure-plugin-e-boekhouden",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Vendure plugin for integration with the e-boekhouden accounting platform",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://plugins.pinelab.studio/",


### PR DESCRIPTION
# Description

This PR migrates e-Boekhouden credentials from DB-managed Channel custom fields to credentials passed in code via the `credentials` property in the plugin options. The `eBoekhoudenEnabled` toggle is still managed per channel in the DB to control whether e-Boekhouden is active for a channel.

This is a **breaking change** and bumps the version to 3.0.0.

# To do before merge

- Nothing

# Breaking changes

- e-Boekhouden credentials (username, secret1, secret2, account, contraAccount) are no longer configured via Channel custom fields in the DB. They must now be passed directly in the `EBoekhoudenPlugin.init()` `credentials` object.
- The `eBoekhoudenEnabled` custom field is still available for per-channel enablement.

# Screenshots

Not applicable

# Checklist

📌 Always:
- [x] Set a clear title
- [x] I have checked my own PR

👍 Most of the time:
- [x] Added or updated test cases
- [x] Updated the README

📦 For publishable packages:
- [x] Increased the version number in `package.json` (3.0.0)
- [x] Added changes to the `CHANGELOG.md`